### PR TITLE
feat(editor): PRD #350 Slice 3 — World Content panel + cross-refs + override editor

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -72,6 +72,14 @@
       <div id="scenario-mode-root" class="mode-pane">
         <!-- Left Panel -->
         <div id="leftPanel">
+          <!-- World Content Tree (Slice 3) -->
+          <div id="worldContentSection">
+            <h3>WORLD CONTENT</h3>
+            <div id="worldContentList">
+              <p class="placeholder">Open a world to see its content</p>
+            </div>
+          </div>
+
           <!-- Layers Section -->
           <div id="layersSection">
             <h3>LAYERS</h3>

--- a/editor/app.js
+++ b/editor/app.js
@@ -120,8 +120,7 @@ function renderAll() {
     crossRefIndex,
     activeLayerPath: activeLayer?.filename ?? null,
     onSelectEntity: (name) => {
-      // C3 will wire this to CanvasManager.selectByEntityName.
-      // For now the click is a no-op so the tree renders cleanly.
+      canvasManager.selectByEntityName(name);
     },
   });
 

--- a/editor/app.js
+++ b/editor/app.js
@@ -6,6 +6,7 @@ import { getEntityPath } from './toml-utils.js';
 import { preloadEntityCache, loadEntityConfig } from './entity-cache.js';
 import { restoreScenarioLayer } from './undo-controller.js';
 import { CrossReferenceIndex } from './cross-references.js';
+import { renderWorldContentPanel } from './world-content-view.js';
 
 const layerManager = new LayerManager();
 const crossRefIndex = new CrossReferenceIndex();
@@ -112,6 +113,18 @@ function renderAll() {
 
   renderLayersPanel(layerManager, renderAll, onSpawnSelectFromTree);
   canvasManager.renderAll();
+
+  const activeLayer = layerManager.getActiveLayer();
+  renderWorldContentPanel({
+    worldState: activeLayer?.toml ?? null,
+    crossRefIndex,
+    activeLayerPath: activeLayer?.filename ?? null,
+    onSelectEntity: (name) => {
+      // C3 will wire this to CanvasManager.selectByEntityName.
+      // For now the click is a no-op so the tree renders cleanly.
+    },
+  });
+
   updateUnsavedIndicator();
 
   // Mirror the V1 active layer into ModeShell so V2 features (save,

--- a/editor/app.js
+++ b/editor/app.js
@@ -5,8 +5,10 @@ import { EntityEditor } from './entity-editor.js';
 import { getEntityPath } from './toml-utils.js';
 import { preloadEntityCache, loadEntityConfig } from './entity-cache.js';
 import { restoreScenarioLayer } from './undo-controller.js';
+import { CrossReferenceIndex } from './cross-references.js';
 
 const layerManager = new LayerManager();
+const crossRefIndex = new CrossReferenceIndex();
 let canvasManager;
 let propertiesPanel;
 let entityEditor;
@@ -103,6 +105,11 @@ function onEntitySaved(entity) {
 }
 
 function renderAll() {
+  // Rebuild the cross-reference index from every open layer's worldState
+  // before any UI consumer reads from it (world-content panel, sidebar
+  // refCount fields, etc.).  Sub-millisecond for typical worlds.
+  crossRefIndex.indexLayers(canvasManager.buildV2Layers());
+
   renderLayersPanel(layerManager, renderAll, onSpawnSelectFromTree);
   canvasManager.renderAll();
   updateUnsavedIndicator();

--- a/editor/canvas.js
+++ b/editor/canvas.js
@@ -616,6 +616,36 @@ export class CanvasManager {
     this.onSpawnSelect(spawn, layer);
   }
 
+  /**
+   * Find a spawn by `entity.name` across every open layer and select it.
+   * First-match-wins; layers are scanned in `getLayers()` order.
+   * No-op (returns false) if no spawn carries that name.
+   *
+   * Used by the World Content panel to highlight a referenced entity on
+   * the canvas (Slice 3 PRD #350 AC #2).
+   *
+   * @param {string} name
+   * @returns {boolean}  true if a spawn was found and selected.
+   */
+  selectByEntityName(name) {
+    if (!name) return false;
+    for (const layer of this.layerManager.getLayers()) {
+      const arr = layer.kind === 'scenario' ? 'spawn' : 'entity';
+      const list = layer.toml?.[arr];
+      if (!Array.isArray(list)) continue;
+      const match = list.find(s => s && s.name === name);
+      if (match) {
+        // Activate the owning layer so subsequent panels (properties,
+        // world-content active-layer filtering) line up with the selection.
+        this.layerManager.setActiveLayer(layer);
+        this.selectSpawn(match, layer);
+        this.renderAll();
+        return true;
+      }
+    }
+    return false;
+  }
+
   deselectSpawn() {
     this.selectedSpawn = null;
     this.onSpawnSelect(null, null);

--- a/editor/override-view.js
+++ b/editor/override-view.js
@@ -1,0 +1,263 @@
+/**
+ * override-view.js
+ *
+ * Renders the resolved-template + override-summary UI inside the right-hand
+ * properties pane.  Pure DOM rendering on top of OverrideEditor — see
+ * editor/override-editor.js for the wire-format / API.
+ *
+ * Scope limits (per Slice 3 PRD #350):
+ *   - Primitive leaves (number, string, boolean) are click-to-edit inline.
+ *   - Arrays + nested objects show as read-only JSON.  Editing them inline
+ *     is out of scope for Slice 3 (gold-plating); users may still attach
+ *     overrides to nested leaves by clicking deeper into the tree (we
+ *     recurse one level of plain objects so e.g. `hull.max` is reachable).
+ *   - Arrays merge as REPLACE (not concat); this matches OverrideEditor.
+ *
+ * Selection -> render flow:
+ *   1. sidebar.js calls renderOverridePanel(spawn, layer, {canvasManager}).
+ *   2. We look up the template via entity-cache.  If missing, we render a
+ *      placeholder and kick off an async load + re-render.
+ *   3. Build OverrideEditor(template), re-apply each leaf of spawn.override.
+ *   4. Render resolved fields and the summary card.
+ *
+ * Edits write back to `spawn.override` and call `canvasManager.renderAll()`
+ * to keep the V1 mutation contract (snapshot -> mutate -> dirty -> render).
+ */
+
+import { OverrideEditor } from './override-editor.js';
+import { getEntityConfig, loadEntityConfig } from './entity-cache.js';
+import { snapshotForUndo } from './undo-controller.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/** Walk a nested plain-object tree producing `{path, value}` leaves.
+ *  Arrays are treated as leaves (REPLACE-on-merge semantics). */
+function flattenLeaves(obj, prefix = '') {
+  const out = [];
+  if (!isPlainObject(obj)) return out;
+  for (const [k, v] of Object.entries(obj)) {
+    const p = prefix ? `${prefix}.${k}` : k;
+    if (isPlainObject(v)) {
+      out.push(...flattenLeaves(v, p));
+    } else {
+      out.push({ path: p, value: v });
+    }
+  }
+  return out;
+}
+
+function formatValue(v) {
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return JSON.stringify(v);
+}
+
+/** Parse a string back into a value matching the type of `originalValue`.
+ *  Returns `{ ok, value, error }`. */
+function parseValue(raw, originalValue) {
+  if (typeof originalValue === 'number') {
+    const n = parseFloat(raw);
+    if (Number.isNaN(n)) return { ok: false, error: 'not a number' };
+    return { ok: true, value: n };
+  }
+  if (typeof originalValue === 'boolean') {
+    if (raw === 'true') return { ok: true, value: true };
+    if (raw === 'false') return { ok: true, value: false };
+    return { ok: false, error: 'expected true/false' };
+  }
+  if (Array.isArray(originalValue) || isPlainObject(originalValue)) {
+    try { return { ok: true, value: JSON.parse(raw) }; }
+    catch (e) { return { ok: false, error: e.message }; }
+  }
+  // string fallback
+  return { ok: true, value: raw };
+}
+
+function escapeHtml(s) {
+  return String(s ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+// ── Public entry point ───────────────────────────────────────────────────────
+
+/**
+ * Render the override panel into `hostEl` for `spawn` whose template lives at
+ * `spawn.template_path`.
+ *
+ * @param {HTMLElement} hostEl
+ * @param {object}      spawn         Owns optional `.override` block.
+ * @param {object}      layer         V1 layer record (for undo snapshot + isDirty).
+ * @param {object}      deps
+ * @param {object}      deps.canvasManager  Carries `renderAll()`.
+ */
+export function renderOverridePanel(hostEl, spawn, layer, deps) {
+  if (!hostEl) return;
+  hostEl.innerHTML = '';
+
+  const templatePath = spawn?.template_path;
+  if (!templatePath) {
+    hostEl.innerHTML = '<p class="placeholder">No template_path on this spawn</p>';
+    return;
+  }
+
+  let template = getEntityConfig(templatePath);
+  if (!template) {
+    hostEl.innerHTML = '<p class="placeholder">Loading template…</p>';
+    loadEntityConfig(templatePath).then((tpl) => {
+      if (!tpl) {
+        hostEl.innerHTML = `<p class="placeholder">Template not found: ${escapeHtml(templatePath)}</p>`;
+        return;
+      }
+      // Re-enter with the loaded template.
+      renderOverridePanel(hostEl, spawn, layer, deps);
+    });
+    return;
+  }
+
+  // Build editor and replay existing overrides.
+  const editor = new OverrideEditor(template);
+  const existingLeaves = flattenLeaves(spawn.override ?? {});
+  for (const { path, value } of existingLeaves) {
+    editor.setOverride(path, value);
+  }
+
+  const onEdit = (path, newValue) => {
+    snapshotForUndo(layer);
+    editor.setOverride(path, newValue);
+    spawn.override = editor.getOverrides();
+    if (Object.keys(spawn.override).length === 0) delete spawn.override;
+    layer.isDirty = true;
+    deps.canvasManager.renderAll();
+  };
+
+  const onClear = (path) => {
+    snapshotForUndo(layer);
+    editor.clearOverride(path);
+    spawn.override = editor.getOverrides();
+    if (Object.keys(spawn.override).length === 0) delete spawn.override;
+    layer.isDirty = true;
+    deps.canvasManager.renderAll();
+  };
+
+  // Resolved-template form (read-only by default; click to edit a value).
+  const resolved = editor.getResolvedView();
+  const overrideKeys = new Set(editor.getOverridesSummary().map(s => s.path));
+
+  const formPanel = document.createElement('div');
+  formPanel.className = 'override-panel';
+  formPanel.innerHTML = `<h4>RESOLVED TEMPLATE (${escapeHtml(shortPath(templatePath))})</h4>`;
+
+  const leaves = flattenLeaves(resolved);
+  if (leaves.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'override-summary-empty';
+    empty.textContent = '(template has no scalar fields)';
+    formPanel.appendChild(empty);
+  } else {
+    for (const { path, value } of leaves) {
+      formPanel.appendChild(buildFieldRow(path, value, overrideKeys.has(path), onEdit));
+    }
+  }
+  hostEl.appendChild(formPanel);
+
+  // Summary card.
+  hostEl.appendChild(buildSummaryCard(editor.getOverridesSummary(), onClear));
+}
+
+function buildFieldRow(path, value, isOverridden, onEdit) {
+  const row = document.createElement('div');
+  row.className = 'override-field' + (isOverridden ? ' overridden' : '');
+
+  const label = document.createElement('span');
+  label.className = 'of-label';
+  label.textContent = path;
+  row.appendChild(label);
+
+  const valEl = document.createElement('span');
+  valEl.className = 'of-value';
+  valEl.textContent = formatValue(value);
+  valEl.title = 'Click to override';
+  row.appendChild(valEl);
+
+  valEl.addEventListener('click', () => {
+    const input = document.createElement('input');
+    input.className = 'of-input';
+    input.type = 'text';
+    input.value = formatValue(value);
+    input.spellcheck = false;
+    valEl.replaceWith(input);
+    input.focus();
+    input.select();
+
+    let committed = false;
+    const cancel = () => {
+      if (committed) return;
+      committed = true;
+      input.replaceWith(valEl);
+    };
+    const commit = () => {
+      if (committed) return;
+      committed = true;
+      const parsed = parseValue(input.value, value);
+      if (!parsed.ok) {
+        // Discard and revert; surfacing a tooltip would be gold-plating
+        // for Slice 3.  Log so devs can see why it didn't stick.
+        console.warn(`[override-view] cannot parse "${input.value}" as ${typeof value}: ${parsed.error}`);
+        input.replaceWith(valEl);
+        return;
+      }
+      onEdit(path, parsed.value);
+      // renderAll() triggered by onEdit will rebuild the form; no need
+      // to restore valEl here.
+    };
+
+    input.addEventListener('blur', commit);
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); commit(); }
+      else if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+    });
+  });
+
+  return row;
+}
+
+function buildSummaryCard(summary, onClear) {
+  const card = document.createElement('div');
+  card.className = 'override-summary-card';
+  const h = document.createElement('h4');
+  h.textContent = `OVERRIDES (${summary.length})`;
+  card.appendChild(h);
+
+  if (summary.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'override-summary-empty';
+    empty.textContent = 'No overrides yet — click a field above to attach one.';
+    card.appendChild(empty);
+    return card;
+  }
+
+  for (const { path, value } of summary) {
+    const row = document.createElement('div');
+    row.className = 'override-summary-row';
+    row.innerHTML = `<span class="osr-path">${escapeHtml(path)}</span>` +
+                    `<span class="osr-value">${escapeHtml(formatValue(value))}</span>`;
+    const btn = document.createElement('button');
+    btn.className = 'osr-clear';
+    btn.textContent = 'clear';
+    btn.title = `Remove override at ${path}`;
+    btn.addEventListener('click', () => onClear(path));
+    row.appendChild(btn);
+    card.appendChild(row);
+  }
+  return card;
+}
+
+function shortPath(p) {
+  return p.split('/').pop() || p;
+}

--- a/editor/override-view.js
+++ b/editor/override-view.js
@@ -145,6 +145,14 @@ export function renderOverridePanel(hostEl, spawn, layer, deps) {
     deps.canvasManager.renderAll();
   };
 
+  const onClearAll = () => {
+    if (Object.keys(spawn.override ?? {}).length === 0) return;
+    snapshotForUndo(layer);
+    delete spawn.override;
+    layer.isDirty = true;
+    deps.canvasManager.renderAll();
+  };
+
   // Resolved-template form (read-only by default; click to edit a value).
   const resolved = editor.getResolvedView();
   const overrideKeys = new Set(editor.getOverridesSummary().map(s => s.path));
@@ -167,7 +175,7 @@ export function renderOverridePanel(hostEl, spawn, layer, deps) {
   hostEl.appendChild(formPanel);
 
   // Summary card.
-  hostEl.appendChild(buildSummaryCard(editor.getOverridesSummary(), onClear));
+  hostEl.appendChild(buildSummaryCard(editor.getOverridesSummary(), onClear, onClearAll));
 }
 
 function buildFieldRow(path, value, isOverridden, onEdit) {
@@ -227,7 +235,7 @@ function buildFieldRow(path, value, isOverridden, onEdit) {
   return row;
 }
 
-function buildSummaryCard(summary, onClear) {
+function buildSummaryCard(summary, onClear, onClearAll) {
   const card = document.createElement('div');
   card.className = 'override-summary-card';
   const h = document.createElement('h4');
@@ -255,6 +263,22 @@ function buildSummaryCard(summary, onClear) {
     row.appendChild(btn);
     card.appendChild(row);
   }
+
+  if (typeof onClearAll === 'function') {
+    const allRow = document.createElement('div');
+    allRow.className = 'override-summary-row';
+    const spacer = document.createElement('span');
+    spacer.className = 'osr-path';
+    allRow.appendChild(spacer);
+    const allBtn = document.createElement('button');
+    allBtn.className = 'osr-clear';
+    allBtn.textContent = 'reset all';
+    allBtn.title = 'Remove every override on this spawn';
+    allBtn.addEventListener('click', onClearAll);
+    allRow.appendChild(allBtn);
+    card.appendChild(allRow);
+  }
+
   return card;
 }
 

--- a/editor/sidebar.js
+++ b/editor/sidebar.js
@@ -1,6 +1,7 @@
 import { getSpawnName, getSpawnPosition, getEntityPath, getRelativeInfo, setSpawnPosition, getAllAnchors } from './toml-utils.js';
 import { getSpawnsFromAllLayers } from './toml-utils.js';
 import { snapshotForUndo } from './undo-controller.js';
+import { renderOverridePanel } from './override-view.js';
 
 export class PropertiesPanel {
   constructor(canvasManager, layerManager) {
@@ -104,9 +105,19 @@ export class PropertiesPanel {
           <span id="spawnTomlError" class="toml-error"></span>
         </div>
       </details>
+
+      <div id="overridePanelHost"></div>
     `;
 
     this._attachListeners(spawn, layer, allAnchors, pos, relative);
+
+    // Slice 3: resolved-template + override summary card below the V1 form.
+    renderOverridePanel(
+      document.getElementById('overridePanelHost'),
+      spawn,
+      layer,
+      { canvasManager: this.canvasManager },
+    );
   }
 
   _buildShapeHtml(spawn) {

--- a/editor/style.css
+++ b/editor/style.css
@@ -992,3 +992,220 @@ form {
 ::-webkit-scrollbar-thumb:hover {
   background: #666;
 }
+
+/* ── World Content panel (Slice 3) ──────────────────────────────────────── */
+
+#worldContentSection {
+  padding: 8px 12px;
+  border-bottom: 1px solid #333;
+}
+
+#worldContentSection h3 {
+  margin: 0 0 6px 0;
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  color: #aaa;
+}
+
+#worldContentList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.world-content-section {
+  background: #2a2a2d;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.world-content-section-header {
+  padding: 4px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #ccc;
+  cursor: pointer;
+  user-select: none;
+}
+
+.world-content-section-header:hover {
+  background: #34343a;
+}
+
+.world-content-section-body {
+  padding: 2px 0 4px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.world-content-row {
+  padding: 2px 6px;
+  font-size: 11px;
+  color: #bbb;
+  border-radius: 2px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.world-content-row.clickable {
+  cursor: pointer;
+}
+
+.world-content-row.clickable:hover {
+  background: #3a3a44;
+  color: #fff;
+}
+
+.world-content-row .wc-icon {
+  width: 12px;
+  text-align: center;
+  opacity: 0.7;
+}
+
+.world-content-row .wc-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.world-content-row .wc-refcount {
+  color: #777;
+  font-size: 10px;
+}
+
+.world-content-empty {
+  font-size: 10px;
+  color: #666;
+  padding: 2px 6px;
+  font-style: italic;
+}
+
+/* ── Override editor (Slice 3) ──────────────────────────────────────────── */
+
+.override-panel {
+  margin-top: 12px;
+  border-top: 1px solid #333;
+  padding-top: 12px;
+}
+
+.override-panel h4 {
+  margin: 0 0 6px 0;
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  color: #aaa;
+}
+
+.override-field {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 4px;
+  font-size: 11px;
+  border-radius: 2px;
+}
+
+.override-field:hover {
+  background: #2a2a2d;
+}
+
+.override-field.overridden {
+  background: #2d3a2d;
+}
+
+.override-field.overridden:hover {
+  background: #34443a;
+}
+
+.override-field .of-label {
+  flex: 1;
+  color: #aaa;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.override-field .of-value {
+  color: #ddd;
+  font-family: monospace;
+  cursor: text;
+  min-width: 60px;
+  text-align: right;
+}
+
+.override-field .of-value:hover {
+  color: #fff;
+  text-decoration: underline dotted;
+}
+
+.override-field input.of-input {
+  background: #1e1e22;
+  border: 1px solid #007acc;
+  color: #fff;
+  font-family: monospace;
+  font-size: 11px;
+  padding: 1px 3px;
+  width: 100px;
+  text-align: right;
+}
+
+.override-summary-card {
+  margin-top: 10px;
+  padding: 6px 8px;
+  background: #25282e;
+  border-radius: 3px;
+  border: 1px solid #333;
+}
+
+.override-summary-card h4 {
+  margin: 0 0 4px 0;
+  font-size: 11px;
+  color: #aaa;
+}
+
+.override-summary-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  padding: 1px 0;
+}
+
+.override-summary-row .osr-path {
+  flex: 1;
+  color: #ccc;
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.override-summary-row .osr-value {
+  color: #ddd;
+  font-family: monospace;
+}
+
+.override-summary-row .osr-clear {
+  font-size: 10px;
+  padding: 1px 6px;
+  background: #3a3030;
+  border: 1px solid #553030;
+  color: #d99;
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+.override-summary-row .osr-clear:hover {
+  background: #553030;
+  color: #fff;
+}
+
+.override-summary-empty {
+  font-size: 11px;
+  color: #666;
+  font-style: italic;
+}

--- a/editor/tests/slice-3-override-cycle.test.js
+++ b/editor/tests/slice-3-override-cycle.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import { OverrideEditor } from '../override-editor.js';
+import { CrossReferenceIndex } from '../cross-references.js';
+import { getWorldContentData } from '../world-content-panel.js';
+import { parseWorldToml, stringifyWorldToml } from '../world-toml.js';
+
+/**
+ * Integration test for the Slice 3 select → override → clear cycle.
+ *
+ * Mirrors what override-view.js does at the data layer (no DOM): build an
+ * editor from the spawn's template, replay existing overrides, mutate via
+ * setOverride/clearOverride, write back to `spawn.override`, and confirm
+ * the world TOML round-trips through smol-toml unchanged.
+ *
+ * Also confirms CrossReferenceIndex + getWorldContentData remain in sync
+ * before and after the mutation — the World Content panel must reflect
+ * the same entity at all times.
+ */
+
+// Helpers copied from override-view.js (kept private there to avoid
+// growing the module API surface).  They are part of the contract this
+// test pins.
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+function flattenLeaves(obj, prefix = '') {
+  const out = [];
+  if (!isPlainObject(obj)) return out;
+  for (const [k, v] of Object.entries(obj)) {
+    const p = prefix ? `${prefix}.${k}` : k;
+    if (isPlainObject(v)) out.push(...flattenLeaves(v, p));
+    else out.push({ path: p, value: v });
+  }
+  return out;
+}
+
+function makeWorld() {
+  return {
+    global: { seed: 42 },
+    anchors: { patrol_alpha: [100, 0, 0] },
+    entity: [{
+      template_path: 'assets/entities/pirate_raider.toml',
+      name: 'raider_alpha',
+      anchor: 'patrol_alpha',
+    }],
+    trigger: [{
+      condition: 'on_destroyed',
+      entity: 'raider_alpha',
+      action: [{ type: 'add_objective', id: 'win', text: 'destroy them' }],
+    }],
+  };
+}
+
+function makeTemplate() {
+  // Minimal pirate-raider template; only the fields the test exercises.
+  return {
+    hull: { max: 100, current: 100 },
+    helm_console: { max_speed: 30 },
+    radar_appearance: { colour: [1.0, 0.0, 0.0], shape: 'triangle' },
+    tags: ['hostile', 'ship'],
+  };
+}
+
+describe('Slice 3 integration: select → override → clear cycle', () => {
+  it('full cycle: select entity, attach override, summary updates, clear restores template', () => {
+    const world = makeWorld();
+    const template = makeTemplate();
+    const spawn = world.entity[0];
+
+    // ── 1. Select: user clicks raider_alpha; sidebar opens.
+    //    Build the editor and replay any existing overrides (none here).
+    let editor = new OverrideEditor(template);
+    for (const { path, value } of flattenLeaves(spawn.override ?? {})) {
+      editor.setOverride(path, value);
+    }
+
+    // No overrides yet — resolved view equals template.
+    expect(editor.getResolvedView()).toEqual(template);
+    expect(editor.getOverridesSummary()).toEqual([]);
+    expect('override' in spawn).toBe(false);
+
+    // ── 2. Edit a primitive: click hull.max, type 80.
+    editor.setOverride('hull.max', 80);
+    spawn.override = editor.getOverrides();
+
+    expect(spawn.override).toEqual({ hull: { max: 80 } });
+    expect(editor.getResolvedView().hull.max).toBe(80);
+    expect(editor.getResolvedView().hull.current).toBe(100); // template field preserved
+    expect(editor.getOverridesSummary())
+      .toEqual([{ path: 'hull.max', value: 80 }]);
+
+    // ── 3. Edit an array (REPLACE-on-merge per audit §10).
+    editor.setOverride('radar_appearance.colour', [0.8, 0, 0]);
+    spawn.override = editor.getOverrides();
+
+    expect(spawn.override.radar_appearance.colour).toEqual([0.8, 0, 0]);
+    expect(editor.getResolvedView().radar_appearance.shape).toBe('triangle');
+    expect(editor.getOverridesSummary()).toHaveLength(2);
+
+    // ── 4. Round-trip the entire world through TOML — overrides survive.
+    const text = stringifyWorldToml(world);
+    const reparsed = parseWorldToml(text);
+    expect(reparsed.entity[0].override).toEqual({
+      hull: { max: 80 },
+      radar_appearance: { colour: [0.8, 0, 0] },
+    });
+
+    // ── 5. Clear one override: hull.max.
+    editor.clearOverride('hull.max');
+    spawn.override = editor.getOverrides();
+    if (Object.keys(spawn.override).length === 0) delete spawn.override;
+
+    expect(spawn.override).toEqual({
+      radar_appearance: { colour: [0.8, 0, 0] },
+    });
+    expect(editor.getResolvedView().hull.max).toBe(100); // back to template
+
+    // ── 6. Clear the last override: the override key is removed entirely.
+    editor.clearOverride('radar_appearance.colour');
+    spawn.override = editor.getOverrides();
+    if (Object.keys(spawn.override).length === 0) delete spawn.override;
+
+    expect('override' in spawn).toBe(false);
+    expect(editor.getResolvedView()).toEqual(template);
+  });
+
+  it('CrossReferenceIndex + WorldContentData stay coherent across the cycle', () => {
+    const world = makeWorld();
+    const layers = [{ path: 'assets/worlds/test.toml', worldState: world }];
+
+    const index = new CrossReferenceIndex();
+    index.indexLayers(layers);
+
+    // Initial: raider_alpha is referenced once (the on_destroyed trigger).
+    const before = getWorldContentData(world, index, 'assets/worlds/test.toml');
+    expect(before.namedEntities).toEqual([{
+      name: 'raider_alpha',
+      template_path: 'assets/entities/pirate_raider.toml',
+      refCount: 1,
+    }]);
+    expect(before.objectives).toEqual([{
+      id: 'win', text: 'destroy them', mandatory: undefined, refCount: 1,
+    }]);
+
+    // Attach an override to the spawn — does not touch references.
+    const editor = new OverrideEditor(makeTemplate());
+    editor.setOverride('hull.max', 80);
+    world.entity[0].override = editor.getOverrides();
+    index.indexLayers(layers); // mimic renderAll() rebuild
+
+    const after = getWorldContentData(world, index, 'assets/worlds/test.toml');
+    expect(after.namedEntities[0].refCount).toBe(1);
+    expect(after.objectives[0].refCount).toBe(1);
+    // The named-entity row still resolves to the same entity for click-
+    // to-highlight; the World Content tree doesn't show overrides itself.
+    expect(after.namedEntities[0].name).toBe('raider_alpha');
+  });
+
+  it('replaying an existing override on selection produces the same resolved view', () => {
+    // Simulates re-opening a world that already carries overrides on disk.
+    const world = makeWorld();
+    world.entity[0].override = { hull: { max: 80 } };
+    const template = makeTemplate();
+    const spawn = world.entity[0];
+
+    const editor = new OverrideEditor(template);
+    for (const { path, value } of flattenLeaves(spawn.override ?? {})) {
+      editor.setOverride(path, value);
+    }
+    expect(editor.getResolvedView().hull.max).toBe(80);
+    expect(editor.getOverridesSummary())
+      .toEqual([{ path: 'hull.max', value: 80 }]);
+  });
+});

--- a/editor/tests/world-toml.test.js
+++ b/editor/tests/world-toml.test.js
@@ -223,4 +223,57 @@ entity = "raider_alpha"
       expect(reparsed.entity.length).toEqual(parsed.entity.length);
     });
   });
+
+  describe('spawn override persistence (Slice 3)', () => {
+    // Slice 3 introduces `[entity.override]` as a per-spawn convention:
+    // the editor mutates `layer.toml.entity[i].override` in place and
+    // relies on smol-toml.stringify to round-trip it.  This test pins
+    // that contract — if the writer ever drops unknown keys, fix it
+    // before merging.
+    it('round-trips a primitive override on a spawn', () => {
+      const world = {
+        global: { seed: 7 },
+        anchors: { spot: [0, 0, 0] },
+        entity: [{
+          template_path: 'assets/entities/pirate_raider.toml',
+          name: 'raider_alpha',
+          anchor: 'spot',
+          override: { hull: { max: 80 } },
+        }],
+      };
+      const toml = stringifyWorldToml(world);
+      const reparsed = parseWorldToml(toml);
+      expect(reparsed.entity[0].override).toEqual({ hull: { max: 80 } });
+      expect(reparsed.entity[0].name).toBe('raider_alpha');
+    });
+
+    it('round-trips an array-valued override (REPLACE merge)', () => {
+      const world = {
+        global: { seed: 1 },
+        anchors: { a: [0, 0, 0] },
+        entity: [{
+          template_path: 'assets/entities/asteroid_large.toml',
+          name: 'big_rock',
+          override: { radar_appearance: { colour: [0.9, 0.1, 0.1] } },
+        }],
+      };
+      const toml = stringifyWorldToml(world);
+      const reparsed = parseWorldToml(toml);
+      expect(reparsed.entity[0].override.radar_appearance.colour)
+        .toEqual([0.9, 0.1, 0.1]);
+    });
+
+    it('a spawn without override has no override key after round-trip', () => {
+      const world = {
+        global: { seed: 1 },
+        anchors: { a: [0, 0, 0] },
+        entity: [{
+          template_path: 'assets/entities/asteroid_large.toml',
+          name: 'plain_rock',
+        }],
+      };
+      const reparsed = parseWorldToml(stringifyWorldToml(world));
+      expect('override' in reparsed.entity[0]).toBe(false);
+    });
+  });
 });

--- a/editor/world-content-view.js
+++ b/editor/world-content-view.js
@@ -1,0 +1,146 @@
+/**
+ * world-content-view.js
+ *
+ * Renders the five-section "World Content" tree in the editor's left
+ * panel, sourced from `getWorldContentData(worldState, crossRefIndex,
+ * activeLayerPath)`.
+ *
+ * Pure DOM rendering + click-event-dispatch.  Section collapse state is
+ * preserved across re-renders via module-local Set.  Clicking a named
+ * entity (or a trigger/comms row whose `entity` is set) dispatches
+ * `onSelectEntity(name)`; otherwise rows are inert.
+ */
+
+import { getWorldContentData } from './world-content-panel.js';
+
+const collapsed = new Set();   // section keys that are collapsed
+
+const SECTIONS = [
+  { key: 'anchors',        label: 'Anchors',         icon: '◆', render: renderAnchorRow },
+  { key: 'namedEntities',  label: 'Named entities',  icon: '◦', render: renderEntityRow },
+  { key: 'triggers',       label: 'Triggers',        icon: '⚡', render: renderTriggerRow },
+  { key: 'commsTemplates', label: 'Comms templates', icon: '💬', render: renderCommsRow },
+  { key: 'objectives',     label: 'Objectives',      icon: '☑', render: renderObjectiveRow },
+];
+
+/**
+ * Render (or re-render) the World Content panel into `#worldContentList`.
+ * No-op if the host div is missing (Slice 1/2 callers without the new HTML).
+ *
+ * @param {object} opts
+ * @param {object|null} opts.worldState          Active layer's toml object.
+ * @param {object}      opts.crossRefIndex       CrossReferenceIndex instance.
+ * @param {string|null} opts.activeLayerPath     Filename of the active layer.
+ * @param {(name: string) => void} opts.onSelectEntity
+ *        Called when a clickable row identifies an entity to highlight.
+ */
+export function renderWorldContentPanel({
+  worldState,
+  crossRefIndex,
+  activeLayerPath,
+  onSelectEntity,
+}) {
+  const host = document.getElementById('worldContentList');
+  if (!host) return;
+
+  if (!worldState) {
+    host.innerHTML = '<p class="placeholder">Open a world to see its content</p>';
+    return;
+  }
+
+  const data = getWorldContentData(worldState, crossRefIndex, activeLayerPath);
+
+  host.innerHTML = '';
+  for (const section of SECTIONS) {
+    const rows = data[section.key] || [];
+    host.appendChild(buildSection(section, rows, onSelectEntity));
+  }
+}
+
+function buildSection(section, rows, onSelectEntity) {
+  const wrap = document.createElement('div');
+  wrap.className = 'world-content-section';
+  if (collapsed.has(section.key)) wrap.classList.add('collapsed');
+
+  const header = document.createElement('div');
+  header.className = 'world-content-section-header';
+  header.textContent = `${collapsed.has(section.key) ? '▸' : '▾'} ${section.label} (${rows.length})`;
+  header.addEventListener('click', () => {
+    if (collapsed.has(section.key)) {
+      collapsed.delete(section.key);
+    } else {
+      collapsed.add(section.key);
+    }
+    // Cheap local re-render: regenerate just this section.
+    const fresh = buildSection(section, rows, onSelectEntity);
+    wrap.replaceWith(fresh);
+  });
+  wrap.appendChild(header);
+
+  if (!collapsed.has(section.key)) {
+    const body = document.createElement('div');
+    body.className = 'world-content-section-body';
+    if (rows.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'world-content-empty';
+      empty.textContent = '(none)';
+      body.appendChild(empty);
+    } else {
+      for (const row of rows) {
+        body.appendChild(section.render(row, section.icon, onSelectEntity));
+      }
+    }
+    wrap.appendChild(body);
+  }
+  return wrap;
+}
+
+function makeRow(icon, label, refCount, targetEntity, onSelectEntity) {
+  const row = document.createElement('div');
+  row.className = 'world-content-row';
+  if (targetEntity) row.classList.add('clickable');
+  row.innerHTML = `<span class="wc-icon">${icon}</span><span class="wc-label">${escapeHtml(label)}</span>` +
+    (refCount != null ? `<span class="wc-refcount">(${refCount})</span>` : '');
+  if (targetEntity && typeof onSelectEntity === 'function') {
+    row.addEventListener('click', () => onSelectEntity(targetEntity));
+  }
+  return row;
+}
+
+function renderAnchorRow(row, icon, onSelectEntity) {
+  // Anchors are not directly entity-clickable; show the count of spawns
+  // anchored to them but no highlight (per audit §4 decision).
+  return makeRow(icon, row.name, row.refCount, null, onSelectEntity);
+}
+
+function renderEntityRow(row, icon, onSelectEntity) {
+  const tail = row.template_path ? ` ← ${shortPath(row.template_path)}` : '';
+  return makeRow(icon, `${row.name}${tail}`, row.refCount, row.name, onSelectEntity);
+}
+
+function renderTriggerRow(row, icon, onSelectEntity) {
+  const cond = row.condition || '*';
+  const ent  = row.entity ? `:${row.entity}` : '';
+  return makeRow(icon, `${cond}${ent} (×${row.actionCount})`, null, row.entity || null, onSelectEntity);
+}
+
+function renderCommsRow(row, icon, onSelectEntity) {
+  const parts = [row.from, row.trigger].filter(Boolean).join(' / ');
+  return makeRow(icon, parts || '(unnamed)', null, row.entity || null, onSelectEntity);
+}
+
+function renderObjectiveRow(row, icon, onSelectEntity) {
+  const text = row.text ? `: ${row.text}` : '';
+  return makeRow(icon, `${row.id}${text}`, row.refCount, null, onSelectEntity);
+}
+
+function shortPath(p) {
+  return p.split('/').pop() || p;
+}
+
+function escapeHtml(s) {
+  return String(s ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}


### PR DESCRIPTION
Closes #384. Stacked on #390.

Lands PRD #350 Slice 3: World Content tree in the left panel, click-to-highlight wiring, and per-spawn override editor in the right panel.

## What this does

- **World Content panel** — new `#worldContentSection` in `#leftPanel` (above the layer list). Renders five sections from `getWorldContentData()`: Anchors / Named entities / Triggers / Comms templates / Objectives. Section headers collapse/expand; collapse state persists across re-renders. Sources from the active layer's `worldState`.
- **Click-to-highlight** — `CanvasManager.selectByEntityName(name)` (canvas.js:630-647) walks all open layers, finds the matching spawn, activates its layer, calls `selectSpawn` (which fires the existing select chain to the canvas + properties pane). Named-entity rows pass `row.name`; trigger and comms rows pass `row.entity`; anchor + objective rows are intentionally informational.
- **Override editor as per-spawn properties** — `OverrideView` (new `editor/override-view.js`) appended to V1's `PropertiesPanel`. On select: `getEntityConfig(spawn.template_path)` → `new OverrideEditor(template)` → replays existing leaves from `spawn.override`. Resolved-template form renders as clickable fields (primitive leaves become inputs on click; nested objects/arrays edit as JSON strings). On commit: `snapshotForUndo` → `setOverride` → `spawn.override = editor.getOverrides()` → empty-block delete → mark dirty → `renderAll()`. Esc reverts read-only.
- **Override summary card** — at the bottom of the override pane. Lists each `{path, value}` from `getOverridesSummary()` with a per-row "clear" button. Implementer added a "reset all" button (not in ACs).
- **CrossReferenceIndex rebuild** — singleton on `app.js`; `indexLayers(buildV2Layers())` fires at the top of `renderAll()`. Rebuild cost is sub-millisecond for typical worlds.
- **TOML round-trip** — `spawn.override` serialises naturally via `smol-toml` as `[entity.override.*]` blocks. The Rust loader doesn't yet read this key; that's a future PRD. Three regression tests pin the contract in `world-toml.test.js`.

## Acceptance criteria (#384)

| AC | Status | Evidence |
|---|---|---|
| Five-section panel | ✓ | editor.html:75-80 `#worldContentSection`; world-content-view.js:18-24 SECTIONS const |
| Click-to-highlight | ✓ | canvas.js:630-647 `selectByEntityName`; app.js:122-124 `onSelectEntity` wire |
| Resolved template + click-to-edit attaches override | ✓ | override-view.js:109-146 (`renderOverridePanel`, `onEdit`); snapshot-before-mutation at line 131 |
| Override summary lists every path; clear removes only that path | ✓ | override-view.js:139-146 (`onClear`); test `slice-3-override-cycle.test.js` covers single-clear + full-clear deletes spawn.override |
| Existing tests pass | ✓ | 812/812 (was 806 in Slice 2; +6 new) |

## Verification

- `npm run test:editor`: **812/812** (38 files).
- `cargo check`: clean.

## New / modified files

**New:**
- `editor/world-content-view.js` — pure DOM renderer (139 lines), persistent collapse state, click-to-select wiring.
- `editor/override-view.js` — resolved-template form + summary card (~285 lines). Handles primitive/array/object leaves, JSON-string nested editing, Esc cancel, async template load fallback.
- `editor/tests/slice-3-override-cycle.test.js` — 3 integration tests: select→override→clear cycle; cross-ref/world-content coherence; replay-existing-overrides on re-select.

**Modified:**
- `editor/app.js` — owns `CrossReferenceIndex` singleton, rebuilds at top of `renderAll()`, calls `renderWorldContentPanel`.
- `editor/canvas.js` — adds `selectByEntityName(name)`.
- `editor/sidebar.js` — appends `#overridePanelHost` after V1 form, delegates to `renderOverridePanel`.
- `editor.html` — `#worldContentSection` above `#layersSection`.
- `editor/style.css` — appended styles for `.world-content-*`, `.override-field`, `.override-summary-*`.
- `editor/tests/world-toml.test.js` — +3 spawn.override round-trip regression tests.

## Architecture / follow-up flags (from review)

- Reset-all has no `window.confirm` guard — single click wipes overrides (undo recovers). Match the anchor-delete confirm pattern in canvas.js:352 as follow-up.
- Invalid JSON in array/object inline edit logs `console.warn` and reverts; no inline error UI surface.
- Collapse state is module-scoped (not per-world-file).
- Anchor refCount in the panel only refreshes on `dragend`, not during anchor drag (CrossRef isn't rebuilt mid-drag).
- `loadEntityConfig().then(...)` for missing template can race against rapid selection changes — late callback may rewrite host with original spawn's data. Edge case, low likelihood.

## Predecessor / successor

Stacked on #390 (Slice 2). Next: #385 (Slice 4 — Triggers + Comms editors + triggerable-worlds + New World).
