### PR TITLE
feat(editor): PRD #350 Slice 2 — Scenario canvas region + anchor rendering

### DIFF
--- a/editor/canvas.js
+++ b/editor/canvas.js
@@ -179,7 +179,24 @@ export class CanvasManager {
     group.add(vLine);
     group.add(label);
 
-    // Drag wiring lands in commit C4.
+    // Drag: snapshot ONCE on dragstart (avoids the per-pixel snapshot anti-pattern
+    // used by spawn drag). dragmove mutates the anchor; dragend re-renders to
+    // refresh entity positions resolved via this anchor.
+    group.on('dragstart', () => {
+      snapshotForUndo(layer);
+    });
+    group.on('dragmove', () => {
+      const newX = group.x() / this.scale;
+      const newZ = -group.y() / this.scale;
+      const existing = layer.toml?.anchors?.[spec.name];
+      const preservedY = Array.isArray(existing) && existing.length >= 2 ? existing[1] : 0.0;
+      if (!layer.toml.anchors) layer.toml.anchors = {};
+      layer.toml.anchors[spec.name] = [newX, preservedY, newZ];
+      layer.isDirty = true;
+    });
+    group.on('dragend', () => {
+      this.renderAll();
+    });
 
     // Right-click menu (commits C5/C6).
     group.on('contextmenu', (e) => {

--- a/editor/canvas.js
+++ b/editor/canvas.js
@@ -185,6 +185,9 @@ export class CanvasManager {
           outer_radius: entConfig.asteroid_field.outer_radius ?? 200,
         };
       }
+      // Region-entity fields needed by canvas-region renderer
+      if (!spawn.effects && entConfig.effects) spawn.effects = entConfig.effects;
+      if (!spawn.colour && entConfig.colour) spawn.colour = entConfig.colour;
     }
 
     const canvasPos = this.worldToCanvas(pos.x, pos.z);

--- a/editor/canvas.js
+++ b/editor/canvas.js
@@ -2,6 +2,7 @@ import { getSpawns, getAnchors, getSpawnPosition, getSpawnName, getEntityPath, g
 import { getColorForEntity } from './layers.js';
 import { loadEntityConfig, getEntityConfig } from './entity-cache.js';
 import { resolveEntityAppearance, drawEntityShape, colourToHex, RADAR_SHAPE_FALLBACK } from './canvas-scenario.js';
+import { getRegionRenderSpec } from './canvas-region.js';
 import { snapshotForUndo } from './undo-controller.js';
 
 export class CanvasManager {
@@ -210,40 +211,72 @@ export class CanvasManager {
 
     // Draw region area overlay FIRST (behind the entity marker)
     if (spawn.shape) {
-      const hexColour = colourToHex(appearance.colour);
+      // Build a region entity input for the pure renderer. The spawn group is
+      // already positioned at (canvasPos.x, canvasPos.y), so we want the spec
+      // centred on the group origin — pass position=[0,0,0] and let the
+      // shapes draw at local (0,0). `cx`/`cz` from the spec are not used here.
+      const regionEntity = {
+        shape: spawn.shape,
+        colour: spawn.colour,
+        effects: spawn.effects,
+        position: [0, 0, 0],
+      };
+      const spec = getRegionRenderSpec(regionEntity);
+      const hexColour = colourToHex(spec.colour);
+      const alphaHex = Math.round(spec.fillAlpha * 255).toString(16).padStart(2, '0');
+      const fillColour = hexColour + alphaHex;
       const s = this.scale;
-      if (spawn.shape.type === 'sphere' && spawn.shape.radius) {
+
+      if (spec.shape === 'circle') {
         const fillCircle = new Konva.Circle({
-          radius: spawn.shape.radius * s,
-          fill: hexColour + '22',
+          radius: (spec.radius ?? 0) * s,
+          fill: fillColour,
           stroke: hexColour,
           strokeWidth: 1 / s
         });
         group.add(fillCircle);
-      } else if (spawn.shape.type === 'torus') {
-        const innerR = (spawn.shape.inner_radius ?? 50) * s;
-        const outerR = (spawn.shape.outer_radius ?? 150) * s;
+      } else if (spec.shape === 'torus') {
         const ring = new Konva.Ring({
-          innerRadius: innerR,
-          outerRadius: outerR,
-          fill: hexColour + '22',
+          innerRadius: (spec.inner_radius ?? 0) * s,
+          outerRadius: (spec.outer_radius ?? 0) * s,
+          fill: fillColour,
           stroke: hexColour,
           strokeWidth: 1 / s
         });
         group.add(ring);
-      } else if (spawn.shape.type === 'box') {
-        const hx = (Array.isArray(spawn.shape.half_extents) ? spawn.shape.half_extents[0] : 0) * s;
-        const hz = (Array.isArray(spawn.shape.half_extents) ? spawn.shape.half_extents[2] : 0) * s;
+      } else if (spec.shape === 'rect') {
+        const hx = (spec.half_x ?? 0) * s;
+        const hz = (spec.half_z ?? 0) * s;
         const rect = new Konva.Rect({
           x: -hx,
           y: -hz,
           width: hx * 2,
           height: hz * 2,
-          fill: hexColour + '22',
+          fill: fillColour,
           stroke: hexColour,
           strokeWidth: 1 / s
         });
         group.add(rect);
+      }
+
+      // Effect-icon cluster: horizontal row centred on the region origin.
+      if (Array.isArray(spec.effects) && spec.effects.length > 0) {
+        const iconFontSize = 14;
+        const iconGap = 4;
+        const iconWidth = iconFontSize + iconGap;
+        const totalWidth = spec.effects.length * iconWidth - iconGap;
+        const startX = -totalWidth / 2;
+        spec.effects.forEach((key, i) => {
+          const glyph = spec.effectIcons[key] || '?';
+          const txt = new Konva.Text({
+            x: startX + i * iconWidth,
+            y: -iconFontSize / 2,
+            text: glyph,
+            fontSize: iconFontSize,
+            fill: '#ffffff',
+          });
+          group.add(txt);
+        });
       }
     }
 

--- a/editor/canvas.js
+++ b/editor/canvas.js
@@ -4,6 +4,7 @@ import { loadEntityConfig, getEntityConfig } from './entity-cache.js';
 import { resolveEntityAppearance, drawEntityShape, colourToHex, RADAR_SHAPE_FALLBACK } from './canvas-scenario.js';
 import { getRegionRenderSpec } from './canvas-region.js';
 import { getAnchorRenderSpecs } from './canvas-anchor.js';
+import { analyzeAnchorRename } from './anchor-rename.js';
 import { snapshotForUndo } from './undo-controller.js';
 
 export class CanvasManager {
@@ -207,8 +208,138 @@ export class CanvasManager {
     container.add(group);
   }
 
-  showAnchorMenu(_clientX, _clientY, _anchorName, _layer) {
-    // Wired in C5/C6.
+  showAnchorMenu(clientX, clientY, anchorName, ownerLayer) {
+    // Tear down any prior menu.
+    this.dismissAnchorMenu();
+
+    const menu = document.createElement('div');
+    menu.style.cssText = [
+      'position:fixed',
+      `left:${clientX}px`,
+      `top:${clientY}px`,
+      'z-index:9999',
+      'background:#2a2a2a',
+      'border:1px solid #555',
+      'border-radius:4px',
+      'padding:4px 0',
+      'box-shadow:0 4px 8px rgba(0,0,0,0.6)',
+      'font-family:sans-serif',
+      'font-size:12px',
+      'color:#eee',
+      'min-width:120px',
+    ].join(';');
+
+    const makeItem = (label, onClick) => {
+      const item = document.createElement('div');
+      item.textContent = label;
+      item.style.cssText = 'padding:6px 12px;cursor:pointer';
+      item.addEventListener('mouseenter', () => { item.style.background = '#444'; });
+      item.addEventListener('mouseleave', () => { item.style.background = 'transparent'; });
+      item.addEventListener('click', () => {
+        this.dismissAnchorMenu();
+        onClick();
+      });
+      return item;
+    };
+
+    menu.appendChild(makeItem('Rename', () => this.renameAnchor(anchorName, ownerLayer)));
+    menu.appendChild(makeItem('Delete', () => this.deleteAnchor(anchorName, ownerLayer)));
+
+    document.body.appendChild(menu);
+    this._anchorMenu = menu;
+
+    // Dismiss on next outside click.
+    const dismissOnClick = (ev) => {
+      if (!menu.contains(ev.target)) {
+        this.dismissAnchorMenu();
+      }
+    };
+    setTimeout(() => document.addEventListener('mousedown', dismissOnClick, { once: true }), 0);
+    this._anchorMenuDismiss = () => document.removeEventListener('mousedown', dismissOnClick);
+  }
+
+  dismissAnchorMenu() {
+    if (this._anchorMenu && this._anchorMenu.parentNode) {
+      this._anchorMenu.parentNode.removeChild(this._anchorMenu);
+    }
+    if (this._anchorMenuDismiss) {
+      this._anchorMenuDismiss();
+      this._anchorMenuDismiss = null;
+    }
+    this._anchorMenu = null;
+  }
+
+  buildV2Layers() {
+    return this.layerManager.getLayers().map(l => ({ path: l.filename, worldState: l.toml }));
+  }
+
+  renameAnchor(currentName, ownerLayer) {
+    const newName = window.prompt('Rename anchor', currentName);
+    if (newName == null || newName === '' || newName === currentName) return;
+
+    const v2Layers = this.buildV2Layers();
+    const result = analyzeAnchorRename(currentName, newName, v2Layers);
+    if (!result.allowed) {
+      window.alert(result.error || 'Rename blocked.');
+      return;
+    }
+    if (result.crossLayerReferences.length > 0) {
+      const proceed = window.confirm(
+        `Anchor "${currentName}" is referenced in ${result.crossLayerReferences.length} other layer(s). These will also be rewritten. Proceed?`
+      );
+      if (!proceed) return;
+    }
+
+    const layersByPath = new Map(this.layerManager.getLayers().map(l => [l.filename, l]));
+
+    // Snapshot + rewrite owner layers (anchor key + in-layer references).
+    for (const pair of result.rewritePairs) {
+      const ownerL = layersByPath.get(pair.layerPath);
+      if (!ownerL || !ownerL.toml) continue;
+      snapshotForUndo(ownerL);
+      const anchors = ownerL.toml.anchors;
+      if (anchors && anchors[currentName] != null) {
+        anchors[newName] = anchors[currentName];
+        delete anchors[currentName];
+      }
+      this.rewriteAnchorRefsInLayer(ownerL.toml, currentName, newName);
+      ownerL.isDirty = true;
+    }
+
+    // Snapshot + rewrite cross-layer references (no anchor key change).
+    const crossPaths = new Set(result.crossLayerReferences.map(r => r.layerPath));
+    for (const crossPath of crossPaths) {
+      const crossL = layersByPath.get(crossPath);
+      if (!crossL || !crossL.toml) continue;
+      snapshotForUndo(crossL);
+      this.rewriteAnchorRefsInLayer(crossL.toml, currentName, newName);
+      crossL.isDirty = true;
+    }
+
+    this.renderAll();
+  }
+
+  rewriteAnchorRefsInLayer(toml, oldName, newName) {
+    if (!toml || typeof toml !== 'object') return;
+    if (Array.isArray(toml.entity)) {
+      for (const ent of toml.entity) {
+        if (ent && ent.anchor === oldName) ent.anchor = newName;
+      }
+    }
+    if (Array.isArray(toml.trigger)) {
+      for (const trig of toml.trigger) {
+        if (!trig || !Array.isArray(trig.action)) continue;
+        for (const action of trig.action) {
+          if (action && typeof action === 'object' && action.anchor === oldName) {
+            action.anchor = newName;
+          }
+        }
+      }
+    }
+  }
+
+  deleteAnchor(_anchorName, _ownerLayer) {
+    // Wired in C6.
   }
 
   renderSpawn(spawn, layer, container, allAnchors) {

--- a/editor/canvas.js
+++ b/editor/canvas.js
@@ -5,6 +5,7 @@ import { resolveEntityAppearance, drawEntityShape, colourToHex, RADAR_SHAPE_FALL
 import { getRegionRenderSpec } from './canvas-region.js';
 import { getAnchorRenderSpecs } from './canvas-anchor.js';
 import { analyzeAnchorRename } from './anchor-rename.js';
+import { canDeleteAnchor } from './anchor-delete.js';
 import { snapshotForUndo } from './undo-controller.js';
 
 export class CanvasManager {
@@ -338,8 +339,23 @@ export class CanvasManager {
     }
   }
 
-  deleteAnchor(_anchorName, _ownerLayer) {
-    // Wired in C6.
+  deleteAnchor(anchorName, ownerLayer) {
+    const v2Layers = this.buildV2Layers();
+    const result = canDeleteAnchor(anchorName, v2Layers, ownerLayer?.filename);
+    if (!result.canDelete) {
+      const list = result.blockers
+        .map(b => `- ${b.type} "${b.entityName ?? '(unnamed)'}" in ${b.layerPath}`)
+        .join('\n');
+      window.alert(`Cannot delete anchor "${anchorName}". It is referenced by:\n${list}`);
+      return;
+    }
+    if (!window.confirm(`Delete anchor "${anchorName}"?`)) return;
+
+    if (!ownerLayer || !ownerLayer.toml || !ownerLayer.toml.anchors) return;
+    snapshotForUndo(ownerLayer);
+    delete ownerLayer.toml.anchors[anchorName];
+    ownerLayer.isDirty = true;
+    this.renderAll();
   }
 
   renderSpawn(spawn, layer, container, allAnchors) {

--- a/editor/canvas.js
+++ b/editor/canvas.js
@@ -3,6 +3,7 @@ import { getColorForEntity } from './layers.js';
 import { loadEntityConfig, getEntityConfig } from './entity-cache.js';
 import { resolveEntityAppearance, drawEntityShape, colourToHex, RADAR_SHAPE_FALLBACK } from './canvas-scenario.js';
 import { getRegionRenderSpec } from './canvas-region.js';
+import { getAnchorRenderSpecs } from './canvas-anchor.js';
 import { snapshotForUndo } from './undo-controller.js';
 
 export class CanvasManager {
@@ -110,58 +111,87 @@ export class CanvasManager {
     const layers = this.layerManager.getLayers();
     const allAnchors = [];
 
+    // First pass: aggregate anchors from all layers (used by spawn positioning).
+    for (const layer of layers) {
+      if (!layer.visible) continue;
+      allAnchors.push(...getAnchors(layer));
+    }
+
+    // Adapter for cross-layer pure modules (anchor-rename, anchor-delete).
+    const v2Layers = layers.map(l => ({ path: l.filename, worldState: l.toml }));
+
     for (const layer of layers) {
       if (!layer.visible) continue;
 
       const layerGroup = new Konva.Group();
       this.baseLayer.add(layerGroup);
 
-      const anchors = getAnchors(layer);
-      allAnchors.push(...anchors);
-
-      for (const anchor of anchors) {
-        const pos = this.worldToCanvas(anchor.position[0], anchor.position[2]);
-        const diamond = new Konva.Shape({
-          x: pos.x,
-          y: pos.y,
-          stroke: '#ffffff',
-          strokeWidth: 2,
-          sceneFunc: (ctx, shape) => {
-            const size = 8;
-            ctx.beginPath();
-            ctx.moveTo(size, 0);
-            ctx.lineTo(0, size);
-            ctx.lineTo(-size, 0);
-            ctx.lineTo(0, -size);
-            ctx.closePath();
-            ctx.stroke();
-          }
-        });
-
-        const label = new Konva.Text({
-          x: -30,
-          y: 12,
-          text: anchor.name,
-          fontSize: 10,
-          fill: '#ffffff',
-          width: 60,
-          align: 'center'
-        });
-
-        const group = new Konva.Group({ draggable: false });
-        group.add(diamond);
-        group.add(label);
-        layerGroup.add(group);
-      }
-
+      // Spawns first — region overlays + entity markers beneath anchors.
       const spawns = getSpawns(layer);
       for (const spawn of spawns) {
         this.renderSpawn(spawn, layer, layerGroup, allAnchors);
+      }
+
+      // Anchors LAST — drawn on top of entities for visibility + clickability.
+      const anchorSpecs = getAnchorRenderSpecs(layer.toml?.anchors || {});
+      for (const spec of anchorSpecs) {
+        this.renderAnchor(spec, layer, layerGroup, v2Layers);
       }
     }
 
     this.updateArrows();
     this.baseLayer.batchDraw();
+  }
+
+  renderAnchor(spec, layer, container, v2Layers) {
+    const pos = this.worldToCanvas(spec.x, spec.z);
+    const group = new Konva.Group({
+      x: pos.x,
+      y: pos.y,
+      draggable: true,
+      name: 'anchorGroup',
+    });
+
+    const size = spec.size;
+    // Cross-hair: horizontal + vertical lines, length spec.size*2.
+    const hLine = new Konva.Line({
+      points: [-size, 0, size, 0],
+      stroke: '#ffff66',
+      strokeWidth: 1.5,
+    });
+    const vLine = new Konva.Line({
+      points: [0, -size, 0, size],
+      stroke: '#ffff66',
+      strokeWidth: 1.5,
+    });
+
+    const label = new Konva.Text({
+      x: -40,
+      y: size + 4,
+      text: spec.name,
+      fontSize: 10,
+      fill: '#ffff66',
+      width: 80,
+      align: 'center',
+    });
+
+    group.add(hLine);
+    group.add(vLine);
+    group.add(label);
+
+    // Drag wiring lands in commit C4.
+
+    // Right-click menu (commits C5/C6).
+    group.on('contextmenu', (e) => {
+      e.evt.preventDefault();
+      this.showAnchorMenu(e.evt.clientX, e.evt.clientY, spec.name, layer);
+    });
+
+    container.add(group);
+  }
+
+  showAnchorMenu(_clientX, _clientY, _anchorName, _layer) {
+    // Wired in C5/C6.
   }
 
   renderSpawn(spawn, layer, container, allAnchors) {

--- a/editor/tests/anchor-rename-integration.test.js
+++ b/editor/tests/anchor-rename-integration.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ModeShell } from '../mode-shell.js';
+import { analyzeAnchorRename } from '../anchor-rename.js';
+import { snapshotForUndo } from '../undo-controller.js';
+
+/**
+ * End-to-end integration: cross-layer anchor rename.
+ *
+ * Layer A defines anchor "X"; Layer B has an entity that references "X".
+ * The renamer must:
+ *   - allow the rename (no collision)
+ *   - report a cross-layer reference
+ *   - rewrite the anchor key in A and the entity's anchor field in B
+ *   - snapshot BOTH layers before mutation (Slice 1 contract)
+ */
+describe('anchor rename integration (cross-layer)', () => {
+  let modeShell;
+  let layerA;
+  let layerB;
+  let layerManager;
+
+  beforeEach(() => {
+    modeShell = new ModeShell();
+    layerA = {
+      filename: 'worlds/a.toml',
+      toml: {
+        anchors: { X: [10, 0, 20] },
+      },
+      isDirty: false,
+    };
+    layerB = {
+      filename: 'worlds/b.toml',
+      toml: {
+        entity: [{ name: 'patrol', template_path: 'entities/raider.toml', anchor: 'X' }],
+      },
+      isDirty: false,
+    };
+    layerManager = {
+      getLayers: () => [layerA, layerB],
+    };
+    globalThis.window = { __editorV2: { modeShell } };
+  });
+
+  it('rewrites the anchor key and the cross-layer reference, snapshotting both layers', () => {
+    const v2Layers = layerManager.getLayers().map(l => ({ path: l.filename, worldState: l.toml }));
+
+    const result = analyzeAnchorRename('X', 'Y', v2Layers);
+    expect(result.allowed).toBe(true);
+    expect(result.rewritePairs).toEqual([{ layerPath: 'worlds/a.toml', newAnchorValue: 'Y' }]);
+    expect(result.crossLayerReferences).toEqual([
+      { layerPath: 'worlds/b.toml', entityName: 'patrol', field: 'anchor' },
+    ]);
+    expect(result.inLayerReferences).toEqual([]);
+
+    // Apply rewrites — snapshot BEFORE mutation per Slice 1 contract.
+    snapshotForUndo(layerA);
+    layerA.toml.anchors.Y = layerA.toml.anchors.X;
+    delete layerA.toml.anchors.X;
+    layerA.isDirty = true;
+
+    snapshotForUndo(layerB);
+    for (const ent of layerB.toml.entity) {
+      if (ent.anchor === 'X') ent.anchor = 'Y';
+    }
+    layerB.isDirty = true;
+
+    // Owner layer: anchor key was renamed.
+    expect(layerA.toml.anchors.Y).toEqual([10, 0, 20]);
+    expect(layerA.toml.anchors.X).toBeUndefined();
+    // Cross layer: entity's anchor was rewritten.
+    expect(layerB.toml.entity[0].anchor).toBe('Y');
+
+    // Both layers were snapshotted onto the Scenario undo stack.
+    const undoEntryA = modeShell.swapUndoActive('Scenario', 'worlds/a.toml', layerA.toml);
+    expect(undoEntryA).toBeTruthy();
+    expect(undoEntryA.anchors.X).toEqual([10, 0, 20]);
+    expect(undoEntryA.anchors.Y).toBeUndefined();
+
+    const undoEntryB = modeShell.swapUndoActive('Scenario', 'worlds/b.toml', layerB.toml);
+    expect(undoEntryB).toBeTruthy();
+    expect(undoEntryB.entity[0].anchor).toBe('X');
+
+    // Both layers marked dirty.
+    expect(layerA.isDirty).toBe(true);
+    expect(layerB.isDirty).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #383. Stacked on #389.

Lands PRD #350 Slice 2: wires the pure region/anchor renderers and the rename/delete safety analysers into the live Scenario Mode canvas.

## What this does

- **Region rendering.** Replaces V1's inline sphere/torus/box drawing (canvas.js:209-244) with `getRegionRenderSpec(...)` consumption. Sphere/box/torus all draw via the pure spec's `cx/cz/radius/half_x/half_z/inner_radius/outer_radius/colour/fillAlpha:0.15`. Active effects render as `Konva.Text` emoji glyphs (🔥🐢🚫📡📵👁️) clustered horizontally on the region centre.
- **Template merge extension.** `canvas.js` template-merge block now also copies `effects` and `colour` from the entity template TOML, not just `shape`/`tags`/`radar_appearance`/`collider`. Without this, region effect icons had nothing to render — the world `[[entity]]` instance only carries `template_path` + `position`.
- **Anchor rendering.** Replaces V1's hand-coded diamond+label (canvas.js:121-154) with `getAnchorRenderSpecs(layer.toml.anchors)` consumption. Each anchor is a `Konva.Group` with `draggable: true`, two cross-hair `Konva.Line`s, and a centred `Konva.Text` label.
- **Anchor drag.** `dragstart` calls `snapshotForUndo(layer)` once. `dragmove` mutates `layer.toml.anchors[name] = [newX, preservedY, newZ]` (Y read from existing entry before tuple rebuild) and sets `isDirty`. `dragend` triggers `renderAll()` so entities resolving position via `anchor=` follow. **Does NOT replicate the spawn-drag dragmove snapshot anti-pattern** (Slice 1 known issue, deferred).
- **Anchor right-click menu.** Inline absolutely-positioned `<div>` with "Rename" / "Delete" items. Dismisses on outside `mousedown` (registered via `setTimeout(0)` + `{once:true}` so the opening click doesn't trigger dismiss). Tears down prior menu before opening a new one.
- **Anchor rename.** Uses `analyzeAnchorRename(currentName, newName, v2Layers)`. Blocks on collision (`!result.allowed` → alert). Warns on cross-layer references (`window.confirm`). On proceed: `snapshotForUndo` on every touched layer (owner + cross-layer), rewrites key in owner's `worldState.anchors`, walks `entity[].anchor` and `trigger[].action[].anchor` to update references, marks all dirty.
- **Anchor delete.** Uses `canDeleteAnchor(...)`. Blocks with `window.alert` listing blocker `entity`/`trigger` references. On `canDelete:true` + confirm: snapshot, `delete owner.toml.anchors[name]`, mark dirty.

## Acceptance criteria (#383)

| AC | Status | Evidence |
|---|---|---|
| Regions render as outlined shapes with effect icons | ✓ | canvas.js:407-475 (`getRegionRenderSpec` consumption + Konva.Text icon cluster); region_nebula → 📵👁️ on default.toml |
| Anchors render as draggable named cross-hairs | ✓ | canvas.js:135-176 (`getAnchorRenderSpecs`, `draggable: true`) |
| Anchor drag updates coords + marks dirty | ✓ | canvas.js:187-201 (dragstart snapshot, dragmove mutation with Y preservation, dragend re-render) |
| Rename cross-layer warning | ✓ | canvas.js:271-316 (`analyzeAnchorRename` + `window.confirm` on `crossLayerReferences.length > 0`); integration test `anchor-rename-integration.test.js` |
| Delete blocker dialog | ✓ | canvas.js:340-356 (`canDeleteAnchor` + alert with blocker list) |
| All existing editor tests pass | ✓ | 806/806 (805 Slice 1 baseline + 1 new integration) |

## Verification

- `npm run test:editor`: **806/806** pass (37 files).
- `cargo check`: clean.

## Architecture notes (review flags)

- **`renderAnchor` has an unused `v2Layers` param.** Dead parameter; rename/delete handlers rebuild fresh at click time. Harmless; cleanup follow-up.
- **Anchor `dragmove` inlines mutation instead of delegating to pure `moveAnchor()`.** `moveAnchor` returns a new worldState (immutable contract); the live editor mutates in place throughout `canvas.js`. Intentional consistency with V1 pattern. Could be reconciled via an ADR or by adopting immutable mutation throughout.
- **Spawn-drag dragmove snapshot anti-pattern at canvas.js:504 still exists.** Slice 1 known. Anchor drag deliberately does NOT extend the anti-pattern.

## Predecessor / successor

Stacked on #389 (Slice 1). Next: #384 (Slice 3 — World Content panel + cross-refs + override editor).
