### PR TITLE
fix(ci): run cargo test --features client to cover gui library tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,11 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libwayland-dev libudev-dev libxkbcommon-dev libasound2-dev
 
-      - name: Run unit tests
+      - name: Run unit tests (server)
         run: cargo test
+
+      - name: Run unit tests (client feature)
+        run: cargo test --features client
 
   # ── WASM build ────────────────────────────────────────────────────────────────
   build:


### PR DESCRIPTION
## Summary

- Splits the unit-test CI step into two runs: one without features (server codepath) and one with `--features client` (client/gui codepath)
- 165 tests in `src/gui/` were silently skipped on every CI run because the `client` feature gate was never activated

## Test plan

- [ ] CI passes both `cargo test` and `cargo test --features client` on this branch
- [ ] No existing tests are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)