### PR TITLE
feat(editor): PRD #350 Slice 1 — Foundation (Mode-Shell UI, FSA entity-cache, undo, save-flow.writeFile)

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -49,8 +49,7 @@
         <button id="saveLayerBtn">Save Layer</button>
       </div>
       <div class="toolbar-group v2-mode-group">
-        <button class="v2-mode-tab active" data-mode="Properties">Properties</button>
-        <button class="v2-mode-tab" data-mode="Scenario">Scenario</button>
+        <button class="v2-mode-tab active" data-mode="Scenario">Scenario</button>
         <button class="v2-mode-tab" data-mode="Entity">Entity</button>
         <button class="v2-mode-tab" data-mode="Definitions">Definitions</button>
       </div>
@@ -69,43 +68,56 @@
 
     <!-- Main Content -->
     <div id="main">
-      <!-- Left Panel -->
-      <div id="leftPanel">
-        <!-- Layers Section -->
-        <div id="layersSection">
-          <h3>LAYERS</h3>
-          <div id="layersList"></div>
-          <button id="addLayerBtn">+ Add Layer</button>
-        </div>
+      <!-- Scenario Mode (V1 canvas + layers + properties) -->
+      <div id="scenario-mode-root" class="mode-pane">
+        <!-- Left Panel -->
+        <div id="leftPanel">
+          <!-- Layers Section -->
+          <div id="layersSection">
+            <h3>LAYERS</h3>
+            <div id="layersList"></div>
+            <button id="addLayerBtn">+ Add Layer</button>
+          </div>
 
-        <!-- Entities Palette -->
-        <div id="entitiesSection">
-          <h3>ENTITIES</h3>
-          <div id="entitiesList"></div>
-          <button id="newEntityBtn">+ New</button>
-        </div>
-      </div>
-
-      <!-- Canvas -->
-      <div id="canvasContainer">
-        <div id="canvas"></div>
-        <div id="canvasControls">
-          <span id="zoomLevel">100%</span>
-        </div>
-      </div>
-
-      <!-- Right Panel (Properties / Text Editor) -->
-      <div id="rightPanel">
-        <div id="propertiesPanel">
-          <h3>PROPERTIES</h3>
-          <div id="propertiesPanelContent">
-            <p class="placeholder">Select a spawn to edit properties</p>
+          <!-- Entities Palette -->
+          <div id="entitiesSection">
+            <h3>ENTITIES</h3>
+            <div id="entitiesList"></div>
+            <button id="newEntityBtn">+ New</button>
           </div>
         </div>
-        <div id="v2-text-panel" class="hidden">
-          <h3>TEXT EDITOR</h3>
-          <textarea id="v2-file-content" class="v2-editor-textarea" spellcheck="false" placeholder="Open a TOML file to edit…"></textarea>
+
+        <!-- Canvas -->
+        <div id="canvasContainer">
+          <div id="canvas"></div>
+          <div id="canvasControls">
+            <span id="zoomLevel">100%</span>
+          </div>
         </div>
+
+        <!-- Right Panel (Properties / Text Editor) -->
+        <div id="rightPanel">
+          <div id="propertiesPanel">
+            <h3>PROPERTIES</h3>
+            <div id="propertiesPanelContent">
+              <p class="placeholder">Select a spawn to edit properties</p>
+            </div>
+          </div>
+          <div id="v2-text-panel" class="hidden">
+            <h3>TEXT EDITOR</h3>
+            <textarea id="v2-file-content" class="v2-editor-textarea" spellcheck="false" placeholder="Open a TOML file to edit…"></textarea>
+          </div>
+        </div>
+      </div>
+
+      <!-- Entity Mode (Slice 5 will populate) -->
+      <div id="entity-mode-root" class="mode-pane hidden">
+        <p class="placeholder">Entity Mode — wired in a later slice.</p>
+      </div>
+
+      <!-- Definitions Mode (Slice 6 will populate) -->
+      <div id="definitions-mode-root" class="mode-pane hidden">
+        <p class="placeholder">Definitions Mode — wired in a later slice.</p>
       </div>
     </div>
   </div>

--- a/editor/app-v2.js
+++ b/editor/app-v2.js
@@ -1,12 +1,28 @@
 import { isSupported, pickProjectRoot, getProjectRoot, readFile, writeFile } from './project-root.js';
 import { ModeShell } from './mode-shell.js';
-import { parseWorldToml, stringifyWorldToml, validateWorldToml } from './world-toml.js';
-import { parseEntityToml, stringifyEntityToml, validateEntityToml } from './entity-toml.js';
+import { stringifyWorldToml } from './world-toml.js';
+import { stringifyEntityToml } from './entity-toml.js';
+import { InvalidationBus } from './invalidation-bus.js';
+import { SaveFlow } from './save-flow.js';
 
 const $ = (id) => document.getElementById(id);
 
 const modeShell = new ModeShell();
+const invalidationBus = new InvalidationBus();
+const saveFlow = new SaveFlow(
+  modeShell,
+  { world: stringifyWorldToml, entity: stringifyEntityToml },
+  writeFile,
+  invalidationBus,
+);
+
 let currentFilePath = null;
+
+// Expose to V1 (app.js) and to dev consoles. This is the cross-file
+// integration point until Slice 2+ moves everything into V2 properly.
+if (typeof window !== 'undefined') {
+  window.__editorV2 = { modeShell, invalidationBus, saveFlow };
+}
 
 async function init() {
   if (!isSupported()) {
@@ -19,6 +35,7 @@ async function init() {
   setupChangeRoot();
   setupOpenFile();
   setupSaveFile();
+  setupGlobalUndoShortcuts();
 
   // V1 map editor (canvas + layers) is the default view.
   // V2 text editor stays hidden; it's shown only when the user triggers it
@@ -31,22 +48,26 @@ function showBanner() {
   $('browser-not-supported').classList.remove('hidden');
 }
 
-function showPicker() {
-  $('root-picker').classList.remove('hidden');
-}
-
-function showEditor() {
-  $('v2-editor').classList.remove('hidden');
-  $('v2-root-label').textContent = 'Project root: selected';
-}
+const MODE_PANE_IDS = {
+  Scenario: 'scenario-mode-root',
+  Entity: 'entity-mode-root',
+  Definitions: 'definitions-mode-root',
+};
 
 function setupModeSwitcher() {
   document.querySelectorAll('.v2-mode-tab').forEach((tab) => {
     tab.addEventListener('click', () => {
       const mode = tab.dataset.mode;
-      modeShell.switchMode(mode);
+      if (!modeShell.switchMode(mode)) return;
+
       document.querySelectorAll('.v2-mode-tab').forEach((t) => t.classList.remove('active'));
       tab.classList.add('active');
+
+      for (const [m, id] of Object.entries(MODE_PANE_IDS)) {
+        const pane = document.getElementById(id);
+        if (!pane) continue;
+        pane.classList.toggle('hidden', m !== mode);
+      }
     });
   });
 }
@@ -55,7 +76,7 @@ function setupPickRoot() {
   $('pickRootBtn').addEventListener('click', async () => {
     try {
       await pickProjectRoot();
-      showEditor();
+      $('root-picker').classList.add('hidden');
     } catch (err) {
       $('v2-status').textContent = `Error picking root: ${err.message}`;
     }
@@ -113,6 +134,30 @@ function setupSaveFile() {
       $('v2-status').textContent = `Saved: ${currentFilePath}`;
     } catch (err) {
       $('v2-status').textContent = `Error: ${err.message}`;
+    }
+  });
+}
+
+function setupGlobalUndoShortcuts() {
+  document.addEventListener('keydown', (e) => {
+    // Don't hijack native textarea/input undo.
+    const tag = e.target?.tagName;
+    if (tag === 'TEXTAREA' || tag === 'INPUT') return;
+    if (!(e.ctrlKey || e.metaKey)) return;
+    if (e.key !== 'z' && e.key !== 'Z') return;
+
+    const mode = modeShell.getCurrentMode();
+    const path = modeShell.getActiveFile(mode);
+    if (!path) return;
+
+    e.preventDefault();
+
+    // Slice 1 just pops the stack; Slices 2/3/5/6 wire mode-specific
+    // restoration that consumes the entry returned here.
+    if (e.shiftKey) {
+      modeShell.redoActive(mode, path);
+    } else {
+      modeShell.undoActive(mode, path);
     }
   });
 }

--- a/editor/app-v2.js
+++ b/editor/app-v2.js
@@ -18,10 +18,24 @@ const saveFlow = new SaveFlow(
 
 let currentFilePath = null;
 
+// Per-mode restore callbacks. Cross-file decoupling: each mode (Scenario in
+// Slice 1; Entity/Definitions in later slices) registers a `(path, snapshot)`
+// handler that knows how to apply a snapshot back to that mode's V1 state.
+const restoreCallbacks = {};
+
+function registerRestore(mode, fn) {
+  restoreCallbacks[mode] = fn;
+}
+
 // Expose to V1 (app.js) and to dev consoles. This is the cross-file
 // integration point until Slice 2+ moves everything into V2 properly.
 if (typeof window !== 'undefined') {
-  window.__editorV2 = { modeShell, invalidationBus, saveFlow };
+  window.__editorV2 = {
+    modeShell,
+    invalidationBus,
+    saveFlow,
+    registerRestore,
+  };
 }
 
 async function init() {
@@ -150,15 +164,18 @@ function setupGlobalUndoShortcuts() {
     const path = modeShell.getActiveFile(mode);
     if (!path) return;
 
-    e.preventDefault();
+    const direction = e.shiftKey ? 'redo' : 'undo';
 
-    // Slice 1 just pops the stack; Slices 2/3/5/6 wire mode-specific
-    // restoration that consumes the entry returned here.
-    if (e.shiftKey) {
-      modeShell.redoActive(mode, path);
-    } else {
-      modeShell.undoActive(mode, path);
-    }
+    // Early-return without preventDefault when nothing to do, so the browser
+    // can still surface its own no-op.
+    if (direction === 'undo' && !modeShell.canUndoActive(mode, path)) return;
+    if (direction === 'redo' && !modeShell.canRedoActive(mode, path)) return;
+
+    const restore = restoreCallbacks[mode];
+    if (!restore) return;
+
+    e.preventDefault();
+    restore(modeShell, path, direction);
   });
 }
 

--- a/editor/app.js
+++ b/editor/app.js
@@ -35,7 +35,6 @@ async function init() {
 
   setupToolbar();
   setupLayersPanel();
-  setupModeTabs();
   renderAll();
 }
 
@@ -71,6 +70,29 @@ function renderAll() {
   renderLayersPanel(layerManager, renderAll, onSpawnSelectFromTree);
   canvasManager.renderAll();
   updateUnsavedIndicator();
+
+  // Mirror the V1 active layer into ModeShell so V2 features (save,
+  // undo shortcuts, invalidation) target the right file.
+  const active = layerManager.getActiveLayer();
+  const editorV2 = window.__editorV2;
+  if (editorV2 && editorV2.modeShell && active && active.filename) {
+    editorV2.modeShell.setActiveFile('Scenario', active.filename);
+    editorV2.modeShell.setActiveLayer('Scenario', active.filename);
+
+    const openFilenames = layerManager.getLayers()
+      .map((l) => l.filename)
+      .filter(Boolean);
+    editorV2.modeShell.setOpenFiles('Scenario', openFilenames);
+
+    // Mirror the saveFlow content cache so V2's saveActive has a parsed
+    // payload to serialize when the toolbar Save buttons run.
+    if (editorV2.saveFlow) {
+      for (const layer of layerManager.getLayers()) {
+        if (!layer.filename) continue;
+        editorV2.saveFlow.setContent('Scenario', layer.filename, layer.toml);
+      }
+    }
+  }
 }
 
 function updateUnsavedIndicator() {
@@ -126,6 +148,11 @@ function setupToolbar() {
 
         layerManager.layers.push(layer);
         layerManager.activeLayer = layer;
+
+        console.warn(
+          `[editor] Layer "${file.name}" was opened via file picker, so its root-relative path is unknown. ` +
+          `Saving through the new SaveFlow will fail. Use "Pick Project Root" and reopen the file from there.`
+        );
       } catch (err) {
         console.error('Failed to parse file:', file.name, err);
       }
@@ -140,15 +167,41 @@ function setupToolbar() {
   });
 
   document.getElementById('saveAllBtn').addEventListener('click', async () => {
-    for (const layer of layerManager.getLayers()) {
-      await saveLayer(layer);
+    const v2 = window.__editorV2;
+    if (!v2 || !v2.saveFlow) {
+      console.warn('[editor] SaveFlow not yet initialised; cannot save.');
+      return;
     }
+    const results = await v2.saveFlow.saveAll(null);
+    for (const r of results) {
+      if (!r.ok) {
+        console.error(`Save failed for ${r.path}:`, r.errors);
+      } else {
+        const layer = layerManager.getLayers().find((l) => l.filename === r.path);
+        if (layer) layer.isDirty = false;
+      }
+    }
+    renderAll();
   });
 
   document.getElementById('saveLayerBtn').addEventListener('click', async () => {
+    const v2 = window.__editorV2;
     const activeLayer = layerManager.getActiveLayer();
-    if (activeLayer) {
-      await saveLayer(activeLayer);
+    if (!v2 || !v2.saveFlow || !activeLayer) {
+      console.warn('[editor] No active layer or SaveFlow unavailable.');
+      return;
+    }
+    // renderAll() already mirrored the parsed payload into saveFlow's cache,
+    // but call again here in case the user edited and clicked save before a
+    // render tick fired.
+    v2.saveFlow.setContent('Scenario', activeLayer.filename, activeLayer.toml);
+    v2.modeShell.setActiveFile('Scenario', activeLayer.filename);
+    const result = await v2.saveFlow.saveActive(null);
+    if (!result.ok) {
+      console.error(`Save failed for ${activeLayer.filename}:`, result.errors);
+    } else {
+      activeLayer.isDirty = false;
+      renderAll();
     }
   });
 
@@ -157,62 +210,9 @@ function setupToolbar() {
   });
 }
 
-async function saveLayer(layer) {
-  try {
-    const raw = stringifyToml(layer.toml);
-
-    if (layer.fileHandle.createWritable) {
-      const writable = await layer.fileHandle.createWritable();
-      await writable.write(raw);
-      await writable.close();
-    } else {
-      const blob = new Blob([raw], { type: 'application/toml' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = layer.filename;
-      a.click();
-      URL.revokeObjectURL(url);
-      console.log(`Downloaded: ${layer.filename} (save-as required)`);
-    }
-
-    layer.isDirty = false;
-    console.log(`Saved: ${layer.filename}`);
-  } catch (err) {
-    console.error(`Failed to save ${layer.filename}:`, err);
-  }
-}
-
 function setupLayersPanel() {
   document.getElementById('addLayerBtn').addEventListener('click', () => {
     fileInput.click();
-  });
-}
-
-function setupModeTabs() {
-  const tabs = document.querySelectorAll('.v2-mode-tab');
-  const propertiesPanel = document.getElementById('propertiesPanel');
-  const textPanel = document.getElementById('v2-text-panel');
-  const v2Toolbar = document.querySelector('.v2-text-toolbar');
-
-  tabs.forEach(tab => {
-    tab.addEventListener('click', () => {
-      const mode = tab.dataset.mode;
-
-      // Update active tab
-      tabs.forEach(t => t.classList.remove('active'));
-      tab.classList.add('active');
-
-      if (mode === 'Properties') {
-        propertiesPanel?.classList.remove('hidden');
-        textPanel?.classList.add('hidden');
-        v2Toolbar?.classList.add('hidden');
-      } else {
-        propertiesPanel?.classList.add('hidden');
-        textPanel?.classList.remove('hidden');
-        v2Toolbar?.classList.remove('hidden');
-      }
-    });
   });
 }
 

--- a/editor/app.js
+++ b/editor/app.js
@@ -2,7 +2,7 @@ import { LayerManager, renderLayersPanel, inferLayerKind } from './layers.js';
 import { CanvasManager } from './canvas.js';
 import { PropertiesPanel } from './sidebar.js';
 import { EntityEditor } from './entity-editor.js';
-import { stringifyToml, getEntityPath } from './toml-utils.js';
+import { getEntityPath } from './toml-utils.js';
 import { preloadEntityCache, loadEntityConfig } from './entity-cache.js';
 import { restoreScenarioLayer } from './undo-controller.js';
 

--- a/editor/app.js
+++ b/editor/app.js
@@ -4,6 +4,7 @@ import { PropertiesPanel } from './sidebar.js';
 import { EntityEditor } from './entity-editor.js';
 import { stringifyToml, getEntityPath } from './toml-utils.js';
 import { preloadEntityCache, loadEntityConfig } from './entity-cache.js';
+import { restoreScenarioLayer } from './undo-controller.js';
 
 const layerManager = new LayerManager();
 let canvasManager;
@@ -35,7 +36,42 @@ async function init() {
 
   setupToolbar();
   setupLayersPanel();
+  registerScenarioUndoRestore();
   renderAll();
+}
+
+function registerScenarioUndoRestore() {
+  const v2 = window.__editorV2;
+  if (!v2 || typeof v2.registerRestore !== 'function') return;
+
+  v2.registerRestore('Scenario', (modeShell, path, direction) => {
+    const layer = layerManager.getLayers().find((l) => l.filename === path);
+    if (!layer) return;
+
+    // Snapshot CURRENT (post-mutation) state so the opposite stack can
+    // restore it later. structuredClone keeps the undo entries independent
+    // of subsequent in-place edits.
+    const current = structuredClone(layer.toml);
+
+    const snapshot = direction === 'undo'
+      ? modeShell.swapUndoActive('Scenario', path, current)
+      : modeShell.swapRedoActive('Scenario', path, current);
+    if (!snapshot) return;
+
+    restoreScenarioLayer(layerManager, path, snapshot);
+
+    // Re-render canvas + layers panel and refresh the properties sidebar
+    // if a spawn is still selected (and still exists in the restored TOML).
+    renderAll();
+
+    const sel = canvasManager.selectedSpawn;
+    if (sel && sel.layer === layer) {
+      // The spawn object may have been replaced by structuredClone; clear
+      // selection to avoid pointing at a stale reference.
+      canvasManager.deselectSpawn();
+      propertiesPanel.render(null, null);
+    }
+  });
 }
 
 function onSpawnSelect(spawn, layer) {

--- a/editor/canvas-scenario.js
+++ b/editor/canvas-scenario.js
@@ -132,6 +132,44 @@ export function drawEntityShape(group, Konva, appearance, selected = false) {
       group.add(square);
       break;
     }
+    case 'Diamond': {
+      // Square rotated 45°: a four-pointed kite centred on the entity.
+      // Used for stations to match the runtime "station" radar icon.
+      const r = radius * 1.0;
+      const diamond = new Konva.Line({
+        points: [0, -r, r, 0, 0, r, -r, 0],
+        closed: true,
+        fill: hexColour + '88',
+        stroke: strokeColour,
+        strokeWidth,
+      });
+      group.add(diamond);
+      break;
+    }
+    case 'Ring': {
+      // Hollow circle: stroke only, no fill. Used for planets so they read
+      // as a large bounded body rather than a small filled blip.
+      const r = Math.max(6, radius * 0.6);
+      const ring = new Konva.Circle({
+        radius: r,
+        fill: 'transparent',
+        stroke: hexColour,
+        strokeWidth: Math.max(2, strokeWidth),
+      });
+      group.add(ring);
+      if (selected) {
+        // Overlay a thin selection outline so selection state is still
+        // visible against the hollow ring.
+        const sel = new Konva.Circle({
+          radius: r + 2,
+          fill: 'transparent',
+          stroke: strokeColour,
+          strokeWidth: 1.5,
+        });
+        group.add(sel);
+      }
+      break;
+    }
     default: {
       // Dot
       const circle = new Konva.Circle({

--- a/editor/canvas.js
+++ b/editor/canvas.js
@@ -2,6 +2,7 @@ import { getSpawns, getAnchors, getSpawnPosition, getSpawnName, getEntityPath, g
 import { getColorForEntity } from './layers.js';
 import { loadEntityConfig, getEntityConfig } from './entity-cache.js';
 import { resolveEntityAppearance, drawEntityShape, colourToHex, RADAR_SHAPE_FALLBACK } from './canvas-scenario.js';
+import { snapshotForUndo } from './undo-controller.js';
 
 export class CanvasManager {
   constructor(layerManager, onSpawnSelect, onSpawnUpdate, onSpawnCreate, onSpawnDrag) {
@@ -276,6 +277,7 @@ export class CanvasManager {
           setSpawnPosition(spawn, newX, newZ, 'absolute');
         }
         layer.isDirty = true;
+        snapshotForUndo(layer);
 
         if (this.selectedSpawn?.spawn === spawn) {
           this.onSpawnDrag(spawn, layer);
@@ -369,6 +371,7 @@ export class CanvasManager {
     }
     activeLayer.toml[arr].push(spawn);
     activeLayer.isDirty = true;
+    snapshotForUndo(activeLayer);
 
     this.onSpawnCreate(spawn, activeLayer);
     this.selectSpawn(spawn, activeLayer);

--- a/editor/canvas.js
+++ b/editor/canvas.js
@@ -271,13 +271,13 @@ export class CanvasManager {
       if (this.placeMode) {
         setSpawnPosition(spawn, newX, newZ, 'absolute');
       } else {
+        snapshotForUndo(layer);
         if (relative) {
           setSpawnPosition(spawn, newX, newZ, 'relative', relative.parent, { x: newX - oldPos.x, z: newZ - oldPos.z });
         } else {
           setSpawnPosition(spawn, newX, newZ, 'absolute');
         }
         layer.isDirty = true;
-        snapshotForUndo(layer);
 
         if (this.selectedSpawn?.spawn === spawn) {
           this.onSpawnDrag(spawn, layer);
@@ -366,12 +366,12 @@ export class CanvasManager {
     const arr = activeLayer.kind === 'scenario' ? 'spawn' : 'entity';
     spawn[activeLayer.kind === 'scenario' ? 'entity_path' : 'template_path'] = this.placeEntityPath;
 
+    snapshotForUndo(activeLayer);
     if (!activeLayer.toml[arr]) {
       activeLayer.toml[arr] = [];
     }
     activeLayer.toml[arr].push(spawn);
     activeLayer.isDirty = true;
-    snapshotForUndo(activeLayer);
 
     this.onSpawnCreate(spawn, activeLayer);
     this.selectSpawn(spawn, activeLayer);

--- a/editor/cross-references.js
+++ b/editor/cross-references.js
@@ -54,6 +54,12 @@ export class CrossReferenceIndex {
             this._addRef(action.target_entity, path, 'action',
               `trigger.action target_entity`);
           }
+          // Some action schemas use `entity` instead of `target_entity`
+          // (e.g. set_ai_state, apply_modifier).  See action-schema.js.
+          if (action.entity) {
+            this._addRef(action.entity, path, 'action',
+              `trigger.action entity`);
+          }
           if (action.type === 'add_objective' && action.id) {
             if (!this._objectiveIds.has(action.id)) {
               this._objectiveIds.set(action.id, path);
@@ -81,6 +87,10 @@ export class CrossReferenceIndex {
               this._addRef(action.target_entity, path, 'action',
                 `comms.response.action target_entity`);
             }
+            if (action.entity) {
+              this._addRef(action.entity, path, 'action',
+                `comms.response.action entity`);
+            }
             if (action.type === 'add_objective' && action.id) {
               if (!this._objectiveIds.has(action.id)) {
                 this._objectiveIds.set(action.id, path);
@@ -101,6 +111,28 @@ export class CrossReferenceIndex {
 
   findReferences(targetName) {
     return this._references.get(targetName) || [];
+  }
+
+  /**
+   * Iterate every recorded reference as
+   *   { targetName, layerPath, type, context }
+   * objects.  Used by `world-references.js` to surface
+   * references whose `targetName` isn't a known entity.
+   */
+  *allReferences() {
+    for (const [targetName, refs] of this._references) {
+      for (const ref of refs) {
+        yield { targetName, ...ref };
+      }
+    }
+  }
+
+  /**
+   * True if `name` was recorded as a `[[entity]] name = "..."` during
+   * the last `indexLayers` call.
+   */
+  hasEntity(name) {
+    return this._entityNames.has(name);
   }
 
   getAllEntityNames() {

--- a/editor/entity-cache.js
+++ b/editor/entity-cache.js
@@ -1,53 +1,108 @@
-export const entityCache = new Map();
+import { readFile, listDirectory, getProjectRoot } from './project-root.js';
 
+const cache = new Map();
+const listeners = new Set();
+
+/** Live cache of `path -> parsed TOML`. Exported for legacy callers
+ * (entity-editor.js iterates and mutates this Map). */
+export const entityCache = cache;
+
+/** Load and parse an entity TOML by project-root-relative path.
+ * Returns the cached value if present, otherwise reads, parses, caches, returns.
+ * Returns null on read/parse failure. */
 export async function loadEntityConfig(path) {
-  if (entityCache.has(path)) return entityCache.get(path);
+  if (cache.has(path)) return cache.get(path);
   try {
-    const url = path.startsWith('/') ? path : '/' + path;
-    const resp = await fetch(url);
-    if (!resp.ok) return null;
-    const text = await resp.text();
+    const text = await readFile(path);
     const config = window.tomlParse(text);
-    entityCache.set(path, config);
+    cache.set(path, config);
     return config;
-  } catch {
+  } catch (err) {
+    console.warn(`[entity-cache] failed to load ${path}:`, err?.message || err);
     return null;
   }
 }
 
+/** Synchronous lookup of an already-cached entity config. */
 export function getEntityConfig(path) {
-  return entityCache.get(path) || null;
+  return cache.get(path) || null;
 }
 
-const KNOWN_ENTITIES = [
-  { name: 'player_ship', path: 'assets/entities/player_ship.toml', tags: ['player', 'ship'] },
-  { name: 'pirate_raider', path: 'assets/entities/pirate_raider.toml', tags: ['enemy', 'ship'] },
-  { name: 'ship_harrow_warhawk', path: 'assets/entities/ship_harrow_warhawk.toml', tags: ['enemy', 'ship'] },
-  { name: 'ship_harrow_patrol', path: 'assets/entities/ship_harrow_patrol.toml', tags: ['enemy', 'ship'] },
-  { name: 'ship_requiem_courier', path: 'assets/entities/ship_requiem_courier.toml', tags: ['enemy', 'ship'] },
-  { name: 'asteroid_large', path: 'assets/entities/asteroid_large.toml', tags: ['asteroid'] },
-  { name: 'asteroid_small', path: 'assets/entities/asteroid_small.toml', tags: ['asteroid'] },
-  { name: 'asteroid_cosmetic', path: 'assets/entities/asteroid_cosmetic.toml', tags: ['asteroid', 'cosmetic'] },
-  { name: 'asteroid_field_main', path: 'assets/entities/asteroid_field_main.toml', tags: ['asteroid_field'] },
-  { name: 'station_axiom', path: 'assets/entities/station_axiom.toml', tags: ['station'] },
-  { name: 'station_outpost', path: 'assets/entities/station_outpost.toml', tags: ['station'] },
-  { name: 'station_research_outpost', path: 'assets/entities/station_research_outpost.toml', tags: ['station'] },
-  { name: 'region_nebula', path: 'assets/entities/region_nebula.toml', tags: ['region', 'nebula'] },
-  { name: 'region_kaleth_nebula', path: 'assets/entities/region_kaleth_nebula.toml', tags: ['region', 'nebula'] },
-  { name: 'region_radiation_zone', path: 'assets/entities/region_radiation_zone.toml', tags: ['region'] },
-  { name: 'star_sun', path: 'assets/entities/star_sun.toml', tags: ['star'] },
-  { name: 'planet_earth', path: 'assets/entities/planet_earth.toml', tags: ['planet'] },
-];
-
-export function preloadEntityList() {
-  return KNOWN_ENTITIES;
-}
-
+/** Walk assets/entities/, load every *.toml into the cache.
+ * No-ops (and returns []) if no project root is selected yet. */
 export async function preloadEntityCache() {
+  const root = await getProjectRoot().catch(() => null);
+  if (!root) {
+    console.warn('[entity-cache] no project root selected; entity palette will be empty until you pick one');
+    return [];
+  }
+
+  let entries;
+  try {
+    entries = await listDirectory('assets/entities');
+  } catch (err) {
+    console.warn('[entity-cache] failed to list assets/entities:', err?.message || err);
+    return [];
+  }
+
   const results = [];
-  for (const ent of KNOWN_ENTITIES) {
-    const config = await loadEntityConfig(ent.path);
-    results.push({ ...ent, config });
+  for (const entry of entries) {
+    if (entry.kind !== 'file') continue;
+    if (!entry.name.endsWith('.toml')) continue;
+    const path = `assets/entities/${entry.name}`;
+    const config = await loadEntityConfig(path);
+    if (config) {
+      results.push({ ...entryToListItem(entry.name, config), config });
+    }
   }
   return results;
+}
+
+/** Returns [{ name, path, tags }] for every entity in the cache. */
+export function preloadEntityList() {
+  const out = [];
+  for (const [path, config] of cache) {
+    out.push(entryToListItem(filenameFromPath(path), config, path));
+  }
+  return out;
+}
+
+/** Drop a single entry from the cache and notify listeners. */
+export function invalidateEntity(path) {
+  cache.delete(path);
+  for (const cb of listeners) {
+    try { cb(path); } catch (err) { console.error(err); }
+  }
+}
+
+/** Drop everything and notify listeners (called with null). */
+export function invalidateAll() {
+  cache.clear();
+  for (const cb of listeners) {
+    try { cb(null); } catch (err) { console.error(err); }
+  }
+}
+
+/** Subscribe to invalidations. Returns { unsubscribe }. */
+export function onInvalidate(callback) {
+  listeners.add(callback);
+  return {
+    unsubscribe: () => {
+      listeners.delete(callback);
+    },
+  };
+}
+
+function filenameFromPath(path) {
+  const tail = path.split('/').pop() || path;
+  return tail.replace(/\.toml$/, '');
+}
+
+function entryToListItem(filename, config, path) {
+  const name = filename.replace(/\.toml$/, '');
+  return {
+    name,
+    path: path || `assets/entities/${filename}`,
+    tags: (config && Array.isArray(config.tags)) ? config.tags : [],
+  };
 }

--- a/editor/mode-shell.js
+++ b/editor/mode-shell.js
@@ -1,5 +1,7 @@
 const DEFAULT_MODES = ['Scenario', 'Entity', 'Definitions'];
 
+import { UndoStack } from './undo-stack.js';
+
 export class ModeShell {
   constructor(modes = DEFAULT_MODES) {
     this._modes = [...modes];
@@ -90,15 +92,42 @@ export class ModeShell {
   }
 
   getUndoHistory(mode, filePath) {
-    if (!this._undoHistory[mode]) return [];
-    return this._undoHistory[mode][filePath] || [];
+    const stack = this._getStack(mode, filePath, false);
+    if (!stack) return [];
+    // Preserve legacy contract: callers (and tests) expect a raw array.
+    return stack._undoStack;
   }
 
   pushUndoEntry(mode, filePath, entry) {
-    if (!this._undoHistory[mode]) return;
-    if (!this._undoHistory[mode][filePath]) {
-      this._undoHistory[mode][filePath] = [];
+    const stack = this._getStack(mode, filePath, true);
+    if (!stack) return;
+    stack.push(entry);
+  }
+
+  undoActive(mode, filePath) {
+    const stack = this._getStack(mode, filePath, false);
+    if (!stack) return null;
+    return stack.undo();
+  }
+
+  redoActive(mode, filePath) {
+    const stack = this._getStack(mode, filePath, false);
+    if (!stack) return null;
+    return stack.redo();
+  }
+
+  clearUndoHistory(mode, filePath) {
+    const stack = this._getStack(mode, filePath, false);
+    if (stack) stack.clear();
+  }
+
+  _getStack(mode, filePath, createIfMissing) {
+    if (!this._undoHistory[mode]) return null;
+    let stack = this._undoHistory[mode][filePath];
+    if (!stack && createIfMissing) {
+      stack = new UndoStack();
+      this._undoHistory[mode][filePath] = stack;
     }
-    this._undoHistory[mode][filePath].push(entry);
+    return stack || null;
   }
 }

--- a/editor/mode-shell.js
+++ b/editor/mode-shell.js
@@ -116,9 +116,36 @@ export class ModeShell {
     return stack.redo();
   }
 
+  /**
+   * Snapshot-before-mutation swap variants. The caller passes the current
+   * external state so it gets parked on the opposite stack — see
+   * `undo-controller.js` for the contract.
+   */
+  swapUndoActive(mode, filePath, currentValue) {
+    const stack = this._getStack(mode, filePath, false);
+    if (!stack) return null;
+    return stack.swapUndo(currentValue);
+  }
+
+  swapRedoActive(mode, filePath, currentValue) {
+    const stack = this._getStack(mode, filePath, false);
+    if (!stack) return null;
+    return stack.swapRedo(currentValue);
+  }
+
   clearUndoHistory(mode, filePath) {
     const stack = this._getStack(mode, filePath, false);
     if (stack) stack.clear();
+  }
+
+  canUndoActive(mode, filePath) {
+    const stack = this._getStack(mode, filePath, false);
+    return !!stack && stack.canUndo();
+  }
+
+  canRedoActive(mode, filePath) {
+    const stack = this._getStack(mode, filePath, false);
+    return !!stack && stack.canRedo();
   }
 
   _getStack(mode, filePath, createIfMissing) {

--- a/editor/project-root.js
+++ b/editor/project-root.js
@@ -47,6 +47,29 @@ export async function writeFile(relativePath, content) {
   await writable.close();
 }
 
+/**
+ * List entries in a directory relative to the project root.
+ * Empty path means the root itself. Returns [{ name, kind }] where kind is
+ * 'file' or 'directory'. Throws if no project root has been selected.
+ */
+export async function listDirectory(relativePath = '') {
+  const handle = await requireRoot();
+  const parts = normalizePath(relativePath);
+  let dir = handle;
+  for (let i = 0; i < parts.length; i++) {
+    dir = await dir.getDirectoryHandle(parts[i]);
+  }
+  const results = [];
+  if (typeof dir.entries === 'function') {
+    for await (const [name, entry] of dir.entries()) {
+      const kind = entry.kind
+        || (typeof entry.getFile === 'function' ? 'file' : 'directory');
+      results.push({ name, kind });
+    }
+  }
+  return results;
+}
+
 /** For testing: inject a mock root handle */
 export function _setRootHandleForTest(handle) {
   rootHandle = handle;

--- a/editor/save-flow.js
+++ b/editor/save-flow.js
@@ -1,9 +1,21 @@
 import { validateFile } from './validation.js';
 
 export class SaveFlow {
-  constructor(modeShell, stringifyFunctions) {
+  /**
+   * @param {ModeShell} modeShell
+   * @param {{ world: (obj) => string, entity: (obj) => string }} stringifyFunctions
+   * @param {(path: string, content: string) => Promise<void>} [writeFile]
+   *   FSA-backed writer. Defaults to a no-op that resolves immediately so
+   *   pre-Slice-1 callers / older tests that don't supply one keep working.
+   * @param {{ fireEntitySaved?: (path: string) => void,
+   *           fireWorldSaved?: (path: string) => void }} [invalidationBus]
+   *   Notified on successful save. Optional for the same back-compat reason.
+   */
+  constructor(modeShell, stringifyFunctions, writeFile, invalidationBus) {
     this._modeShell = modeShell;
     this._stringifyFunctions = stringifyFunctions;
+    this._writeFile = writeFile || (async () => {});
+    this._invalidationBus = invalidationBus || null;
     this._contentCache = {};
   }
 
@@ -30,7 +42,7 @@ export class SaveFlow {
     return this._contentCache[mode]?.[filePath];
   }
 
-  saveActive(crossRefIndex) {
+  async saveActive(crossRefIndex) {
     const mode = this._modeShell.getCurrentMode();
     const path = this._modeShell.getActiveFile(mode);
 
@@ -38,6 +50,22 @@ export class SaveFlow {
       return { ok: false, errors: ['No active file to save'], warnings: [] };
     }
 
+    return this._saveOne(mode, path);
+  }
+
+  async saveAll(crossRefIndex) {
+    const dirtyFiles = this.getDirtyFiles();
+    const results = [];
+
+    for (const { mode, path } of dirtyFiles) {
+      const result = await this._saveOne(mode, path);
+      results.push({ path, ...result });
+    }
+
+    return results;
+  }
+
+  async _saveOne(mode, path) {
     const parsedContent = this._getParsedContent(mode, path);
     if (!parsedContent) {
       return { ok: false, errors: ['No content available for the active file'], warnings: [] };
@@ -53,37 +81,24 @@ export class SaveFlow {
     const validationResults = validateFile(path, parsedContent);
     const warnings = validationResults.map((r) => r.message);
 
-    this._modeShell.markDirty(mode, path, false);
-
-    return { ok: true, errors: [], warnings };
-  }
-
-  saveAll(crossRefIndex) {
-    const dirtyFiles = this.getDirtyFiles();
-    const results = [];
-
-    for (const { mode, path } of dirtyFiles) {
-      const parsedContent = this._getParsedContent(mode, path);
-      if (!parsedContent) {
-        results.push({ path, ok: false, errors: ['No content available'], warnings: [] });
-        continue;
-      }
-
-      try {
-        this.getContentForFile(mode, path, parsedContent);
-      } catch (e) {
-        results.push({ path, ok: false, errors: [e.message], warnings: [] });
-        continue;
-      }
-
-      const validationResults = validateFile(path, parsedContent);
-      const warnings = validationResults.map((r) => r.message);
-
-      this._modeShell.markDirty(mode, path, false);
-      results.push({ path, ok: true, errors: [], warnings });
+    try {
+      await this._writeFile(path, content);
+    } catch (e) {
+      return { ok: false, errors: [`Write failed: ${e.message}`], warnings };
     }
 
-    return results;
+    this._modeShell.markDirty(mode, path, false);
+    this._modeShell.clearUndoHistory(mode, path);
+
+    if (this._invalidationBus) {
+      if (mode === 'Entity' && typeof this._invalidationBus.fireEntitySaved === 'function') {
+        this._invalidationBus.fireEntitySaved(path);
+      } else if (mode === 'Scenario' && typeof this._invalidationBus.fireWorldSaved === 'function') {
+        this._invalidationBus.fireWorldSaved(path);
+      }
+    }
+
+    return { ok: true, errors: [], warnings };
   }
 
   getDirtyFiles() {

--- a/editor/sidebar.js
+++ b/editor/sidebar.js
@@ -1,5 +1,6 @@
 import { getSpawnName, getSpawnPosition, getEntityPath, getRelativeInfo, setSpawnPosition, getAllAnchors } from './toml-utils.js';
 import { getSpawnsFromAllLayers } from './toml-utils.js';
+import { snapshotForUndo } from './undo-controller.js';
 
 export class PropertiesPanel {
   constructor(canvasManager, layerManager) {
@@ -152,6 +153,7 @@ export class PropertiesPanel {
   _attachListeners(spawn, layer, allAnchors, pos, relative) {
     document.getElementById('propName').addEventListener('input', (e) => {
       spawn.name = e.target.value;
+      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
@@ -181,6 +183,7 @@ export class PropertiesPanel {
           const currentPos = getSpawnPosition(spawn, allAnchors);
           setSpawnPosition(spawn, currentPos.x, currentPos.z, 'relative', parentSelect?.value || null, { x: offsetX, z: offsetZ });
         }
+        snapshotForUndo(layer);
         layer.isDirty = true;
         this.canvasManager.renderAll();
       });
@@ -190,6 +193,7 @@ export class PropertiesPanel {
       const x = parseFloat(e.target.value) || 0;
       const z = parseFloat(document.getElementById('propZ')?.value || '0');
       setSpawnPosition(spawn, x, z, 'absolute');
+      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
@@ -198,12 +202,14 @@ export class PropertiesPanel {
       const x = parseFloat(document.getElementById('propX')?.value || '0');
       const z = parseFloat(e.target.value) || 0;
       setSpawnPosition(spawn, x, z, 'absolute');
+      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
 
     document.getElementById('propAnchor')?.addEventListener('change', (e) => {
       setSpawnPosition(spawn, 0, 0, 'anchor', e.target.value, null);
+      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
@@ -213,6 +219,7 @@ export class PropertiesPanel {
       const offsetX = parseFloat(document.getElementById('propOffsetX')?.value || '0');
       const offsetZ = parseFloat(document.getElementById('propOffsetZ')?.value || '0');
       setSpawnPosition(spawn, pos.x, pos.z, 'relative', parent, { x: offsetX, z: offsetZ });
+      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
@@ -222,6 +229,7 @@ export class PropertiesPanel {
       const offsetX = parseFloat(e.target.value) || 0;
       const offsetZ = parseFloat(document.getElementById('propOffsetZ')?.value || '0');
       setSpawnPosition(spawn, 0, 0, 'relative', cur?.parent, { x: offsetX, z: offsetZ });
+      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.updateArrows();
     });
@@ -231,6 +239,7 @@ export class PropertiesPanel {
       const offsetX = parseFloat(document.getElementById('propOffsetX')?.value || '0');
       const offsetZ = parseFloat(e.target.value) || 0;
       setSpawnPosition(spawn, 0, 0, 'relative', cur?.parent, { x: offsetX, z: offsetZ });
+      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.updateArrows();
     });
@@ -239,6 +248,7 @@ export class PropertiesPanel {
     document.getElementById('shapeRadius')?.addEventListener('input', (e) => {
       if (!spawn.shape) spawn.shape = { type: 'sphere' };
       spawn.shape.radius = parseFloat(e.target.value) || 100;
+      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
@@ -246,6 +256,7 @@ export class PropertiesPanel {
     document.getElementById('shapeInnerRadius')?.addEventListener('input', (e) => {
       if (!spawn.shape) spawn.shape = { type: 'torus' };
       spawn.shape.inner_radius = parseFloat(e.target.value) || 50;
+      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
@@ -253,6 +264,7 @@ export class PropertiesPanel {
     document.getElementById('shapeOuterRadius')?.addEventListener('input', (e) => {
       if (!spawn.shape) spawn.shape = { type: 'torus' };
       spawn.shape.outer_radius = parseFloat(e.target.value) || 150;
+      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
@@ -262,6 +274,7 @@ export class PropertiesPanel {
       const idx = layer.toml[arr]?.indexOf(spawn);
       if (idx !== -1) {
         layer.toml[arr].splice(idx, 1);
+        snapshotForUndo(layer);
         layer.isDirty = true;
         this.canvasManager.spawnGroups.delete(spawn);
         this.canvasManager.deselectSpawn();
@@ -278,6 +291,7 @@ export class PropertiesPanel {
           if (!key.startsWith('_')) delete spawn[key];
         }
         Object.assign(spawn, parsed);
+        snapshotForUndo(layer);
         layer.isDirty = true;
         errorEl.textContent = '';
         this.canvasManager.renderAll();

--- a/editor/sidebar.js
+++ b/editor/sidebar.js
@@ -152,8 +152,8 @@ export class PropertiesPanel {
 
   _attachListeners(spawn, layer, allAnchors, pos, relative) {
     document.getElementById('propName').addEventListener('input', (e) => {
-      spawn.name = e.target.value;
       snapshotForUndo(layer);
+      spawn.name = e.target.value;
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
@@ -169,6 +169,7 @@ export class PropertiesPanel {
         document.getElementById('anchorPos').classList.toggle('hidden', mode !== 'anchor');
         document.getElementById('relativePos').classList.toggle('hidden', mode !== 'relative');
 
+        snapshotForUndo(layer);
         if (mode === 'absolute') {
           const x = parseFloat(document.getElementById('propX')?.value || '0');
           const z = parseFloat(document.getElementById('propZ')?.value || '0');
@@ -183,7 +184,6 @@ export class PropertiesPanel {
           const currentPos = getSpawnPosition(spawn, allAnchors);
           setSpawnPosition(spawn, currentPos.x, currentPos.z, 'relative', parentSelect?.value || null, { x: offsetX, z: offsetZ });
         }
-        snapshotForUndo(layer);
         layer.isDirty = true;
         this.canvasManager.renderAll();
       });
@@ -192,8 +192,8 @@ export class PropertiesPanel {
     document.getElementById('propX')?.addEventListener('input', (e) => {
       const x = parseFloat(e.target.value) || 0;
       const z = parseFloat(document.getElementById('propZ')?.value || '0');
-      setSpawnPosition(spawn, x, z, 'absolute');
       snapshotForUndo(layer);
+      setSpawnPosition(spawn, x, z, 'absolute');
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
@@ -201,15 +201,15 @@ export class PropertiesPanel {
     document.getElementById('propZ')?.addEventListener('input', (e) => {
       const x = parseFloat(document.getElementById('propX')?.value || '0');
       const z = parseFloat(e.target.value) || 0;
-      setSpawnPosition(spawn, x, z, 'absolute');
       snapshotForUndo(layer);
+      setSpawnPosition(spawn, x, z, 'absolute');
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
 
     document.getElementById('propAnchor')?.addEventListener('change', (e) => {
-      setSpawnPosition(spawn, 0, 0, 'anchor', e.target.value, null);
       snapshotForUndo(layer);
+      setSpawnPosition(spawn, 0, 0, 'anchor', e.target.value, null);
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
@@ -218,8 +218,8 @@ export class PropertiesPanel {
       const parent = document.getElementById('propParent').value;
       const offsetX = parseFloat(document.getElementById('propOffsetX')?.value || '0');
       const offsetZ = parseFloat(document.getElementById('propOffsetZ')?.value || '0');
-      setSpawnPosition(spawn, pos.x, pos.z, 'relative', parent, { x: offsetX, z: offsetZ });
       snapshotForUndo(layer);
+      setSpawnPosition(spawn, pos.x, pos.z, 'relative', parent, { x: offsetX, z: offsetZ });
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
@@ -228,8 +228,8 @@ export class PropertiesPanel {
       const cur = getRelativeInfo(spawn);
       const offsetX = parseFloat(e.target.value) || 0;
       const offsetZ = parseFloat(document.getElementById('propOffsetZ')?.value || '0');
-      setSpawnPosition(spawn, 0, 0, 'relative', cur?.parent, { x: offsetX, z: offsetZ });
       snapshotForUndo(layer);
+      setSpawnPosition(spawn, 0, 0, 'relative', cur?.parent, { x: offsetX, z: offsetZ });
       layer.isDirty = true;
       this.canvasManager.updateArrows();
     });
@@ -238,33 +238,33 @@ export class PropertiesPanel {
       const cur = getRelativeInfo(spawn);
       const offsetX = parseFloat(document.getElementById('propOffsetX')?.value || '0');
       const offsetZ = parseFloat(e.target.value) || 0;
-      setSpawnPosition(spawn, 0, 0, 'relative', cur?.parent, { x: offsetX, z: offsetZ });
       snapshotForUndo(layer);
+      setSpawnPosition(spawn, 0, 0, 'relative', cur?.parent, { x: offsetX, z: offsetZ });
       layer.isDirty = true;
       this.canvasManager.updateArrows();
     });
 
     // Shape size fields
     document.getElementById('shapeRadius')?.addEventListener('input', (e) => {
+      snapshotForUndo(layer);
       if (!spawn.shape) spawn.shape = { type: 'sphere' };
       spawn.shape.radius = parseFloat(e.target.value) || 100;
-      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
 
     document.getElementById('shapeInnerRadius')?.addEventListener('input', (e) => {
+      snapshotForUndo(layer);
       if (!spawn.shape) spawn.shape = { type: 'torus' };
       spawn.shape.inner_radius = parseFloat(e.target.value) || 50;
-      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
 
     document.getElementById('shapeOuterRadius')?.addEventListener('input', (e) => {
+      snapshotForUndo(layer);
       if (!spawn.shape) spawn.shape = { type: 'torus' };
       spawn.shape.outer_radius = parseFloat(e.target.value) || 150;
-      snapshotForUndo(layer);
       layer.isDirty = true;
       this.canvasManager.renderAll();
     });
@@ -273,8 +273,8 @@ export class PropertiesPanel {
       const arr = layer.kind === 'scenario' ? 'spawn' : 'entity';
       const idx = layer.toml[arr]?.indexOf(spawn);
       if (idx !== -1) {
-        layer.toml[arr].splice(idx, 1);
         snapshotForUndo(layer);
+        layer.toml[arr].splice(idx, 1);
         layer.isDirty = true;
         this.canvasManager.spawnGroups.delete(spawn);
         this.canvasManager.deselectSpawn();
@@ -286,12 +286,12 @@ export class PropertiesPanel {
       const errorEl = document.getElementById('spawnTomlError');
       try {
         const parsed = window.tomlParse(document.getElementById('spawnToml').value);
+        snapshotForUndo(layer);
         // Update spawn in-place
         for (const key of Object.keys(spawn)) {
           if (!key.startsWith('_')) delete spawn[key];
         }
         Object.assign(spawn, parsed);
-        snapshotForUndo(layer);
         layer.isDirty = true;
         errorEl.textContent = '';
         this.canvasManager.renderAll();

--- a/editor/style.css
+++ b/editor/style.css
@@ -963,6 +963,18 @@ form {
   display: none !important;
 }
 
+/* V2: per-mode pane container.
+ * Visible pane fills the main area in the same flex layout V1 used; hidden
+ * panes are dropped entirely so their children don't steal layout space. */
+.mode-pane {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+.mode-pane.hidden {
+  display: none !important;
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar {
   width: 8px;

--- a/editor/tag-shape-map.js
+++ b/editor/tag-shape-map.js
@@ -1,33 +1,69 @@
 /**
  * tag-shape-map.js — Pure tag→RadarShape mapping.
  *
- * Mirrors the runtime logic in src/console/helm/client.rs:
- *   has_tag("ship")    → RadarShape::Triangle
- *   has_tag("station") → RadarShape::Square
- *   (everything else)  → RadarShape::Dot
+ * Mirrors the runtime table in src/gui/radar.rs `tags_to_radar_layer` +
+ * `layer_to_icon`. Each Rust `RadarLayer` maps to one editor `RadarShape`:
  *
- * Order of precedence matches the Rust runtime: ship is checked first,
- * then station, then fallback to Dot.
+ *   Rust layer  →  editor shape
+ *   ──────────────────────────
+ *   Ship        →  Triangle
+ *   Asteroid    →  Dot
+ *   Station     →  Diamond
+ *   Missile     →  Dot       (rare in editor; torpedoes are runtime-only)
+ *   Planet      →  Ring
+ *   Star        →  Dot       (drawn as a filled circle, distinct from Ring)
+ *
+ * Precedence matches the runtime (first-match-wins, identical to
+ * `tags_to_radar_layer` in src/gui/radar.rs):
+ *
+ *   has("region")                    → Dot (regions are not radar-relevant
+ *                                           in-game; editor still draws them
+ *                                           as a generic dot via fallback)
+ *   has("ship") | has("pirate")      → Triangle
+ *   has("asteroid") | "asteroid_field" → Dot
+ *   has("station")                   → Diamond
+ *   has("missile") | has("torpedo")  → Dot
+ *   has("planet")                    → Ring
+ *   has("star")                      → Dot
+ *   (otherwise)                      → Dot
+ *
+ * When the Rust table changes, update this file AND the matching tests in
+ * editor/tests/tag-shape-map.test.js.
  */
 
 export const RADAR_SHAPE = Object.freeze({
   Triangle: 'Triangle',
   Square: 'Square',
+  Diamond: 'Diamond',
+  Ring: 'Ring',
   Dot: 'Dot',
 });
 
 /**
  * Return the RadarShape for a given tag array.
  *
+ * Order of checks matches `tags_to_radar_layer` in src/gui/radar.rs.
+ *
  * @param {string[]|null|undefined} tags
- * @returns {'Triangle'|'Square'|'Dot'}
+ * @returns {'Triangle'|'Square'|'Diamond'|'Ring'|'Dot'}
  */
 export function tagShape(tags) {
   if (!Array.isArray(tags)) return RADAR_SHAPE.Dot;
 
   const has = (tag) => tags.includes(tag);
 
-  if (has('ship')) return RADAR_SHAPE.Triangle;
-  if (has('station')) return RADAR_SHAPE.Square;
+  // Region is filtered out of the runtime radar entirely; in the editor we
+  // still need *some* shape so the entity is visible on the canvas, and Dot
+  // is the safest generic. Region rendering proper is handled by
+  // canvas-region.js, not by this mapping.
+  if (has('region')) return RADAR_SHAPE.Dot;
+
+  if (has('ship') || has('pirate')) return RADAR_SHAPE.Triangle;
+  if (has('asteroid') || has('asteroid_field')) return RADAR_SHAPE.Dot;
+  if (has('station')) return RADAR_SHAPE.Diamond;
+  if (has('missile') || has('torpedo')) return RADAR_SHAPE.Dot;
+  if (has('planet')) return RADAR_SHAPE.Ring;
+  if (has('star')) return RADAR_SHAPE.Dot;
+
   return RADAR_SHAPE.Dot;
 }

--- a/editor/tests/canvas-scenario.test.js
+++ b/editor/tests/canvas-scenario.test.js
@@ -22,7 +22,7 @@ describe('resolveEntityAppearance', () => {
       expect(result.hasFallback).toBe(false);
     });
 
-    it('station_axiom returns green colour, radius 18, Square shape', () => {
+    it('station_axiom returns green colour, radius 18, Diamond shape', () => {
       const entity = {
         tags: ['station', 'comms_contact', 'allied'],
         radar_appearance: { colour: [0.3, 0.8, 0.6], radius: 18.0 },
@@ -30,7 +30,7 @@ describe('resolveEntityAppearance', () => {
       const result = resolveEntityAppearance(entity);
       expect(result.colour).toEqual([0.3, 0.8, 0.6]);
       expect(result.radius).toBe(18.0);
-      expect(result.shape).toBe('Square');
+      expect(result.shape).toBe('Diamond');
       expect(result.hasFallback).toBe(false);
     });
 
@@ -46,7 +46,7 @@ describe('resolveEntityAppearance', () => {
       expect(result.hasFallback).toBe(false);
     });
 
-    it('planet_earth returns blue colour, radius 20, Dot shape', () => {
+    it('planet_earth returns blue colour, radius 20, Ring shape', () => {
       const entity = {
         tags: ['planet', 'habitable'],
         radar_appearance: { colour: [0.0, 0.6, 1.0], radius: 20.0 },
@@ -54,7 +54,7 @@ describe('resolveEntityAppearance', () => {
       const result = resolveEntityAppearance(entity);
       expect(result.colour).toEqual([0.0, 0.6, 1.0]);
       expect(result.radius).toBe(20.0);
-      expect(result.shape).toBe('Dot');
+      expect(result.shape).toBe('Ring');
       expect(result.hasFallback).toBe(false);
     });
 

--- a/editor/tests/cross-references.test.js
+++ b/editor/tests/cross-references.test.js
@@ -146,4 +146,66 @@ describe('CrossReferenceIndex', () => {
     expect(names[0].name).toBe('beta');
     expect(names[0].layerPath).toBe('second.toml');
   });
+
+  describe('hasEntity / allReferences (composition surface)', () => {
+    it('hasEntity returns true for declared entities and false for others', () => {
+      const idx = new CrossReferenceIndex();
+      idx.indexLayers([
+        { path: 'w.toml', worldState: { entity: [{ name: 'alpha' }, { name: 'beta' }] } },
+      ]);
+      expect(idx.hasEntity('alpha')).toBe(true);
+      expect(idx.hasEntity('beta')).toBe(true);
+      expect(idx.hasEntity('phantom')).toBe(false);
+    });
+
+    it('allReferences yields every recorded site with targetName + context', () => {
+      const idx = new CrossReferenceIndex();
+      idx.indexLayers([
+        {
+          path: 'w.toml',
+          worldState: {
+            entity: [{ name: 'alpha' }],
+            trigger: [{
+              condition: 'on_destroyed',
+              entity: 'alpha',
+              action: [{ type: 'set_ai_state', entity: 'phantom', state: 'patrol' }],
+            }],
+          },
+        },
+      ]);
+      const refs = Array.from(idx.allReferences());
+      const names = refs.map(r => r.targetName).sort();
+      expect(names).toContain('alpha');
+      expect(names).toContain('phantom');
+      // Every yielded object must carry the context string the index recorded.
+      for (const ref of refs) {
+        expect(typeof ref.context).toBe('string');
+        expect(ref.context.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('allReferences records trigger.action `entity` (not just target_entity)', () => {
+      const idx = new CrossReferenceIndex();
+      idx.indexLayers([
+        {
+          path: 'w.toml',
+          worldState: {
+            entity: [{ name: 'real' }],
+            trigger: [{
+              condition: 'on_attacked',
+              entity: 'real',
+              action: [
+                { type: 'apply_modifier', entity: 'mod_target', tag: 't', slot: 'MaxSpeed', bonus: 0.5 },
+                { type: 'set_ai_state', target_entity: 'tgt_target', state: 'flee' },
+              ],
+            }],
+          },
+        },
+      ]);
+      const refs = Array.from(idx.allReferences());
+      const names = refs.map(r => r.targetName);
+      expect(names).toContain('mod_target');
+      expect(names).toContain('tgt_target');
+    });
+  });
 });

--- a/editor/tests/entity-cache.test.js
+++ b/editor/tests/entity-cache.test.js
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  entityCache,
+  loadEntityConfig,
+  getEntityConfig,
+  preloadEntityCache,
+  preloadEntityList,
+  invalidateEntity,
+  invalidateAll,
+  onInvalidate,
+} from '../entity-cache.js';
+import { _setRootHandleForTest } from '../project-root.js';
+
+function makeFileHandle(content) {
+  return {
+    kind: 'file',
+    getFile: async () => ({ text: async () => content }),
+  };
+}
+
+function makeAssetsEntitiesRoot(files) {
+  const entitiesDir = {
+    kind: 'directory',
+    entries: async function* () {
+      for (const [name, content] of Object.entries(files)) {
+        yield [name, makeFileHandle(content)];
+      }
+    },
+    getFileHandle: async (name) => {
+      if (!(name in files)) {
+        throw new DOMException(`File "${name}" not found`, 'NotFoundError');
+      }
+      return makeFileHandle(files[name]);
+    },
+  };
+  const assetsDir = {
+    kind: 'directory',
+    getDirectoryHandle: async (name) => {
+      if (name === 'entities') return entitiesDir;
+      throw new DOMException(`Directory "${name}" not found`, 'NotFoundError');
+    },
+  };
+  return {
+    kind: 'directory',
+    getDirectoryHandle: async (name) => {
+      if (name === 'assets') return assetsDir;
+      throw new DOMException(`Directory "${name}" not found`, 'NotFoundError');
+    },
+  };
+}
+
+// Minimal global TOML parser stub for tests.
+if (!globalThis.window) globalThis.window = globalThis;
+globalThis.window.tomlParse = (text) => {
+  // Very small parser: just extracts `tags = ["a","b"]` and `name = "..."` lines.
+  const out = {};
+  const tagsMatch = text.match(/tags\s*=\s*\[([^\]]*)\]/);
+  if (tagsMatch) {
+    out.tags = tagsMatch[1]
+      .split(',')
+      .map((s) => s.trim().replace(/^"|"$/g, ''))
+      .filter(Boolean);
+  }
+  const nameMatch = text.match(/^name\s*=\s*"([^"]*)"/m);
+  if (nameMatch) out.name = nameMatch[1];
+  return out;
+};
+
+describe('entity-cache (FSA)', () => {
+  beforeEach(() => {
+    entityCache.clear();
+    _setRootHandleForTest(null);
+  });
+
+  it('preloadEntityCache no-ops gracefully when no root is selected', async () => {
+    const results = await preloadEntityCache();
+    expect(results).toEqual([]);
+    expect(entityCache.size).toBe(0);
+  });
+
+  it('preloadEntityCache loads every .toml from assets/entities', async () => {
+    const root = makeAssetsEntitiesRoot({
+      'ship_a.toml': 'name = "Ship A"\ntags = ["ship","alpha"]\n',
+      'ship_b.toml': 'name = "Ship B"\ntags = ["ship","beta"]\n',
+      'README.md': 'not toml',
+    });
+    _setRootHandleForTest(root);
+
+    const results = await preloadEntityCache();
+    expect(results).toHaveLength(2);
+    expect(entityCache.size).toBe(2);
+    expect(entityCache.has('assets/entities/ship_a.toml')).toBe(true);
+    expect(entityCache.has('assets/entities/ship_b.toml')).toBe(true);
+  });
+
+  it('loadEntityConfig caches and returns parsed config', async () => {
+    const root = makeAssetsEntitiesRoot({
+      'ship_a.toml': 'name = "Ship A"\ntags = ["ship"]\n',
+    });
+    _setRootHandleForTest(root);
+
+    const cfg = await loadEntityConfig('assets/entities/ship_a.toml');
+    expect(cfg).not.toBeNull();
+    expect(cfg.tags).toEqual(['ship']);
+    expect(getEntityConfig('assets/entities/ship_a.toml')).toBe(cfg);
+  });
+
+  it('loadEntityConfig returns null on missing file', async () => {
+    const root = makeAssetsEntitiesRoot({});
+    _setRootHandleForTest(root);
+
+    const cfg = await loadEntityConfig('assets/entities/missing.toml');
+    expect(cfg).toBeNull();
+  });
+
+  it('preloadEntityList returns name/path/tags from cache', async () => {
+    const root = makeAssetsEntitiesRoot({
+      'ship_a.toml': 'tags = ["ship"]\n',
+    });
+    _setRootHandleForTest(root);
+    await preloadEntityCache();
+
+    const list = preloadEntityList();
+    expect(list).toEqual([
+      { name: 'ship_a', path: 'assets/entities/ship_a.toml', tags: ['ship'] },
+    ]);
+  });
+
+  it('invalidateEntity removes the entry and fires listeners', async () => {
+    const root = makeAssetsEntitiesRoot({
+      'ship_a.toml': 'tags = ["ship"]\n',
+    });
+    _setRootHandleForTest(root);
+    await loadEntityConfig('assets/entities/ship_a.toml');
+    expect(entityCache.has('assets/entities/ship_a.toml')).toBe(true);
+
+    const fired = [];
+    const sub = onInvalidate((p) => fired.push(p));
+    invalidateEntity('assets/entities/ship_a.toml');
+
+    expect(entityCache.has('assets/entities/ship_a.toml')).toBe(false);
+    expect(fired).toEqual(['assets/entities/ship_a.toml']);
+    sub.unsubscribe();
+  });
+
+  it('invalidateAll clears the cache and fires listeners with null', async () => {
+    const root = makeAssetsEntitiesRoot({
+      'ship_a.toml': 'tags = ["ship"]\n',
+      'ship_b.toml': 'tags = ["ship"]\n',
+    });
+    _setRootHandleForTest(root);
+    await preloadEntityCache();
+    expect(entityCache.size).toBe(2);
+
+    const fired = [];
+    const sub = onInvalidate((p) => fired.push(p));
+    invalidateAll();
+
+    expect(entityCache.size).toBe(0);
+    expect(fired).toEqual([null]);
+    sub.unsubscribe();
+  });
+
+  it('onInvalidate.unsubscribe stops further notifications', async () => {
+    const fired = [];
+    const sub = onInvalidate((p) => fired.push(p));
+    sub.unsubscribe();
+    invalidateEntity('any');
+    expect(fired).toEqual([]);
+  });
+});

--- a/editor/tests/entity-preview.test.js
+++ b/editor/tests/entity-preview.test.js
@@ -79,9 +79,9 @@ describe('computeEntityPreview', () => {
       expect(result.radarShape).toBe('Triangle');
     });
 
-    it('station-tagged entity with radar_appearance returns Square shape', () => {
+    it('station-tagged entity with radar_appearance returns Diamond shape', () => {
       const result = computeEntityPreview(stationWithRadar);
-      expect(result.radarShape).toBe('Square');
+      expect(result.radarShape).toBe('Diamond');
     });
   });
 

--- a/editor/tests/mode-shell.test.js
+++ b/editor/tests/mode-shell.test.js
@@ -272,6 +272,64 @@ describe('mode-shell', () => {
     });
   });
 
+  describe('undoActive / redoActive / clearUndoHistory (UndoStack integration)', () => {
+    it('undoActive pops the most recent entry', () => {
+      const shell = new ModeShell();
+      shell.pushUndoEntry('Scenario', 'a.toml', { v: 1 });
+      shell.pushUndoEntry('Scenario', 'a.toml', { v: 2 });
+
+      const popped = shell.undoActive('Scenario', 'a.toml');
+      expect(popped).toEqual({ v: 2 });
+      expect(shell.getUndoHistory('Scenario', 'a.toml')).toEqual([{ v: 1 }]);
+    });
+
+    it('undoActive returns null with no history', () => {
+      const shell = new ModeShell();
+      expect(shell.undoActive('Scenario', 'a.toml')).toBeNull();
+    });
+
+    it('redoActive restores the last undone entry', () => {
+      const shell = new ModeShell();
+      shell.pushUndoEntry('Scenario', 'a.toml', { v: 1 });
+      shell.undoActive('Scenario', 'a.toml');
+
+      const restored = shell.redoActive('Scenario', 'a.toml');
+      expect(restored).toEqual({ v: 1 });
+      expect(shell.getUndoHistory('Scenario', 'a.toml')).toEqual([{ v: 1 }]);
+    });
+
+    it('redoActive returns null with empty redo stack', () => {
+      const shell = new ModeShell();
+      shell.pushUndoEntry('Scenario', 'a.toml', { v: 1 });
+      // No undo yet → nothing to redo.
+      expect(shell.redoActive('Scenario', 'a.toml')).toBeNull();
+    });
+
+    it('pushUndoEntry after undo clears the redo stack', () => {
+      const shell = new ModeShell();
+      shell.pushUndoEntry('Scenario', 'a.toml', { v: 1 });
+      shell.undoActive('Scenario', 'a.toml');
+      shell.pushUndoEntry('Scenario', 'a.toml', { v: 99 });
+      // Redo should now be empty.
+      expect(shell.redoActive('Scenario', 'a.toml')).toBeNull();
+    });
+
+    it('clearUndoHistory empties both stacks for that file', () => {
+      const shell = new ModeShell();
+      shell.pushUndoEntry('Scenario', 'a.toml', { v: 1 });
+      shell.pushUndoEntry('Scenario', 'a.toml', { v: 2 });
+      shell.clearUndoHistory('Scenario', 'a.toml');
+      expect(shell.getUndoHistory('Scenario', 'a.toml')).toEqual([]);
+      expect(shell.undoActive('Scenario', 'a.toml')).toBeNull();
+      expect(shell.redoActive('Scenario', 'a.toml')).toBeNull();
+    });
+
+    it('clearUndoHistory on unknown file is a no-op', () => {
+      const shell = new ModeShell();
+      expect(() => shell.clearUndoHistory('Scenario', 'never.toml')).not.toThrow();
+    });
+  });
+
   describe('full persistence scenario (AC integration test)', () => {
     it('open file A in Scenario → switch to Entity → open file B → switch back → file A is still open and active', () => {
       const shell = new ModeShell();

--- a/editor/tests/project-root.test.js
+++ b/editor/tests/project-root.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { isSupported, readFile, writeFile, _setRootHandleForTest } from '../project-root.js';
+import { isSupported, readFile, writeFile, listDirectory, _setRootHandleForTest } from '../project-root.js';
 
 function createMockFileHandle(name, content) {
   return {
@@ -168,9 +168,8 @@ describe('project-root', () => {
           return {
             getFile: async () => ({ text: async () => content }),
             createWritable: async () => {
-              let buffer = files[name];
               return {
-                write: async (data) => { files[name] = data; buffer = data; },
+                write: async (data) => { files[name] = data; },
                 close: async () => {},
               };
             },
@@ -184,6 +183,69 @@ describe('project-root', () => {
       await writeFile('test.toml', toml);
       const result = await readFile('test.toml');
       expect(result).toBe(toml);
+    });
+  });
+
+  describe('listDirectory', () => {
+    it('rejects when no root is selected', async () => {
+      // Either throws "No project root selected" (if loadHandle resolves to
+      // null) or rejects with an indexedDB error (in test env). Both are
+      // "not usable" — what matters is that callers must select a root first.
+      await expect(listDirectory('')).rejects.toBeDefined();
+    });
+
+    it('lists files at the root', async () => {
+      const root = createMockDirectoryHandle({
+        'a.toml': 'a',
+        'b.toml': 'b',
+      });
+      _setRootHandleForTest(root);
+
+      const entries = await listDirectory('');
+      const names = entries.map((e) => e.name).sort();
+      expect(names).toEqual(['a.toml', 'b.toml']);
+      expect(entries.every((e) => e.kind === 'file')).toBe(true);
+    });
+
+    it('lists entries in a nested directory', async () => {
+      const inner = {
+        entries: async function* () {
+          yield ['x.toml', { kind: 'file' }];
+          yield ['y.toml', { kind: 'file' }];
+        },
+      };
+      const root = {
+        getDirectoryHandle: async (name) => {
+          if (name === 'assets') {
+            return {
+              getDirectoryHandle: async (n) => {
+                if (n === 'entities') return inner;
+                throw new DOMException('Not found', 'NotFoundError');
+              },
+            };
+          }
+          throw new DOMException('Not found', 'NotFoundError');
+        },
+      };
+      _setRootHandleForTest(root);
+
+      const entries = await listDirectory('assets/entities');
+      expect(entries.map((e) => e.name).sort()).toEqual(['x.toml', 'y.toml']);
+    });
+
+    it('distinguishes files from directories via kind', async () => {
+      const root = {
+        entries: async function* () {
+          yield ['file.toml', { kind: 'file' }];
+          yield ['subdir', { kind: 'directory' }];
+        },
+      };
+      _setRootHandleForTest(root);
+
+      const entries = await listDirectory('');
+      const byName = Object.fromEntries(entries.map((e) => [e.name, e.kind]));
+      expect(byName['file.toml']).toBe('file');
+      expect(byName['subdir']).toBe('directory');
     });
   });
 });

--- a/editor/tests/save-flow.test.js
+++ b/editor/tests/save-flow.test.js
@@ -1,10 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ModeShell } from '../mode-shell.js';
 import { SaveFlow } from '../save-flow.js';
+import { InvalidationBus } from '../invalidation-bus.js';
+
+const noopWriter = async () => {};
+const noopBus = { fireEntitySaved: () => {}, fireWorldSaved: () => {} };
 
 describe('SaveFlow', () => {
   describe('saveActive', () => {
-    it('returns ok when file is serializable', () => {
+    it('returns ok when file is serializable', async () => {
       const modeShell = new ModeShell();
       modeShell.setOpenFiles('Scenario', ['assets/worlds/test.toml']);
       modeShell.setActiveFile('Scenario', 'assets/worlds/test.toml');
@@ -15,19 +19,19 @@ describe('SaveFlow', () => {
         entity: () => '',
       };
 
-      const saveFlow = new SaveFlow(modeShell, stringifyFns);
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, noopBus);
       saveFlow.setContent('Scenario', 'assets/worlds/test.toml', {
         name: 'Test World',
         global: {},
         anchors: {},
       });
 
-      const result = saveFlow.saveActive(null);
+      const result = await saveFlow.saveActive(null);
       expect(result.ok).toBe(true);
       expect(result.errors).toEqual([]);
     });
 
-    it('returns error when file cannot be serialized', () => {
+    it('returns error when file cannot be serialized', async () => {
       const modeShell = new ModeShell();
       modeShell.setOpenFiles('Scenario', ['assets/worlds/test.toml']);
       modeShell.setActiveFile('Scenario', 'assets/worlds/test.toml');
@@ -40,18 +44,18 @@ describe('SaveFlow', () => {
         entity: () => '',
       };
 
-      const saveFlow = new SaveFlow(modeShell, stringifyFns);
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, noopBus);
       saveFlow.setContent('Scenario', 'assets/worlds/test.toml', {
         name: 'Test World',
       });
 
-      const result = saveFlow.saveActive(null);
+      const result = await saveFlow.saveActive(null);
       expect(result.ok).toBe(false);
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toContain('failed');
     });
 
-    it('returns warnings for validation errors but does not block', () => {
+    it('returns warnings for validation errors but does not block', async () => {
       const modeShell = new ModeShell();
       modeShell.setOpenFiles('Scenario', ['assets/worlds/invalid.toml']);
       modeShell.setActiveFile('Scenario', 'assets/worlds/invalid.toml');
@@ -62,18 +66,18 @@ describe('SaveFlow', () => {
         entity: () => '',
       };
 
-      const saveFlow = new SaveFlow(modeShell, stringifyFns);
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, noopBus);
       saveFlow.setContent('Scenario', 'assets/worlds/invalid.toml', {
         name: 'Bad World',
       });
 
-      const result = saveFlow.saveActive(null);
+      const result = await saveFlow.saveActive(null);
       expect(result.ok).toBe(true);
       expect(result.errors).toEqual([]);
       expect(result.warnings.length).toBeGreaterThan(0);
     });
 
-    it('marks file as clean after successful save', () => {
+    it('marks file as clean after successful save', async () => {
       const modeShell = new ModeShell();
       modeShell.setOpenFiles('Scenario', ['assets/worlds/test.toml']);
       modeShell.setActiveFile('Scenario', 'assets/worlds/test.toml');
@@ -84,23 +88,23 @@ describe('SaveFlow', () => {
         entity: () => '',
       };
 
-      const saveFlow = new SaveFlow(modeShell, stringifyFns);
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, noopBus);
       saveFlow.setContent('Scenario', 'assets/worlds/test.toml', {
         global: {},
         anchors: {},
       });
 
       expect(modeShell.isDirty('Scenario', 'assets/worlds/test.toml')).toBe(true);
-      saveFlow.saveActive(null);
+      await saveFlow.saveActive(null);
       expect(modeShell.isDirty('Scenario', 'assets/worlds/test.toml')).toBe(false);
     });
 
-    it('with no active file returns error', () => {
+    it('with no active file returns error', async () => {
       const modeShell = new ModeShell();
       const stringifyFns = { world: () => '', entity: () => '' };
-      const saveFlow = new SaveFlow(modeShell, stringifyFns);
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, noopBus);
 
-      const result = saveFlow.saveActive(null);
+      const result = await saveFlow.saveActive(null);
       expect(result.ok).toBe(false);
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toContain('No active file');
@@ -108,7 +112,7 @@ describe('SaveFlow', () => {
   });
 
   describe('saveAll', () => {
-    it('saves all dirty files', () => {
+    it('saves all dirty files', async () => {
       const modeShell = new ModeShell();
       modeShell.setOpenFiles('Scenario', ['assets/worlds/a.toml']);
       modeShell.setOpenFiles('Entity', ['assets/entities/b.toml']);
@@ -122,19 +126,19 @@ describe('SaveFlow', () => {
         entity: () => 'entity content',
       };
 
-      const saveFlow = new SaveFlow(modeShell, stringifyFns);
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, noopBus);
       saveFlow.setContent('Scenario', 'assets/worlds/a.toml', {
         global: {},
         anchors: {},
       });
       saveFlow.setContent('Entity', 'assets/entities/b.toml', { tags: ['test'] });
 
-      const results = saveFlow.saveAll(null);
+      const results = await saveFlow.saveAll(null);
       expect(results).toHaveLength(2);
       expect(results.every((r) => r.ok)).toBe(true);
     });
 
-    it('returns per-file results', () => {
+    it('returns per-file results', async () => {
       const modeShell = new ModeShell();
       modeShell.setOpenFiles('Scenario', ['assets/worlds/a.toml']);
       modeShell.setOpenFiles('Entity', ['assets/entities/b.toml']);
@@ -148,11 +152,11 @@ describe('SaveFlow', () => {
         entity: () => 'entity content',
       };
 
-      const saveFlow = new SaveFlow(modeShell, stringifyFns);
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, noopBus);
       saveFlow.setContent('Scenario', 'assets/worlds/a.toml', { name: 'test' });
       saveFlow.setContent('Entity', 'assets/entities/b.toml', { tags: ['test'] });
 
-      const results = saveFlow.saveAll(null);
+      const results = await saveFlow.saveAll(null);
       expect(results).toHaveLength(2);
       expect(results[0].path).toBe('assets/worlds/a.toml');
       expect(results[0].ok).toBe(false);
@@ -160,7 +164,7 @@ describe('SaveFlow', () => {
       expect(results[1].ok).toBe(true);
     });
 
-    it('marks each file clean on success', () => {
+    it('marks each file clean on success', async () => {
       const modeShell = new ModeShell();
       modeShell.setOpenFiles('Scenario', ['assets/worlds/a.toml']);
       modeShell.setOpenFiles('Entity', ['assets/entities/b.toml']);
@@ -172,14 +176,14 @@ describe('SaveFlow', () => {
         entity: () => 'content',
       };
 
-      const saveFlow = new SaveFlow(modeShell, stringifyFns);
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, noopBus);
       saveFlow.setContent('Scenario', 'assets/worlds/a.toml', {
         global: {},
         anchors: {},
       });
       saveFlow.setContent('Entity', 'assets/entities/b.toml', { tags: ['test'] });
 
-      saveFlow.saveAll(null);
+      await saveFlow.saveAll(null);
       expect(modeShell.isDirty('Scenario', 'assets/worlds/a.toml')).toBe(false);
       expect(modeShell.isDirty('Entity', 'assets/entities/b.toml')).toBe(false);
     });
@@ -196,7 +200,7 @@ describe('SaveFlow', () => {
       const saveFlow = new SaveFlow(modeShell, {
         world: () => '',
         entity: () => '',
-      });
+      }, noopWriter, noopBus);
 
       const dirty = saveFlow.getDirtyFiles();
       expect(dirty).toHaveLength(2);
@@ -206,19 +210,135 @@ describe('SaveFlow', () => {
   });
 
   describe('cross-reference warnings', () => {
-    it('do not block save (never-refuse-valid-TOML)', () => {
+    it('do not block save (never-refuse-valid-TOML)', async () => {
       const modeShell = new ModeShell();
       modeShell.setOpenFiles('Scenario', ['assets/worlds/test.toml']);
       modeShell.setActiveFile('Scenario', 'assets/worlds/test.toml');
       modeShell.markDirty('Scenario', 'assets/worlds/test.toml', true);
 
       const stringifyFns = { world: () => 'content', entity: () => '' };
-      const saveFlow = new SaveFlow(modeShell, stringifyFns);
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, noopBus);
       saveFlow.setContent('Scenario', 'assets/worlds/test.toml', {});
 
-      const result = saveFlow.saveActive(null);
+      const result = await saveFlow.saveActive(null);
       expect(result.ok).toBe(true);
       expect(result.warnings).toBeDefined();
+    });
+  });
+
+  describe('writeFile integration', () => {
+    it('calls writeFile with (path, stringified content)', async () => {
+      const modeShell = new ModeShell();
+      modeShell.setOpenFiles('Scenario', ['assets/worlds/test.toml']);
+      modeShell.setActiveFile('Scenario', 'assets/worlds/test.toml');
+      modeShell.markDirty('Scenario', 'assets/worlds/test.toml', true);
+
+      const writeFile = vi.fn(async () => {});
+      const stringifyFns = {
+        world: () => 'WORLD_CONTENT',
+        entity: () => '',
+      };
+
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, writeFile, noopBus);
+      saveFlow.setContent('Scenario', 'assets/worlds/test.toml', {});
+
+      await saveFlow.saveActive(null);
+      expect(writeFile).toHaveBeenCalledTimes(1);
+      expect(writeFile).toHaveBeenCalledWith('assets/worlds/test.toml', 'WORLD_CONTENT');
+    });
+
+    it('returns ok: false when writeFile rejects', async () => {
+      const modeShell = new ModeShell();
+      modeShell.setOpenFiles('Scenario', ['assets/worlds/test.toml']);
+      modeShell.setActiveFile('Scenario', 'assets/worlds/test.toml');
+      modeShell.markDirty('Scenario', 'assets/worlds/test.toml', true);
+
+      const writeFile = async () => { throw new Error('disk full'); };
+      const stringifyFns = { world: () => 'X', entity: () => '' };
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, writeFile, noopBus);
+      saveFlow.setContent('Scenario', 'assets/worlds/test.toml', {});
+
+      const result = await saveFlow.saveActive(null);
+      expect(result.ok).toBe(false);
+      expect(result.errors[0]).toMatch(/disk full/);
+      // Still dirty — write failed.
+      expect(modeShell.isDirty('Scenario', 'assets/worlds/test.toml')).toBe(true);
+    });
+
+    it('does not write or mark clean if serialization throws', async () => {
+      const modeShell = new ModeShell();
+      modeShell.setOpenFiles('Scenario', ['assets/worlds/test.toml']);
+      modeShell.setActiveFile('Scenario', 'assets/worlds/test.toml');
+      modeShell.markDirty('Scenario', 'assets/worlds/test.toml', true);
+
+      const writeFile = vi.fn(async () => {});
+      const stringifyFns = {
+        world: () => { throw new Error('bad'); },
+        entity: () => '',
+      };
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, writeFile, noopBus);
+      saveFlow.setContent('Scenario', 'assets/worlds/test.toml', {});
+
+      const result = await saveFlow.saveActive(null);
+      expect(result.ok).toBe(false);
+      expect(writeFile).not.toHaveBeenCalled();
+      expect(modeShell.isDirty('Scenario', 'assets/worlds/test.toml')).toBe(true);
+    });
+  });
+
+  describe('undo + invalidation on save', () => {
+    it('clears undo history on successful save', async () => {
+      const modeShell = new ModeShell();
+      modeShell.setOpenFiles('Scenario', ['assets/worlds/test.toml']);
+      modeShell.setActiveFile('Scenario', 'assets/worlds/test.toml');
+      modeShell.markDirty('Scenario', 'assets/worlds/test.toml', true);
+      modeShell.pushUndoEntry('Scenario', 'assets/worlds/test.toml', { v: 1 });
+      modeShell.pushUndoEntry('Scenario', 'assets/worlds/test.toml', { v: 2 });
+      expect(modeShell.getUndoHistory('Scenario', 'assets/worlds/test.toml')).toHaveLength(2);
+
+      const stringifyFns = { world: () => 'X', entity: () => '' };
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, noopBus);
+      saveFlow.setContent('Scenario', 'assets/worlds/test.toml', {});
+
+      await saveFlow.saveActive(null);
+      expect(modeShell.getUndoHistory('Scenario', 'assets/worlds/test.toml')).toEqual([]);
+    });
+
+    it('fires fireWorldSaved on Scenario mode save', async () => {
+      const modeShell = new ModeShell();
+      modeShell.setOpenFiles('Scenario', ['assets/worlds/test.toml']);
+      modeShell.setActiveFile('Scenario', 'assets/worlds/test.toml');
+      modeShell.markDirty('Scenario', 'assets/worlds/test.toml', true);
+
+      const bus = new InvalidationBus();
+      const fired = [];
+      bus.onWorldSaved((p) => fired.push(p));
+
+      const stringifyFns = { world: () => 'X', entity: () => '' };
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, bus);
+      saveFlow.setContent('Scenario', 'assets/worlds/test.toml', {});
+
+      await saveFlow.saveActive(null);
+      expect(fired).toEqual(['assets/worlds/test.toml']);
+    });
+
+    it('fires fireEntitySaved on Entity mode save', async () => {
+      const modeShell = new ModeShell();
+      modeShell.switchMode('Entity');
+      modeShell.setOpenFiles('Entity', ['assets/entities/a.toml']);
+      modeShell.setActiveFile('Entity', 'assets/entities/a.toml');
+      modeShell.markDirty('Entity', 'assets/entities/a.toml', true);
+
+      const bus = new InvalidationBus();
+      const fired = [];
+      bus.onEntitySaved((p) => fired.push(p));
+
+      const stringifyFns = { world: () => '', entity: () => 'E' };
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, bus);
+      saveFlow.setContent('Entity', 'assets/entities/a.toml', {});
+
+      await saveFlow.saveActive(null);
+      expect(fired).toEqual(['assets/entities/a.toml']);
     });
   });
 });

--- a/editor/tests/tag-shape-map.test.js
+++ b/editor/tests/tag-shape-map.test.js
@@ -1,16 +1,25 @@
 import { describe, it, expect } from 'vitest';
 import { tagShape, RADAR_SHAPE } from '../tag-shape-map.js';
 
-// Mirrors the runtime mapping in src/console/helm/client.rs:
-//   ship  → Triangle
-//   station → Square
-//   (everything else) → Dot
+// Mirrors the runtime table `tags_to_radar_layer` + `layer_to_icon` in
+// src/gui/radar.rs. The full editor mapping is:
+//   ship | pirate          → Triangle
+//   asteroid | asteroid_field → Dot
+//   station               → Diamond
+//   missile | torpedo     → Dot
+//   planet                → Ring
+//   star                  → Dot
+//   region                → Dot   (regions are filtered from runtime radar
+//                                  entirely; editor uses Dot as a generic)
+//   (everything else)     → Dot
 
 describe('tag-shape-map', () => {
   describe('RADAR_SHAPE constants', () => {
-    it('exports Triangle, Square, and Dot constants', () => {
+    it('exports Triangle, Square, Diamond, Ring, and Dot constants', () => {
       expect(RADAR_SHAPE.Triangle).toBe('Triangle');
       expect(RADAR_SHAPE.Square).toBe('Square');
+      expect(RADAR_SHAPE.Diamond).toBe('Diamond');
+      expect(RADAR_SHAPE.Ring).toBe('Ring');
       expect(RADAR_SHAPE.Dot).toBe('Dot');
     });
   });
@@ -20,8 +29,8 @@ describe('tag-shape-map', () => {
       expect(tagShape(['player', 'ship'])).toBe(RADAR_SHAPE.Triangle);
     });
 
-    it('pirate_raider ["ship","npc","enemy"] → Triangle', () => {
-      expect(tagShape(['ship', 'npc', 'enemy'])).toBe(RADAR_SHAPE.Triangle);
+    it('pirate-tagged entity ["pirate","npc","enemy"] → Triangle', () => {
+      expect(tagShape(['pirate', 'npc', 'enemy'])).toBe(RADAR_SHAPE.Triangle);
     });
 
     it('ship_harrow_patrol ["ship","npc","comms_contact"] → Triangle', () => {
@@ -38,20 +47,30 @@ describe('tag-shape-map', () => {
   });
 
   describe('tagShape — station entities', () => {
-    it('station_axiom ["station","comms_contact","allied"] → Square', () => {
-      expect(tagShape(['station', 'comms_contact', 'allied'])).toBe(RADAR_SHAPE.Square);
+    it('station_axiom ["station","comms_contact","allied"] → Diamond', () => {
+      expect(tagShape(['station', 'comms_contact', 'allied'])).toBe(RADAR_SHAPE.Diamond);
     });
 
-    it('station_outpost ["station","destructible"] → Square', () => {
-      expect(tagShape(['station', 'destructible'])).toBe(RADAR_SHAPE.Square);
+    it('station_outpost ["station","destructible"] → Diamond', () => {
+      expect(tagShape(['station', 'destructible'])).toBe(RADAR_SHAPE.Diamond);
     });
 
-    it('station_research_outpost ["station","comms_contact","science_facility"] → Square', () => {
-      expect(tagShape(['station', 'comms_contact', 'science_facility'])).toBe(RADAR_SHAPE.Square);
+    it('station_research_outpost ["station","comms_contact","science_facility"] → Diamond', () => {
+      expect(tagShape(['station', 'comms_contact', 'science_facility'])).toBe(RADAR_SHAPE.Diamond);
     });
   });
 
-  describe('tagShape — dot entities (asteroids, planets, stars, regions, fields)', () => {
+  describe('tagShape — planet entities', () => {
+    it('planet_earth ["planet","habitable"] → Ring', () => {
+      expect(tagShape(['planet', 'habitable'])).toBe(RADAR_SHAPE.Ring);
+    });
+
+    it('planet_mars ["planet","barren"] → Ring', () => {
+      expect(tagShape(['planet', 'barren'])).toBe(RADAR_SHAPE.Ring);
+    });
+  });
+
+  describe('tagShape — dot entities (asteroids, stars, missiles, regions, fields)', () => {
     it('asteroid_large ["asteroid","gameplay","large"] → Dot', () => {
       expect(tagShape(['asteroid', 'gameplay', 'large'])).toBe(RADAR_SHAPE.Dot);
     });
@@ -68,12 +87,16 @@ describe('tag-shape-map', () => {
       expect(tagShape(['field', 'main', 'asteroid_field'])).toBe(RADAR_SHAPE.Dot);
     });
 
-    it('planet_earth ["planet","habitable"] → Dot', () => {
-      expect(tagShape(['planet', 'habitable'])).toBe(RADAR_SHAPE.Dot);
-    });
-
     it('star_sun ["star","center"] → Dot', () => {
       expect(tagShape(['star', 'center'])).toBe(RADAR_SHAPE.Dot);
+    });
+
+    it('missile-tagged entity → Dot', () => {
+      expect(tagShape(['missile'])).toBe(RADAR_SHAPE.Dot);
+    });
+
+    it('torpedo-tagged entity → Dot', () => {
+      expect(tagShape(['torpedo'])).toBe(RADAR_SHAPE.Dot);
     });
 
     it('region_nebula ["region","nebula"] → Dot', () => {
@@ -84,22 +107,30 @@ describe('tag-shape-map', () => {
       expect(tagShape(['region', 'asteroid_belt'])).toBe(RADAR_SHAPE.Dot);
     });
 
-    it('region_kaleth_nebula ["region","nebula"] → Dot', () => {
-      expect(tagShape(['region', 'nebula'])).toBe(RADAR_SHAPE.Dot);
-    });
-
     it('region_radiation_zone ["region","damage_zone","weapon_effect"] → Dot', () => {
       expect(tagShape(['region', 'damage_zone', 'weapon_effect'])).toBe(RADAR_SHAPE.Dot);
     });
   });
 
-  describe('tagShape — deterministic for multi-tag entities', () => {
-    it('same tags in different order produce same result', () => {
-      expect(tagShape(['npc', 'ship', 'enemy'])).toBe(tagShape(['ship', 'npc', 'enemy']));
+  describe('tagShape — precedence', () => {
+    it('region tag forces Dot even when combined with station', () => {
+      // Matches the Rust precedence: region check is first.
+      expect(tagShape(['region', 'station'])).toBe(RADAR_SHAPE.Dot);
     });
 
-    it('same tags in different order produce same result for stations', () => {
-      expect(tagShape(['comms_contact', 'station', 'allied'])).toBe(tagShape(['station', 'allied', 'comms_contact']));
+    it('ship beats station when both tags present', () => {
+      // Matches the Rust precedence: ship is checked before station.
+      expect(tagShape(['station', 'ship'])).toBe(RADAR_SHAPE.Triangle);
+    });
+
+    it('station beats planet when both tags present', () => {
+      expect(tagShape(['planet', 'station'])).toBe(RADAR_SHAPE.Diamond);
+    });
+
+    it('same tags in different order produce same result', () => {
+      expect(tagShape(['npc', 'ship', 'enemy'])).toBe(tagShape(['ship', 'npc', 'enemy']));
+      expect(tagShape(['comms_contact', 'station', 'allied']))
+        .toBe(tagShape(['station', 'allied', 'comms_contact']));
     });
   });
 

--- a/editor/tests/undo-integration.test.js
+++ b/editor/tests/undo-integration.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ModeShell } from '../mode-shell.js';
+import { snapshotForUndo, restoreScenarioLayer } from '../undo-controller.js';
+
+/**
+ * End-to-end undo/redo for the Scenario mode. Exercises the contract
+ * documented in `undo-controller.js`:
+ *
+ *   1. snapshot-BEFORE-mutation
+ *   2. Cmd+Z: pop pre-mutation snapshot, push CURRENT (post-mutation) onto redo
+ *   3. Cmd+Shift+Z: pop post-mutation snapshot, push CURRENT (pre-mutation) onto undo
+ *
+ * Uses real ModeShell + UndoStack and a minimal mock layerManager so the
+ * test stays a true integration of the undo/restore wiring without dragging
+ * DOM, Konva or window globals in.
+ */
+describe('undo integration (scenario mode)', () => {
+  let modeShell;
+  let layer;
+  let layerManager;
+
+  // Drive snapshotForUndo through window.__editorV2 the same way app.js does.
+  beforeEach(() => {
+    modeShell = new ModeShell();
+    layer = {
+      filename: 'worlds/test.toml',
+      toml: { name: 'original', spawn: [{ name: 'sun' }] },
+      isDirty: false,
+    };
+    layerManager = {
+      getLayers: () => [layer],
+    };
+    globalThis.window = { __editorV2: { modeShell } };
+  });
+
+  // Mirror of app.js's registerScenarioUndoRestore callback. This lets the
+  // test exercise the exact swap-then-restore flow that the keydown handler
+  // triggers in production.
+  function performUndo(mode, path) {
+    const layerObj = layerManager.getLayers().find((l) => l.filename === path);
+    if (!layerObj) return null;
+    const current = structuredClone(layerObj.toml);
+    const snapshot = modeShell.swapUndoActive(mode, path, current);
+    if (!snapshot) return null;
+    restoreScenarioLayer(layerManager, path, snapshot);
+    return snapshot;
+  }
+
+  function performRedo(mode, path) {
+    const layerObj = layerManager.getLayers().find((l) => l.filename === path);
+    if (!layerObj) return null;
+    const current = structuredClone(layerObj.toml);
+    const snapshot = modeShell.swapRedoActive(mode, path, current);
+    if (!snapshot) return null;
+    restoreScenarioLayer(layerManager, path, snapshot);
+    return snapshot;
+  }
+
+  it('undo restores the pre-mutation state', () => {
+    // Pre-edit value.
+    expect(layer.toml.name).toBe('original');
+
+    // Snapshot BEFORE mutating.
+    snapshotForUndo(layer);
+    layer.toml.name = 'edited';
+
+    expect(layer.toml.name).toBe('edited');
+
+    performUndo('Scenario', layer.filename);
+
+    expect(layer.toml.name).toBe('original');
+  });
+
+  it('redo restores the post-mutation state after undo', () => {
+    snapshotForUndo(layer);
+    layer.toml.name = 'edited';
+
+    performUndo('Scenario', layer.filename);
+    expect(layer.toml.name).toBe('original');
+
+    performRedo('Scenario', layer.filename);
+    expect(layer.toml.name).toBe('edited');
+  });
+
+  it('multiple undos walk back through the history in reverse order', () => {
+    snapshotForUndo(layer);
+    layer.toml.name = 'step1';
+
+    snapshotForUndo(layer);
+    layer.toml.name = 'step2';
+
+    snapshotForUndo(layer);
+    layer.toml.name = 'step3';
+
+    performUndo('Scenario', layer.filename);
+    expect(layer.toml.name).toBe('step2');
+
+    performUndo('Scenario', layer.filename);
+    expect(layer.toml.name).toBe('step1');
+
+    performUndo('Scenario', layer.filename);
+    expect(layer.toml.name).toBe('original');
+  });
+
+  it('redo after multiple undos walks forward again', () => {
+    snapshotForUndo(layer);
+    layer.toml.name = 'step1';
+    snapshotForUndo(layer);
+    layer.toml.name = 'step2';
+
+    performUndo('Scenario', layer.filename);
+    performUndo('Scenario', layer.filename);
+    expect(layer.toml.name).toBe('original');
+
+    performRedo('Scenario', layer.filename);
+    expect(layer.toml.name).toBe('step1');
+
+    performRedo('Scenario', layer.filename);
+    expect(layer.toml.name).toBe('step2');
+  });
+
+  it('undo on empty stack is a no-op and does not corrupt layer state', () => {
+    const before = layer.toml;
+    const result = performUndo('Scenario', layer.filename);
+    expect(result).toBeNull();
+    expect(layer.toml).toBe(before);
+  });
+
+  it('snapshots are independent of subsequent in-place edits', () => {
+    snapshotForUndo(layer);
+    // Mutate a nested object in-place.
+    layer.toml.spawn[0].name = 'moon';
+
+    performUndo('Scenario', layer.filename);
+    expect(layer.toml.spawn[0].name).toBe('sun');
+  });
+
+  it('restoreScenarioLayer returns null when no layer matches the path', () => {
+    const result = restoreScenarioLayer(layerManager, 'unknown.toml', {});
+    expect(result).toBeNull();
+  });
+
+  it('a new edit after undo clears the redo branch', () => {
+    snapshotForUndo(layer);
+    layer.toml.name = 'edited';
+    performUndo('Scenario', layer.filename);
+    expect(modeShell.canRedoActive('Scenario', layer.filename)).toBe(true);
+
+    // New edit while in the "undone" state.
+    snapshotForUndo(layer);
+    layer.toml.name = 'new-branch';
+
+    expect(modeShell.canRedoActive('Scenario', layer.filename)).toBe(false);
+  });
+});

--- a/editor/tests/validation-fixtures.test.js
+++ b/editor/tests/validation-fixtures.test.js
@@ -1,0 +1,145 @@
+/**
+ * validation-fixtures.test.js — Round-trip the canonical world fixtures
+ * (assets/worlds/default.toml and assets/worlds/patrol.toml) through
+ * smol-toml parse + validateFile and assert they are clean.
+ *
+ * Also tests a synthesised broken world to confirm the composed
+ * validator surfaces:
+ *   - action-schema violations (`trigger[i].action`)
+ *   - cross-reference failures (`trigger[i].entity`)
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { parse } from 'smol-toml';
+import { validateFile } from '../validation.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '..', '..');
+
+function loadWorld(relPath) {
+  const text = readFileSync(resolve(repoRoot, relPath), 'utf8');
+  return parse(text);
+}
+
+describe('validation against shipped world fixtures', () => {
+  it('assets/worlds/default.toml validates clean', () => {
+    const parsed = loadWorld('assets/worlds/default.toml');
+    const results = validateFile('assets/worlds/default.toml', parsed);
+    // Surface the actual messages on failure so the diff is debuggable.
+    expect(results).toEqual([]);
+  });
+
+  it('assets/worlds/patrol.toml validates clean', () => {
+    const parsed = loadWorld('assets/worlds/patrol.toml');
+    const results = validateFile('assets/worlds/patrol.toml', parsed);
+    expect(results).toEqual([]);
+  });
+});
+
+describe('validation surfaces composed errors', () => {
+  it('flags an unknown trigger.entity reference', () => {
+    const world = {
+      global: { seed: 42 },
+      anchors: { start: [0, 0, 0] },
+      entity: [{ name: 'real_target' }],
+      trigger: [
+        {
+          condition: 'on_destroyed',
+          entity: 'phantom_target',
+          action: [{ type: 'add_objective', id: 'x', text: 'y' }],
+        },
+      ],
+    };
+    const results = validateFile('assets/worlds/broken.toml', world);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some(r => /unknown entity "phantom_target"/.test(r.message))).toBe(true);
+  });
+
+  it('flags a malformed action-schema entry', () => {
+    const world = {
+      global: { seed: 42 },
+      anchors: { start: [0, 0, 0] },
+      entity: [{ name: 'real_target' }],
+      trigger: [
+        {
+          condition: 'on_destroyed',
+          entity: 'real_target',
+          // Missing required `id` and `text` for add_objective.
+          action: [{ type: 'add_objective' }],
+        },
+      ],
+    };
+    const results = validateFile('assets/worlds/broken.toml', world);
+    expect(results.some(r => r.path.startsWith('trigger[0].action'))).toBe(true);
+    expect(results.some(r => /missing required field/.test(r.message))).toBe(true);
+  });
+
+  it('flags an apply_modifier action with an invalid slot', () => {
+    const world = {
+      global: { seed: 42 },
+      anchors: { start: [0, 0, 0] },
+      entity: [{ name: 'real_target' }],
+      trigger: [
+        {
+          condition: 'on_attacked',
+          entity: 'real_target',
+          action: [{
+            type: 'apply_modifier',
+            entity: 'real_target',
+            tag: 'helm_console',
+            slot: 'NotAValidSlot',
+            bonus: 0.5,
+          }],
+        },
+      ],
+    };
+    const results = validateFile('assets/worlds/broken.toml', world);
+    expect(results.some(r => /invalid value "NotAValidSlot"/.test(r.message))).toBe(true);
+  });
+
+  it('flags an unknown reference inside comms.response.action target_entity', () => {
+    const world = {
+      global: { seed: 42 },
+      anchors: { start: [0, 0, 0] },
+      entity: [{ name: 'station_a' }],
+      comms: [
+        {
+          from: 'station_a',
+          trigger: 'on_hailed',
+          entity: 'station_a',
+          message: 'Hello.',
+          response: [
+            {
+              text: 'Hi.',
+              action: [{ type: 'set_ai_state', entity: 'ghost_entity', state: 'patrol' }],
+            },
+          ],
+        },
+      ],
+    };
+    const results = validateFile('assets/worlds/broken.toml', world);
+    expect(results.some(r => /unknown entity "ghost_entity"/.test(r.message))).toBe(true);
+  });
+
+  it('treats comms.from as free-form (no error if it is not an entity)', () => {
+    const world = {
+      global: { seed: 42 },
+      anchors: { start: [0, 0, 0] },
+      entity: [{ name: 'station_a' }],
+      comms: [
+        {
+          from: 'Some Display Name Not An Entity',
+          trigger: 'on_hailed',
+          entity: 'station_a',
+          message: 'Hi.',
+        },
+      ],
+    };
+    const results = validateFile('assets/worlds/broken.toml', world);
+    // No reference error should be raised for the `from` field.
+    expect(results.filter(r => r.message.includes('Some Display Name'))).toEqual([]);
+  });
+});

--- a/editor/undo-controller.js
+++ b/editor/undo-controller.js
@@ -1,0 +1,20 @@
+/**
+ * Slice 1 undo helper. Snapshots a layer's parsed TOML onto the Scenario
+ * mode's undo stack before a mutation is applied. The actual restoration is
+ * gated on per-mode wiring (Slices 2/3/5/6); for now the entry is parked on
+ * the stack so Cmd/Ctrl+Z surfaces it.
+ *
+ * @param {{ filename: string, toml: object }} layer
+ */
+export function snapshotForUndo(layer) {
+  if (!layer || !layer.filename) return;
+  const editorV2 = (typeof window !== 'undefined') ? window.__editorV2 : null;
+  if (!editorV2 || !editorV2.modeShell) return;
+  try {
+    const snapshot = structuredClone(layer.toml);
+    editorV2.modeShell.pushUndoEntry('Scenario', layer.filename, snapshot);
+    editorV2.modeShell.markDirty('Scenario', layer.filename, true);
+  } catch (err) {
+    console.warn('[undo-controller] snapshot failed:', err?.message || err);
+  }
+}

--- a/editor/undo-controller.js
+++ b/editor/undo-controller.js
@@ -1,8 +1,28 @@
 /**
- * Slice 1 undo helper. Snapshots a layer's parsed TOML onto the Scenario
- * mode's undo stack before a mutation is applied. The actual restoration is
- * gated on per-mode wiring (Slices 2/3/5/6); for now the entry is parked on
- * the stack so Cmd/Ctrl+Z surfaces it.
+ * Undo controller.
+ *
+ * Contract: snapshot-BEFORE-mutation.
+ *
+ *   snapshotForUndo(layer);   // records layer.toml as the PRE-mutation state
+ *   layer.toml.something = newValue;  // mutate
+ *
+ * The undo stack therefore holds *pre-mutation* states. To restore on Cmd+Z
+ * we pop the pre-mutation snapshot AND push the current (post-mutation)
+ * value onto the redo stack via a swap. Redo is the mirror image.
+ *
+ * The swap is implemented on top of `UndoStack` via the dedicated
+ * `swapUndo(current)` / `swapRedo(current)` helpers on the stack — the
+ * built-in `undo()`/`redo()` methods do not give us this behaviour because
+ * they push the popped entry onto the opposite stack rather than the
+ * caller-supplied current state.
+ *
+ * `restoreScenarioLayer` is exported as a pure function so the integration
+ * test can drive it without DOM, Konva, or window globals.
+ */
+
+/**
+ * Push the current (pre-mutation) layer state onto the Scenario undo stack.
+ * Callers MUST invoke this BEFORE mutating `layer.toml`.
  *
  * @param {{ filename: string, toml: object }} layer
  */
@@ -17,4 +37,24 @@ export function snapshotForUndo(layer) {
   } catch (err) {
     console.warn('[undo-controller] snapshot failed:', err?.message || err);
   }
+}
+
+/**
+ * Pure restoration helper. Finds the layer by `path` in `layerManager` and
+ * sets its `toml` to `snapshot`. Returns the matched layer (for the caller
+ * to drive UI re-renders) or null if no match.
+ *
+ * @param {{ getLayers: () => Array<{ filename: string, toml: object, isDirty?: boolean }> }} layerManager
+ * @param {string} path
+ * @param {object} snapshot
+ * @returns {object | null}
+ */
+export function restoreScenarioLayer(layerManager, path, snapshot) {
+  if (!layerManager || !path) return null;
+  const layers = layerManager.getLayers();
+  const layer = layers.find((l) => l.filename === path);
+  if (!layer) return null;
+  layer.toml = snapshot;
+  layer.isDirty = true;
+  return layer;
 }

--- a/editor/undo-stack.js
+++ b/editor/undo-stack.js
@@ -27,6 +27,31 @@ export class UndoStack {
     return entry;
   }
 
+  /**
+   * Snapshot-before-mutation swap: pop the most recent pre-mutation entry
+   * off the undo stack, push the caller-supplied *current* (post-mutation)
+   * value onto the redo stack, and return the popped pre-mutation entry.
+   *
+   * Returns null when the undo stack is empty (no swap is performed).
+   */
+  swapUndo(currentValue) {
+    if (this._undoStack.length === 0) return null;
+    const entry = this._undoStack.pop();
+    this._redoStack.push(currentValue);
+    return entry;
+  }
+
+  /**
+   * Inverse of `swapUndo`: pop from redo, push caller's current value back
+   * onto the undo stack, return the popped entry.
+   */
+  swapRedo(currentValue) {
+    if (this._redoStack.length === 0) return null;
+    const entry = this._redoStack.pop();
+    this._undoStack.push(currentValue);
+    return entry;
+  }
+
   clear() {
     this._undoStack = [];
     this._redoStack = [];

--- a/editor/validation.js
+++ b/editor/validation.js
@@ -1,6 +1,8 @@
 import { validateWorldToml } from './world-toml.js';
 import { validateEntityToml, validateEntitySections } from './entity-toml.js';
 import { validateStations } from './stations-validate.js';
+import { validateTriggerActions } from './action-schema.js';
+import { validateWorldReferences } from './world-references.js';
 
 function isEntityFile(filePath, parsed) {
   if (filePath && filePath.includes('assets/entities/')) return true;
@@ -138,6 +140,49 @@ export function validateFile(filePath, parsedContent) {
       else if (msg.includes('[anchors]')) path = 'anchors';
       results.push({ path, severity: 'error', message: msg });
     }
+
+    // Validate every `[[trigger.action]]` and `[[comms.response.action]]`
+    // against the action schema (mirrors TriggerAction in src/world/config.rs).
+    if (Array.isArray(parsedContent.trigger)) {
+      for (let i = 0; i < parsedContent.trigger.length; i++) {
+        const trigger = parsedContent.trigger[i];
+        if (Array.isArray(trigger?.action)) {
+          const r = validateTriggerActions(trigger.action);
+          for (const msg of r.errors) {
+            results.push({
+              path: `trigger[${i}].action`,
+              severity: 'error',
+              message: msg,
+            });
+          }
+        }
+      }
+    }
+    if (Array.isArray(parsedContent.comms)) {
+      for (let i = 0; i < parsedContent.comms.length; i++) {
+        const block = parsedContent.comms[i];
+        if (Array.isArray(block?.response)) {
+          for (let r = 0; r < block.response.length; r++) {
+            const resp = block.response[r];
+            if (Array.isArray(resp?.action)) {
+              const result = validateTriggerActions(resp.action);
+              for (const msg of result.errors) {
+                results.push({
+                  path: `comms[${i}].response[${r}].action`,
+                  severity: 'error',
+                  message: msg,
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Resolve every entity reference in triggers and comms against the
+    // set of `[[entity]] name = "..."` declared in this world.
+    const refResults = validateWorldReferences(parsedContent);
+    results.push(...refResults);
   }
 
   return results;

--- a/editor/world-references.js
+++ b/editor/world-references.js
@@ -1,0 +1,66 @@
+/**
+ * world-references.js — Pure cross-reference validator for world TOML.
+ *
+ * Delegates to `CrossReferenceIndex` for the actual scan of triggers,
+ * trigger actions, comms templates, and comms responses, then emits one
+ * `{ path, severity, message }` record per reference whose `targetName`
+ * isn't a known entity in the same world.
+ *
+ * Designed to be called by `validation.js validateFile` for world files.
+ *
+ * Anchor references on `[[entity]] anchor = "..."` are NOT validated
+ * here because the runtime resolves anchors during parsing; absence
+ * surfaces as a parse error from the Rust side.
+ *
+ * `[[comms]].from` is allowed to be either an entity name or a
+ * free-form display string, so it is not required to resolve.
+ */
+
+import { CrossReferenceIndex } from './cross-references.js';
+
+/**
+ * Validate every entity reference in `worldObj` against the entity name
+ * set declared in the same world.  Returns one record per unresolved
+ * reference.
+ *
+ * The `path` field uses `CrossReferenceIndex`'s recorded `context`
+ * string so the resulting messages stay aligned with whatever sites the
+ * index scans — extending the index automatically extends this
+ * validator.
+ *
+ * @param {object} worldObj  Parsed world TOML object.
+ * @returns {Array<{ path: string, severity: 'error'|'warning', message: string }>}
+ */
+export function validateWorldReferences(worldObj) {
+  const results = [];
+  if (!worldObj || typeof worldObj !== 'object') return results;
+
+  const index = new CrossReferenceIndex();
+  index.indexLayers([{ path: '', worldState: worldObj }]);
+
+  // De-duplicate so the same dangling name referenced from two sites
+  // doesn't fire twice with identical messages — but we DO want one
+  // entry per (name, context) pair so the editor can show every call
+  // site that needs fixing.
+  const seen = new Set();
+
+  for (const ref of index.allReferences()) {
+    const { targetName, context } = ref;
+    if (index.hasEntity(targetName)) continue;
+    // `comms.from` is a free-form display string (e.g. "Starbase Alpha"
+    // or "Pirate Raider Captain") and is not required to resolve to an
+    // entity declared in the world.  The index still records it so the
+    // editor UI can highlight known senders, but the validator skips it.
+    if (context === 'comms.from') continue;
+    const key = `${targetName}::${context}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    results.push({
+      path: context,
+      severity: 'error',
+      message: `Reference to unknown entity "${targetName}" (${context})`,
+    });
+  }
+
+  return results;
+}

--- a/src/console/helm/client.rs
+++ b/src/console/helm/client.rs
@@ -12,9 +12,10 @@ use crate::client_app::{HelmPanel, OutboundClientMessage};
 use crate::client_lobby::{ActiveConsole, LobbyState, LocalPlayerToken};
 use crate::client_sim::ClientSimState;
 use crate::gui::{
-    spawn_gui_button, ButtonPressed, ButtonSize, GenericJoystick, GenericRadar, JoystickMoved,
-    OnRadar, OrientationMode, RadarAppearance, RadarCenter, RadarFilter, RadarIcon, RadarLayer,
-    ReadoutValue, StateVisuals, TextReadout, Visual,
+    default_layer_colour, layer_to_icon, spawn_gui_button, tags_to_radar_layer, ButtonPressed,
+    ButtonSize, GenericJoystick, GenericRadar, JoystickMoved, OnRadar, OrientationMode,
+    RadarAppearance, RadarCenter, RadarFilter, RadarIcon, RadarLayer, ReadoutValue, StateVisuals,
+    TextReadout, Visual,
 };
 use crate::messages::{ClientMessage, Console, GamePhase, ViewMode};
 use crate::phone_border::framing::{DeviceOrientation, PhoneAssets};
@@ -213,21 +214,7 @@ fn sync_helm_radar_range(
 
 // ── Radar entity bridge ─────────────────────────────────────────────
 
-/// Map a `RadarLayer` to the icon used for its blip. `Missile` uses the
-/// torpedo icon since the wire layer for torpedoes is `Missile`.
-fn layer_to_icon(layer: RadarLayer) -> RadarIcon {
-    match layer {
-        RadarLayer::Ship => RadarIcon::Ship,
-        RadarLayer::Asteroid => RadarIcon::Asteroid,
-        RadarLayer::Station => RadarIcon::Station,
-        RadarLayer::Missile => RadarIcon::Torpedo,
-        RadarLayer::Planet => RadarIcon::Planet,
-        RadarLayer::Star => RadarIcon::Star,
-    }
-}
-
-/// Bridges `ClientSimState` entity snapshots into ECS entities with
-/// `OnRadar` / `RadarAppearance` for the `GenericRadar` widget.
+/// Build `OnRadar` / `RadarAppearance` for the `GenericRadar` widget.
 fn bridge_client_sim_to_radar_entities(
     mut commands: Commands,
     sim: Res<ClientSimState>,
@@ -295,35 +282,12 @@ fn bridge_client_sim_to_radar_entities(
             continue;
         }
 
-        let has_tag = |tag: &str| snapshot.tags.iter().any(|t| t == tag);
-        if has_tag("region") {
-            continue; // skip regions — not radar-relevant
-        }
-        let layer = if has_tag("ship") || has_tag("pirate") {
-            RadarLayer::Ship
-        } else if has_tag("asteroid") || has_tag("asteroid_field") {
-            RadarLayer::Asteroid
-        } else if has_tag("station") {
-            RadarLayer::Station
-        } else if has_tag("missile") || has_tag("torpedo") {
-            RadarLayer::Missile
-        } else if has_tag("planet") {
-            RadarLayer::Planet
-        } else if has_tag("star") {
-            RadarLayer::Star
-        } else {
-            continue; // unknown type
+        let Some(layer) = tags_to_radar_layer(&snapshot.tags) else {
+            continue; // skip regions and unknown types
         };
 
         let colour = snapshot.colour.map(|c| Color::srgb(c[0], c[1], c[2]));
-        let default_color = match layer {
-            RadarLayer::Ship => Color::srgb(0.95, 0.95, 1.0),
-            RadarLayer::Asteroid => Color::srgb(0.85, 0.75, 0.45),
-            RadarLayer::Station => Color::srgb(0.3, 0.8, 0.6),
-            RadarLayer::Missile => Color::srgb(1.0, 0.4, 0.2),
-            RadarLayer::Planet => Color::srgb(0.0, 0.6, 1.0),
-            RadarLayer::Star => Color::srgb(1.0, 0.85, 0.3),
-        };
+        let default_color = default_layer_colour(layer);
         let icon = layer_to_icon(layer);
         // Prefer the authored radar override, then the physical radius,
         // then a fallback of 4.0 world units.

--- a/src/console/science/client.rs
+++ b/src/console/science/client.rs
@@ -16,8 +16,9 @@ use crate::client_app::OutboundClientMessage;
 use crate::client_lobby::{ActiveConsole, LobbyState, LobbyView, LocalPlayerToken};
 use crate::client_sim::set_science_target_message;
 use crate::gui::{
-    spawn_gui_button, ButtonPressed, ButtonSize, GenericRadar, OnRadar, OrientationMode,
-    RadarAppearance, RadarCenter, RadarFilter, RadarIcon, RadarLayer, StateVisuals,
+    default_layer_colour, layer_to_icon, spawn_gui_button, tags_to_radar_layer, ButtonPressed,
+    ButtonSize, GenericRadar, OnRadar, OrientationMode, RadarAppearance, RadarCenter, RadarFilter,
+    RadarIcon, RadarLayer, StateVisuals,
 };
 use crate::messages::{ClientMessage, Console, GamePhase, ViewMode};
 use crate::ship_view::ShipView;
@@ -344,27 +345,14 @@ fn bridge_client_sim_to_science_radar(
             continue;
         }
 
-        let has_tag = |tag: &str| snapshot.tags.iter().any(|t| t == tag);
-        if has_tag("region") {
-            continue;
-        }
-
-        // Science radar shows ships and asteroids.
-        let (layer, icon, default_color) = if has_tag("ship") || has_tag("pirate") {
-            (
-                RadarLayer::Ship,
-                RadarIcon::Ship,
-                Color::srgb(0.95, 0.95, 1.0),
-            )
-        } else if has_tag("asteroid") || has_tag("asteroid_field") {
-            (
-                RadarLayer::Asteroid,
-                RadarIcon::Asteroid,
-                Color::srgb(0.85, 0.75, 0.45),
-            )
-        } else {
-            continue; // skip everything else
+        // Science radar shows ships and asteroids; everything else
+        // (stations, planets, stars, regions, missiles) is filtered out.
+        let layer = match tags_to_radar_layer(&snapshot.tags) {
+            Some(l @ (RadarLayer::Ship | RadarLayer::Asteroid)) => l,
+            _ => continue,
         };
+        let icon = layer_to_icon(layer);
+        let default_color = default_layer_colour(layer);
 
         let colour = snapshot.colour.map(|c| Color::srgb(c[0], c[1], c[2]));
         let world_size = snapshot

--- a/src/console/weapons/client.rs
+++ b/src/console/weapons/client.rs
@@ -22,8 +22,8 @@ use crate::client_sim::{
     is_fire_button_enabled, phaser_mode_label, ClientSimState,
 };
 use crate::gui::{
-    spawn_gui_button, ButtonPressed, ButtonSize, GenericRadar, OnRadar,
-    OrientationMode, RadarAppearance, RadarCenter, RadarFilter, RadarIcon, RadarLayer,
+    layer_to_icon, spawn_gui_button, tags_to_radar_layer, ButtonPressed, ButtonSize, GenericRadar,
+    OnRadar, OrientationMode, RadarAppearance, RadarCenter, RadarFilter, RadarIcon, RadarLayer,
     StateVisuals, RadioButtonConfig, RadioGroup, RadioSelected,
     Disabled,
 };
@@ -823,18 +823,19 @@ fn bridge_client_sim_to_weapons_radar(
             continue;
         }
 
-        let has_tag = |tag: &str| snapshot.tags.iter().any(|t| t == tag);
-        if has_tag("region") {
-            continue;
-        }
-
-        // Weapons radar only shows ships and torpedoes.
-        let (layer, icon, default_color) = if has_tag("ship") || has_tag("pirate") {
-            (RadarLayer::Ship, RadarIcon::Ship, Color::srgb(1.0, 0.4, 0.4))
-        } else if has_tag("missile") || has_tag("torpedo") {
-            (RadarLayer::Missile, RadarIcon::Torpedo, Color::srgb(1.0, 0.4, 0.2))
-        } else {
-            continue; // skip everything else
+        // Weapons radar only shows ships and torpedoes; everything else
+        // (asteroids, stations, planets, stars, regions) is filtered out.
+        let layer = match tags_to_radar_layer(&snapshot.tags) {
+            Some(l @ (RadarLayer::Ship | RadarLayer::Missile)) => l,
+            _ => continue,
+        };
+        let icon = layer_to_icon(layer);
+        // Tactical paints ships and torpedoes in alert-red shades rather
+        // than the helm-default colours.
+        let default_color = match layer {
+            RadarLayer::Ship => Color::srgb(1.0, 0.4, 0.4),
+            RadarLayer::Missile => Color::srgb(1.0, 0.4, 0.2),
+            _ => unreachable!("filtered above"),
         };
 
         let colour = snapshot.colour.map(|c| Color::srgb(c[0], c[1], c[2]));

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -30,9 +30,10 @@ pub use progress::{
     SegmentCount,
 };
 pub use radar::{
-    blip_local_offset, is_on_radar, project_radar_entity, world_size_to_px, GenericRadar,
-    GenericRadarWidget, OnRadar, OrientationMode, RadarAppearance, RadarCenter, RadarFilter,
-    RadarIcon, RadarIconLookup, RadarLayer,
+    blip_local_offset, default_layer_colour, is_on_radar, layer_to_icon, project_radar_entity,
+    tags_to_radar_layer, world_size_to_px, GenericRadar, GenericRadarWidget, OnRadar,
+    OrientationMode, RadarAppearance, RadarCenter, RadarFilter, RadarIcon, RadarIconLookup,
+    RadarLayer,
 };
 pub use radio::{
     next_radio_selection, on_radio_member_pressed, RadioButtonConfig, RadioGroup, RadioGroupMarker,

--- a/src/gui/radar.rs
+++ b/src/gui/radar.rs
@@ -107,6 +107,73 @@ struct RadarBlipNode {
     source: Entity,
 }
 
+// ── Pure tag → layer / icon mapping ──────────────────────────────────────────
+
+/// Map an entity's `tags` list to a `RadarLayer`. Returns `None` for tags
+/// that are not radar-relevant (e.g. `region`) or for entities lacking any
+/// recognised tag.
+///
+/// This is the single source of truth for tag→layer classification on the
+/// runtime side. Console clients (helm, weapons, science) and the editor's
+/// `tag-shape-map.js` must agree with this table.
+///
+/// Precedence (first match wins):
+///   - `ship` | `pirate`            → `RadarLayer::Ship`
+///   - `asteroid` | `asteroid_field` → `RadarLayer::Asteroid`
+///   - `station`                    → `RadarLayer::Station`
+///   - `missile` | `torpedo`        → `RadarLayer::Missile`
+///   - `planet`                     → `RadarLayer::Planet`
+///   - `star`                       → `RadarLayer::Star`
+///   - `region` or unknown          → `None`
+pub fn tags_to_radar_layer<S: AsRef<str>>(tags: &[S]) -> Option<RadarLayer> {
+    let has = |t: &str| tags.iter().any(|s| s.as_ref() == t);
+    if has("region") {
+        return None;
+    }
+    if has("ship") || has("pirate") {
+        Some(RadarLayer::Ship)
+    } else if has("asteroid") || has("asteroid_field") {
+        Some(RadarLayer::Asteroid)
+    } else if has("station") {
+        Some(RadarLayer::Station)
+    } else if has("missile") || has("torpedo") {
+        Some(RadarLayer::Missile)
+    } else if has("planet") {
+        Some(RadarLayer::Planet)
+    } else if has("star") {
+        Some(RadarLayer::Star)
+    } else {
+        None
+    }
+}
+
+/// Map a `RadarLayer` to the icon used for its blip. `Missile` uses the
+/// torpedo icon since the wire layer for torpedoes is `Missile`.
+pub fn layer_to_icon(layer: RadarLayer) -> RadarIcon {
+    match layer {
+        RadarLayer::Ship => RadarIcon::Ship,
+        RadarLayer::Asteroid => RadarIcon::Asteroid,
+        RadarLayer::Station => RadarIcon::Station,
+        RadarLayer::Missile => RadarIcon::Torpedo,
+        RadarLayer::Planet => RadarIcon::Planet,
+        RadarLayer::Star => RadarIcon::Star,
+    }
+}
+
+/// Default per-layer colour used when an entity does not carry an authored
+/// `radar_appearance.colour`. Editors and clients should agree on these so
+/// the editor canvas matches in-game radar.
+pub fn default_layer_colour(layer: RadarLayer) -> Color {
+    match layer {
+        RadarLayer::Ship => Color::srgb(0.95, 0.95, 1.0),
+        RadarLayer::Asteroid => Color::srgb(0.85, 0.75, 0.45),
+        RadarLayer::Station => Color::srgb(0.3, 0.8, 0.6),
+        RadarLayer::Missile => Color::srgb(1.0, 0.4, 0.2),
+        RadarLayer::Planet => Color::srgb(0.0, 0.6, 1.0),
+        RadarLayer::Star => Color::srgb(1.0, 0.85, 0.3),
+    }
+}
+
 // ── Pure helpers ──────────────────────────────────────────────────────────────
 
 /// Minimum blip diameter in pixels so very small or distant entities
@@ -380,6 +447,91 @@ impl Plugin for GuiRadarPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── tags_to_radar_layer / layer_to_icon / default_layer_colour ────────────
+
+    #[test]
+    fn tags_to_radar_layer_ship_tag_returns_ship() {
+        assert_eq!(tags_to_radar_layer(&["ship"]), Some(RadarLayer::Ship));
+    }
+
+    #[test]
+    fn tags_to_radar_layer_pirate_tag_returns_ship() {
+        assert_eq!(tags_to_radar_layer(&["pirate"]), Some(RadarLayer::Ship));
+    }
+
+    #[test]
+    fn tags_to_radar_layer_asteroid_and_asteroid_field_return_asteroid() {
+        assert_eq!(tags_to_radar_layer(&["asteroid"]), Some(RadarLayer::Asteroid));
+        assert_eq!(tags_to_radar_layer(&["asteroid_field"]), Some(RadarLayer::Asteroid));
+    }
+
+    #[test]
+    fn tags_to_radar_layer_station_returns_station() {
+        assert_eq!(tags_to_radar_layer(&["station"]), Some(RadarLayer::Station));
+    }
+
+    #[test]
+    fn tags_to_radar_layer_missile_and_torpedo_return_missile() {
+        assert_eq!(tags_to_radar_layer(&["missile"]), Some(RadarLayer::Missile));
+        assert_eq!(tags_to_radar_layer(&["torpedo"]), Some(RadarLayer::Missile));
+    }
+
+    #[test]
+    fn tags_to_radar_layer_planet_returns_planet() {
+        assert_eq!(tags_to_radar_layer(&["planet"]), Some(RadarLayer::Planet));
+    }
+
+    #[test]
+    fn tags_to_radar_layer_star_returns_star() {
+        assert_eq!(tags_to_radar_layer(&["star"]), Some(RadarLayer::Star));
+    }
+
+    #[test]
+    fn tags_to_radar_layer_region_is_excluded() {
+        assert_eq!(tags_to_radar_layer(&["region"]), None);
+        // region wins even when combined with other recognised tags
+        assert_eq!(tags_to_radar_layer(&["region", "ship"]), None);
+    }
+
+    #[test]
+    fn tags_to_radar_layer_unknown_or_empty_returns_none() {
+        let empty: [&str; 0] = [];
+        assert_eq!(tags_to_radar_layer(&empty), None);
+        assert_eq!(tags_to_radar_layer(&["mystery"]), None);
+    }
+
+    #[test]
+    fn tags_to_radar_layer_precedence_ship_before_station() {
+        // A ship that is also tagged station (unusual but legal in TOML)
+        // resolves as Ship because ship is checked first.
+        assert_eq!(
+            tags_to_radar_layer(&["ship", "station"]),
+            Some(RadarLayer::Ship)
+        );
+    }
+
+    #[test]
+    fn layer_to_icon_round_trips_every_layer() {
+        assert_eq!(layer_to_icon(RadarLayer::Ship), RadarIcon::Ship);
+        assert_eq!(layer_to_icon(RadarLayer::Asteroid), RadarIcon::Asteroid);
+        assert_eq!(layer_to_icon(RadarLayer::Station), RadarIcon::Station);
+        assert_eq!(layer_to_icon(RadarLayer::Missile), RadarIcon::Torpedo);
+        assert_eq!(layer_to_icon(RadarLayer::Planet), RadarIcon::Planet);
+        assert_eq!(layer_to_icon(RadarLayer::Star), RadarIcon::Star);
+    }
+
+    #[test]
+    fn default_layer_colour_covers_every_layer() {
+        // Just assert each call returns; the actual values are visual choices
+        // and changing them is a deliberate gameplay change, not a regression.
+        let _ = default_layer_colour(RadarLayer::Ship);
+        let _ = default_layer_colour(RadarLayer::Asteroid);
+        let _ = default_layer_colour(RadarLayer::Station);
+        let _ = default_layer_colour(RadarLayer::Missile);
+        let _ = default_layer_colour(RadarLayer::Planet);
+        let _ = default_layer_colour(RadarLayer::Star);
+    }
 
     fn all_layers_filter() -> RadarFilter {
         let mut s = HashSet::new();

--- a/tests/smoke/tactical-fire-flow.spec.ts
+++ b/tests/smoke/tactical-fire-flow.spec.ts
@@ -46,13 +46,10 @@ const CLOSE_RAIDER_WORLD = WORLD_WITHOUT_FAR_RAIDER + `
 
 # Smoke-test override: a raider 20 units in front of the player ship spawn.
 # Ship spawns at (150, 0, 0) per assets/worlds/default.toml; forward is -Z.
-# Override = idle with no transitions so the raider stays stationary and
-# doesn't move out of the 40-unit phaser range between beam cycles.
 [[entity]]
 template_path = "assets/entities/pirate_raider.toml"
 name          = "raider_alpha"
 position      = [150.0, 0.0, -20.0]
-overrides     = { behaviour = { initial_state = "idle", transition = [] } }
 `;
 
 async function waitForStation(

--- a/tests/smoke/tactical-fire-flow.spec.ts
+++ b/tests/smoke/tactical-fire-flow.spec.ts
@@ -47,7 +47,7 @@ const CLOSE_RAIDER_WORLD = WORLD_WITHOUT_FAR_RAIDER + `
 # Smoke-test override: a raider 20 units in front of the player ship spawn.
 # Ship spawns at (150, 0, 0) per assets/worlds/default.toml; forward is -Z.
 # Override = idle with no transitions so the raider stays stationary and
-# cannot flee out of phaser range mid-kill.
+# doesn't move out of the 40-unit phaser range between beam cycles.
 [[entity]]
 template_path = "assets/entities/pirate_raider.toml"
 name          = "raider_alpha"


### PR DESCRIPTION
Closes #382. Supersedes (in part) #380.

Lands PRD #350 Slice 1 (Foundation) **plus** the steps 3 & 6 from #380 that were ready to ship (radar shape mirror + composed validation). The remaining slices (2-7) are filed as #383–#388.

## What this does

### PRD #350 step 3 — radar shape mirror (was #380)
- `editor/tag-shape-map.js` mirrors the full radar shape table from `src/gui/radar.rs`. Canvas tag→shape lookup consolidated.

### PRD #350 step 6 — composed validation (was #380)
- `editor/validation.js` composes `action-schema` + `cross-references` checks. One entry point, multiple validators.

### PRD #350 Slice 1 — Foundation (#382)
- **Mode-Shell UI.** `editor.html` now has three sibling mode panes (`#scenario-mode-root`, `#entity-mode-root`, `#definitions-mode-root`); the V1 canvas/sidebar/layers structure is wrapped inside Scenario. The `Properties` tab is removed (it was never a real mode). `app-v2.js setupModeSwitcher` is the single owner of `.v2-mode-tab` clicks; V1's competing `setupModeTabs` is gone.
- **FSA entity-cache rewrite.** `editor/entity-cache.js` no longer uses `fetch()` or the hard-coded `KNOWN_ENTITIES` list (which had already drifted: `region_asteroid_belt.toml` exists on disk but wasn't listed). Now reads `assets/entities/*.toml` on-demand via `project-root.listDirectory()` (new helper). Gracefully no-ops when no root is selected. Exposes `invalidateEntity(path)` + `onInvalidate(cb)` for Slice 7.
- **Undo wired end-to-end.** Cmd/Ctrl+Z reverts the last property/spawn edit; Shift+Cmd/Ctrl+Z redoes; both clear on save. `ModeShell` gained `swapUndoActive`/`swapRedoActive`/`canUndoActive`/`canRedoActive` (swap semantics: pop pre-state from undo, push caller-supplied current to redo). Snapshots happen BEFORE mutation (documented contract in `undo-controller.js`). 15 mutation sites in `canvas.js` + `sidebar.js` wired. Textarea/input focus skipped so native browser undo still works.
- **`save-flow.writeFile` writes to disk.** `SaveFlow.saveActive` is now `async`, awaits `project-root.writeFile(path, content)`, clears the file's undo history (PRD #350 user story #44), and fires `InvalidationBus.fireEntitySaved` / `fireWorldSaved` based on mode. The V1 `<a download>` blob fallback in `app.js saveLayer` is deleted.

## Acceptance criteria (Slice 1 / #382)

| AC | Status | Evidence |
|---|---|---|
| Tabs switch the main editing pane (PRD #2) | ✓ | `editor.html` mode panes; `app-v2.js:57-73` toggles `.hidden` |
| `mode-shell.openFiles['Scenario']` persists across switches | ✓ | `app.js:82-85` mirrors layer filenames; `mode-shell.switchMode` doesn't touch `_openFiles` |
| Save calls `writeFile`; no `<a download>` (PRD #41) | ✓ | `save-flow.js:85` `await this._writeFile`; V1 `saveLayer` deleted |
| Cmd+Z reverts; Shift+Cmd+Z redoes; clears on save (PRD #43, #44) | ✓ | `editor/tests/undo-integration.test.js` (8 specs); `app-v2.js:155-180` keydown handler; `save-flow.js:91` clears undo on save |
| Existing tests pass | ✓ | 805/805 (was 772 at start of slice; +33 net) |

## Verification

- `npm run test:editor`: **805/805** pass (36 files).
- `cargo check`: clean.
- `cargo test --lib`: 1653 pass.

## Architecture notes (flagged in review)

- `window.__editorV2` is a deliberate bridge between V1 (classic globals in `app.js`) and V2 (ESM in `app-v2.js`). Exposes `modeShell`, `invalidationBus`, `saveFlow`, `registerRestore(mode, fn)`. Slices 2+ will progressively move handlers into V2 and shrink this surface.
- `canvas.js` snapshots on every `dragmove`. A single 1-second drag can fill the 100-entry undo cap. Functionally correct but coarse. Defer to a "snapshot on dragstart, commit on dragend" follow-up.
- Legacy `ModeShell.undoActive`/`redoActive` methods retained for backward compat with existing tests; production uses `swapUndoActive`/`swapRedoActive`. Mark `@deprecated` in a follow-up.

## Successor work

This is the first of seven slice-shaped issues filed against PRD #350: #382 (this PR), #383, #384, #385, #386, #387, #388. Each will land as its own PR stacked off this branch (or rebased onto main once this merges).
