### PR TITLE
Slice 4 — Triggers, Comms, Triggerable Worlds, New World (#385)

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -80,11 +80,18 @@
             </div>
           </div>
 
+          <!-- Triggerable Worlds (Slice 4b) -->
+          <div id="triggerableWorldsSection">
+            <h3>TRIGGERABLE WORLDS</h3>
+            <div id="triggerableWorldsList"></div>
+          </div>
+
           <!-- Layers Section -->
           <div id="layersSection">
             <h3>LAYERS</h3>
             <div id="layersList"></div>
             <button id="addLayerBtn">+ Add Layer</button>
+            <button id="newWorldBtn">+ New World</button>
           </div>
 
           <!-- Entities Palette -->

--- a/editor/action-card-view.js
+++ b/editor/action-card-view.js
@@ -1,0 +1,419 @@
+/**
+ * action-card-view.js
+ *
+ * Pure DOM-rendering module for a single trigger-action card.
+ *
+ * Exports `renderActionCard(host, action, deps) → void`.  The card is
+ * schema-driven: it reads `ACTION_SCHEMA[action.type].fields` and maps
+ * each field to an appropriate input element (text / number / checkbox /
+ * select), with picker integrations for entity-name, objective-id,
+ * AI-state, modifier-slot, flag-kind, and world-file path fields.
+ *
+ * The card never mutates `action` in place — every edit produces a fresh
+ * `{...action, [key]: newValue}` object and calls `deps.onChange(updated)`.
+ * The caller is responsible for writing the new object into world state
+ * and re-rendering.
+ *
+ * Slice 4a contract (PRD #350):
+ *   - AC #2: entity picker shows red ⚠ when the saved value is not in the
+ *            options list, but still allows save.
+ *   - AC #3: `complete_objective` / `fail_objective` use a dropdown for
+ *            their `id` field, sourced from same-world `add_objective`s.
+ *   - AC #4: `load_world` / `unload_world` (path) and `load_scenario`
+ *            (load_scenario) fields use a file picker stub.
+ */
+
+import {
+  ACTION_SCHEMA,
+  INT_MODIFIER_SLOTS,
+} from './action-schema.js';
+import {
+  getEntityNameOptions,
+  getObjectiveIdOptions,
+  getAiStateOptions,
+  getModifierSlotOptions,
+  getFlagKindOptions,
+} from './trigger-pickers.js';
+
+/**
+ * Render an action card into `host`.
+ *
+ * @param {HTMLElement} host
+ * @param {object} action       The action object — must have a `type` key
+ *                              matching an entry in ACTION_SCHEMA.
+ * @param {object} deps
+ * @param {object} deps.worldState
+ * @param {Array<{path, worldState}>} deps.allLayers
+ * @param {(updated: object) => void} deps.onChange
+ * @param {(direction: 'up'|'down') => void} deps.onMove
+ * @param {() => void} deps.onRemove
+ * @param {(rootPath: string) => Promise<string|null>} deps.openFilePicker
+ */
+export function renderActionCard(host, action, deps) {
+  const schema = ACTION_SCHEMA[action.type];
+  if (!schema) {
+    host.innerHTML = `<div class="action-card"><div class="action-card-header">
+      <span class="action-card-title">⚠ Unknown action type: ${escapeHtml(action.type)}</span>
+    </div></div>`;
+    return;
+  }
+
+  const card = document.createElement('div');
+  card.className = 'action-card';
+
+  // ── Header ────────────────────────────────────────────────────────────
+  const header = document.createElement('div');
+  header.className = 'action-card-header';
+
+  const title = document.createElement('span');
+  title.className = 'action-card-title';
+  title.textContent = `▾ ${schema.label}`;
+  header.appendChild(title);
+
+  const controls = document.createElement('span');
+  controls.className = 'action-card-controls';
+  controls.appendChild(makeIconButton('⬆', 'up',     () => deps.onMove?.('up')));
+  controls.appendChild(makeIconButton('⬇', 'down',   () => deps.onMove?.('down')));
+  controls.appendChild(makeIconButton('✕', 'remove', () => deps.onRemove?.()));
+  header.appendChild(controls);
+  card.appendChild(header);
+
+  // ── Body ──────────────────────────────────────────────────────────────
+  const body = document.createElement('div');
+  body.className = 'action-card-body';
+
+  for (const field of schema.fields) {
+    body.appendChild(renderField(action, field, deps));
+  }
+
+  card.appendChild(body);
+  host.appendChild(card);
+}
+
+// ── Field rendering ─────────────────────────────────────────────────────
+
+function renderField(action, field, deps) {
+  const row = document.createElement('div');
+  row.className = 'action-field';
+
+  const label = document.createElement('label');
+  label.textContent = field.key;
+  row.appendChild(label);
+
+  const value = action[field.key];
+
+  // Path-style fields (file picker).
+  if (
+    (field.key === 'path' && (action.type === 'load_world' || action.type === 'unload_world')) ||
+    (field.key === 'load_scenario' && action.type === 'load_scenario')
+  ) {
+    row.appendChild(renderFilePickerField(action, field, value, deps));
+    return row;
+  }
+
+  // Entity-name picker.
+  if (field.key === 'entity') {
+    const opts = getEntityNameOptions(deps.allLayers || []);
+    row.appendChild(renderEntityNameSelect(action, field, value, opts, deps));
+    return row;
+  }
+
+  // set_ai_state: state dropdown depends on action.entity.
+  if (field.key === 'state' && action.type === 'set_ai_state') {
+    row.appendChild(renderAiStateSelect(action, field, value, deps));
+    return row;
+  }
+
+  // complete_objective / fail_objective: id dropdown sourced from
+  // same-world add_objective actions.
+  if (field.key === 'id' && (action.type === 'complete_objective' || action.type === 'fail_objective')) {
+    const opts = getObjectiveIdOptions(deps.worldState || {});
+    row.appendChild(renderObjectiveIdSelect(action, field, value, opts, deps));
+    return row;
+  }
+
+  // Modifier-slot dropdowns.
+  if (field.key === 'slot') {
+    const isInt = action.type === 'apply_int_modifier' || action.type === 'remove_int_modifier';
+    const opts = isInt
+      ? INT_MODIFIER_SLOTS.map((s) => ({ value: s, label: s }))
+      : getModifierSlotOptions();
+    row.appendChild(renderEnumSelect(action, field, value, opts, deps));
+    return row;
+  }
+
+  // Flag-kind dropdown.
+  if (field.key === 'kind' && (action.type === 'apply_flag' || action.type === 'remove_flag')) {
+    const opts = getFlagKindOptions();
+    row.appendChild(renderEnumSelect(action, field, value, opts, deps));
+    return row;
+  }
+
+  // Generic schema-driven inputs.
+  if (field.enum) {
+    const opts = field.enum.map((v) => ({ value: v, label: v }));
+    row.appendChild(renderEnumSelect(action, field, value, opts, deps));
+    return row;
+  }
+
+  if (field.type === 'boolean') {
+    row.appendChild(renderBooleanInput(action, field, value, deps));
+    return row;
+  }
+
+  if (field.type === 'number') {
+    row.appendChild(renderNumberInput(action, field, value, deps));
+    return row;
+  }
+
+  // game_over message → textarea.
+  if (field.key === 'message' && action.type === 'game_over') {
+    row.appendChild(renderTextarea(action, field, value, deps));
+    return row;
+  }
+
+  row.appendChild(renderTextInput(action, field, value, deps));
+  return row;
+}
+
+// ── Individual input renderers ──────────────────────────────────────────
+
+function renderEntityNameSelect(action, field, value, opts, deps) {
+  const wrap = document.createElement('span');
+  wrap.style.display = 'flex';
+  wrap.style.gap = '6px';
+  wrap.style.flex = '1';
+
+  const select = document.createElement('select');
+
+  // Placeholder for empty.
+  const empty = document.createElement('option');
+  empty.value = '';
+  empty.textContent = '(none)';
+  select.appendChild(empty);
+
+  const knownValues = new Set();
+  for (const o of opts) {
+    if (knownValues.has(o.value)) continue;
+    knownValues.add(o.value);
+    const opt = document.createElement('option');
+    opt.value = o.value;
+    opt.textContent = o.label;
+    select.appendChild(opt);
+  }
+
+  const isUnknown = value && !knownValues.has(value);
+  if (isUnknown) {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = `${value} ⚠ unknown`;
+    select.appendChild(opt);
+  }
+
+  select.value = value ?? '';
+
+  select.addEventListener('change', (e) => {
+    deps.onChange?.({ ...action, [field.key]: e.target.value });
+  });
+  wrap.appendChild(select);
+
+  if (isUnknown) {
+    const warn = document.createElement('span');
+    warn.className = 'action-field-warning';
+    warn.textContent = '⚠ unknown';
+    wrap.appendChild(warn);
+  }
+  return wrap;
+}
+
+function renderAiStateSelect(action, field, value, deps) {
+  const wrap = document.createElement('span');
+  wrap.style.display = 'flex';
+  wrap.style.flex = '1';
+
+  const opts = getAiStateOptions(deps.worldState || {}, action.entity);
+
+  if (opts.length === 0) {
+    const hint = document.createElement('span');
+    hint.className = 'action-field-hint';
+    hint.textContent = 'Select an entity first';
+    wrap.appendChild(hint);
+    return wrap;
+  }
+
+  const select = document.createElement('select');
+  const known = new Set();
+  for (const o of opts) {
+    known.add(o.value);
+    const opt = document.createElement('option');
+    opt.value = o.value;
+    opt.textContent = o.label;
+    select.appendChild(opt);
+  }
+  if (value && !known.has(value)) {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = `${value} (unknown)`;
+    select.appendChild(opt);
+  }
+  select.value = value ?? '';
+
+  select.addEventListener('change', (e) => {
+    deps.onChange?.({ ...action, [field.key]: e.target.value });
+  });
+  wrap.appendChild(select);
+  return wrap;
+}
+
+function renderObjectiveIdSelect(action, field, value, opts, deps) {
+  const select = document.createElement('select');
+
+  const known = new Set();
+  for (const o of opts) {
+    known.add(o.value);
+    const opt = document.createElement('option');
+    opt.value = o.value;
+    opt.textContent = o.label;
+    select.appendChild(opt);
+  }
+  if (value && !known.has(value)) {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = `${value} (unknown)`;
+    select.appendChild(opt);
+  } else if (!value) {
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.textContent = '(unknown)';
+    select.appendChild(opt);
+  }
+  select.value = value ?? '';
+
+  select.addEventListener('change', (e) => {
+    deps.onChange?.({ ...action, [field.key]: e.target.value });
+  });
+  return select;
+}
+
+function renderEnumSelect(action, field, value, opts, deps) {
+  const select = document.createElement('select');
+  const known = new Set();
+  for (const o of opts) {
+    known.add(o.value);
+    const opt = document.createElement('option');
+    opt.value = o.value;
+    opt.textContent = o.label;
+    select.appendChild(opt);
+  }
+  if (value !== undefined && value !== null && value !== '' && !known.has(value)) {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = `${value} (unknown)`;
+    select.appendChild(opt);
+  }
+  select.value = value ?? '';
+  select.addEventListener('change', (e) => {
+    deps.onChange?.({ ...action, [field.key]: e.target.value });
+  });
+  return select;
+}
+
+function renderBooleanInput(action, field, value, deps) {
+  const input = document.createElement('input');
+  input.type = 'checkbox';
+  input.checked = !!value;
+  input.addEventListener('change', (e) => {
+    deps.onChange?.({ ...action, [field.key]: e.target.checked });
+  });
+  return input;
+}
+
+function renderNumberInput(action, field, value, deps) {
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.step = '0.1';
+  input.value = (value === undefined || value === null) ? '' : String(value);
+  input.addEventListener('input', (e) => {
+    const raw = e.target.value;
+    if (raw === '') {
+      deps.onChange?.({ ...action, [field.key]: 0 });
+      return;
+    }
+    const n = parseFloat(raw);
+    if (!Number.isNaN(n)) {
+      deps.onChange?.({ ...action, [field.key]: n });
+    }
+  });
+  return input;
+}
+
+function renderTextInput(action, field, value, deps) {
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.value = value ?? '';
+  input.addEventListener('input', (e) => {
+    deps.onChange?.({ ...action, [field.key]: e.target.value });
+  });
+  return input;
+}
+
+function renderTextarea(action, field, value, deps) {
+  const ta = document.createElement('textarea');
+  ta.rows = 3;
+  ta.value = value ?? '';
+  ta.addEventListener('input', (e) => {
+    deps.onChange?.({ ...action, [field.key]: e.target.value });
+  });
+  return ta;
+}
+
+function renderFilePickerField(action, field, value, deps) {
+  const wrap = document.createElement('span');
+  wrap.style.display = 'flex';
+  wrap.style.flex = '1';
+  wrap.style.gap = '6px';
+  wrap.style.alignItems = 'center';
+
+  const display = document.createElement('span');
+  display.className = 'action-field-hint';
+  display.style.flex = '1';
+  display.textContent = value || '(no file selected)';
+  wrap.appendChild(display);
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = 'Pick…';
+  btn.addEventListener('click', async () => {
+    const picker = deps.openFilePicker;
+    if (typeof picker !== 'function') return;
+    try {
+      const chosen = await picker('assets/worlds/');
+      if (chosen && typeof chosen === 'string') {
+        deps.onChange?.({ ...action, [field.key]: chosen });
+      }
+    } catch (err) {
+      console.warn('[action-card-view] file picker failed:', err?.message || err);
+    }
+  });
+  wrap.appendChild(btn);
+  return wrap;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function makeIconButton(label, dataAction, onClick) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'btn-icon';
+  btn.dataset.action = dataAction;
+  btn.textContent = label;
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+function escapeHtml(s) {
+  return String(s ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}

--- a/editor/action-card-view.js
+++ b/editor/action-card-view.js
@@ -28,12 +28,12 @@ import {
   INT_MODIFIER_SLOTS,
 } from './action-schema.js';
 import {
-  getEntityNameOptions,
   getObjectiveIdOptions,
   getAiStateOptions,
   getModifierSlotOptions,
   getFlagKindOptions,
 } from './trigger-pickers.js';
+import { renderEntitySelect } from './entity-select-view.js';
 
 /**
  * Render an action card into `host`.
@@ -113,8 +113,12 @@ function renderField(action, field, deps) {
 
   // Entity-name picker.
   if (field.key === 'entity') {
-    const opts = getEntityNameOptions(deps.allLayers || []);
-    row.appendChild(renderEntityNameSelect(action, field, value, opts, deps));
+    renderEntitySelect(
+      row,
+      value,
+      deps.allLayers || [],
+      (newValue) => deps.onChange?.({ ...action, [field.key]: newValue }),
+    );
     return row;
   }
 
@@ -177,54 +181,6 @@ function renderField(action, field, deps) {
 }
 
 // ── Individual input renderers ──────────────────────────────────────────
-
-function renderEntityNameSelect(action, field, value, opts, deps) {
-  const wrap = document.createElement('span');
-  wrap.style.display = 'flex';
-  wrap.style.gap = '6px';
-  wrap.style.flex = '1';
-
-  const select = document.createElement('select');
-
-  // Placeholder for empty.
-  const empty = document.createElement('option');
-  empty.value = '';
-  empty.textContent = '(none)';
-  select.appendChild(empty);
-
-  const knownValues = new Set();
-  for (const o of opts) {
-    if (knownValues.has(o.value)) continue;
-    knownValues.add(o.value);
-    const opt = document.createElement('option');
-    opt.value = o.value;
-    opt.textContent = o.label;
-    select.appendChild(opt);
-  }
-
-  const isUnknown = value && !knownValues.has(value);
-  if (isUnknown) {
-    const opt = document.createElement('option');
-    opt.value = value;
-    opt.textContent = `${value} ⚠ unknown`;
-    select.appendChild(opt);
-  }
-
-  select.value = value ?? '';
-
-  select.addEventListener('change', (e) => {
-    deps.onChange?.({ ...action, [field.key]: e.target.value });
-  });
-  wrap.appendChild(select);
-
-  if (isUnknown) {
-    const warn = document.createElement('span');
-    warn.className = 'action-field-warning';
-    warn.textContent = '⚠ unknown';
-    wrap.appendChild(warn);
-  }
-  return wrap;
-}
 
 function renderAiStateSelect(action, field, value, deps) {
   const wrap = document.createElement('span');

--- a/editor/app.js
+++ b/editor/app.js
@@ -7,6 +7,9 @@ import { preloadEntityCache, loadEntityConfig } from './entity-cache.js';
 import { restoreScenarioLayer } from './undo-controller.js';
 import { CrossReferenceIndex } from './cross-references.js';
 import { renderWorldContentPanel } from './world-content-view.js';
+import { renderTriggerableWorldsPanel } from './triggerable-worlds-panel.js';
+import { mountNewWorldButton } from './new-world-dialog.js';
+import { readFile, writeFile, listDirectory } from './project-root.js';
 
 const layerManager = new LayerManager();
 const crossRefIndex = new CrossReferenceIndex();
@@ -40,6 +43,26 @@ async function init() {
   setupToolbar();
   setupLayersPanel();
   registerScenarioUndoRestore();
+
+  // Slice 4b: + New World button next to addLayerBtn.
+  mountNewWorldButton({
+    layerManager,
+    writeFile,
+    tomlParse: window.tomlParse,
+    onCreated: renderAll,
+    getExistingPaths: () => layerManager.getLayers().map((l) => l.filename),
+  });
+
+  // Slice 4b: session-only triggerable layers must skip the save flow.
+  const v2 = window.__editorV2;
+  if (v2 && v2.saveFlow && typeof v2.saveFlow.setSessionOnlyChecker === 'function') {
+    v2.saveFlow.setSessionOnlyChecker((mode, path) => {
+      if (mode !== 'Scenario') return false;
+      const layer = layerManager.getLayers().find((l) => l.filename === path);
+      return !!(layer && layer._sessionOnly);
+    });
+  }
+
   renderAll();
 }
 
@@ -136,6 +159,18 @@ function renderAll() {
   });
 
   updateUnsavedIndicator();
+
+  // Slice 4b: Triggerable Worlds panel (async — fire and forget; the panel
+  // refreshes itself when listDirectory resolves).
+  renderTriggerableWorldsPanel({
+    layerManager,
+    onLayersChanged: renderAll,
+    readFile,
+    listDirectory,
+    tomlParse: window.tomlParse,
+  }).catch((err) => {
+    console.warn('[editor] triggerable-worlds panel render failed:', err?.message || err);
+  });
 
   // Mirror the V1 active layer into ModeShell so V2 features (save,
   // undo shortcuts, invalidation) target the right file.

--- a/editor/app.js
+++ b/editor/app.js
@@ -122,6 +122,17 @@ function renderAll() {
     onSelectEntity: (name) => {
       canvasManager.selectByEntityName(name);
     },
+    onSelectTrigger: (triggerIndex) => {
+      const layer = layerManager.getActiveLayer();
+      if (!layer) return;
+      propertiesPanel.render({ type: 'trigger', triggerIndex, layer });
+    },
+    onSelectComms: (commsIndex) => {
+      const layer = layerManager.getActiveLayer();
+      if (!layer) return;
+      // Stub for Slice 4b; renders a placeholder.
+      propertiesPanel.render({ type: 'comms', commsIndex, layer });
+    },
   });
 
   updateUnsavedIndicator();

--- a/editor/comms-adapter.js
+++ b/editor/comms-adapter.js
@@ -1,0 +1,129 @@
+/**
+ * comms-adapter.js
+ *
+ * Pure adapter between the live TOML shape of `[[comms]]` blocks (see
+ * `assets/worlds/default.toml`) and the shape consumed by `CommsEditor`
+ * / `comms-view.js`.
+ *
+ * Live TOML shape (per template):
+ *   { from, trigger, entity?, message, response: [
+ *       { text, action: [...], follow_up?: { message, response: [...] } }
+ *   ] }
+ *
+ * Editor shape (per template):
+ *   { from,
+ *     trigger: { kind, entity },   // on_attacked | on_destroyed | on_hailed
+ *     node:    { body, responses: [
+ *       { text, actions: [...], follow_up?: { body, responses: [...] } }
+ *     ] }
+ *   }
+ *
+ * Notes on `on_timer` (audit risk #7): `RawCommsEntry` in
+ * `src/world/config.rs` does NOT include an `after_secs` field, and the
+ * parser passes `None` for after_secs when parsing comms templates. So
+ * `on_timer` is NOT supported at the comms-template level. The adapter
+ * does NOT model `after_secs` for comms; the view layer restricts the
+ * trigger `<select>` to the three supported variants.
+ *
+ * Round-trip contract: `editorCommsToWorld(worldCommsToEditor(x)) ≈ x`
+ * for any well-formed live comms array.
+ */
+
+function deepClone(value) {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(deepClone);
+  const out = {};
+  for (const k of Object.keys(value)) {
+    out[k] = deepClone(value[k]);
+  }
+  return out;
+}
+
+function mapResponseToEditor(resp) {
+  const out = {
+    text: resp.text ?? '',
+    actions: Array.isArray(resp.action) ? deepClone(resp.action) : [],
+  };
+  if (resp.follow_up && typeof resp.follow_up === 'object') {
+    out.follow_up = mapNodeToEditor(resp.follow_up);
+  }
+  return out;
+}
+
+function mapNodeToEditor(node) {
+  return {
+    body: node.message ?? '',
+    responses: Array.isArray(node.response)
+      ? node.response.map(mapResponseToEditor)
+      : [],
+  };
+}
+
+/**
+ * Convert a live comms array (TOML shape) to the editor's normalized tree.
+ *
+ * @param {Array<object>|undefined|null} commsArray
+ * @returns {Array<object>} editor templates
+ */
+export function worldCommsToEditor(commsArray) {
+  if (!Array.isArray(commsArray)) return [];
+  return commsArray.map((tpl) => {
+    const trigger = { kind: tpl.trigger ?? '' };
+    if (tpl.entity !== undefined && tpl.entity !== null) {
+      trigger.entity = tpl.entity;
+    }
+    return {
+      from: tpl.from ?? '',
+      trigger,
+      node: {
+        body: tpl.message ?? '',
+        responses: Array.isArray(tpl.response)
+          ? tpl.response.map(mapResponseToEditor)
+          : [],
+      },
+    };
+  });
+}
+
+function mapResponseToWorld(resp) {
+  const out = { text: resp.text ?? '' };
+  if (Array.isArray(resp.actions) && resp.actions.length > 0) {
+    out.action = deepClone(resp.actions);
+  }
+  if (resp.follow_up && typeof resp.follow_up === 'object') {
+    out.follow_up = mapNodeToWorld(resp.follow_up);
+  }
+  return out;
+}
+
+function mapNodeToWorld(node) {
+  const out = { message: node.body ?? '' };
+  if (Array.isArray(node.responses) && node.responses.length > 0) {
+    out.response = node.responses.map(mapResponseToWorld);
+  }
+  return out;
+}
+
+/**
+ * Convert editor templates back to the live TOML comms array.
+ *
+ * @param {Array<object>} editorTemplates
+ * @returns {Array<object>} live comms array
+ */
+export function editorCommsToWorld(editorTemplates) {
+  if (!Array.isArray(editorTemplates)) return [];
+  return editorTemplates.map((tpl) => {
+    const out = {
+      from: tpl.from ?? '',
+      trigger: tpl.trigger?.kind ?? '',
+      message: tpl.node?.body ?? '',
+    };
+    if (tpl.trigger?.entity !== undefined && tpl.trigger.entity !== null) {
+      out.entity = tpl.trigger.entity;
+    }
+    if (Array.isArray(tpl.node?.responses) && tpl.node.responses.length > 0) {
+      out.response = tpl.node.responses.map(mapResponseToWorld);
+    }
+    return out;
+  });
+}

--- a/editor/comms-view.js
+++ b/editor/comms-view.js
@@ -1,0 +1,412 @@
+/**
+ * comms-view.js
+ *
+ * Renders the comms-template editor inside the right-hand properties pane.
+ *
+ * Structure (mirrors `trigger-view.js`):
+ *   - Header:
+ *       * `from` text input
+ *       * `trigger` <select> (on_attacked | on_destroyed | on_hailed —
+ *         on_timer is intentionally absent because RawCommsEntry in
+ *         `src/world/config.rs` does not model after_secs for comms; see
+ *         the pre-flight finding documented in Slice 4b).
+ *       * Entity picker (via shared `renderEntitySelect`)
+ *   - Body: <textarea> for the node body
+ *   - Responses list: each `.response-card` with text input + action-card
+ *     list (`renderActionCard`) + "Add Action" composer + "Add Follow-Up
+ *     Node" button. If `follow_up` exists, render an inner mini-editor
+ *     (recursive walk via `nodePath`).
+ *
+ * All mutations honour the snapshot-BEFORE-mutate contract via
+ * `snapshotForUndo(layer)`. After each mutation the editor calls
+ * `editorCommsToWorld` to write back into `layer.toml.comms`, marks
+ * `layer.isDirty = true`, calls `canvasManager.renderAll()`, and
+ * re-renders the panel.
+ */
+
+import { ACTION_SCHEMA } from './action-schema.js';
+import { renderActionCard } from './action-card-view.js';
+import { snapshotForUndo } from './undo-controller.js';
+import { renderEntitySelect } from './entity-select-view.js';
+import { worldCommsToEditor, editorCommsToWorld } from './comms-adapter.js';
+import { buildDefaultAction } from './trigger-view.js';
+import { CommsEditor } from './comms-editor.js';
+
+// `on_timer` is omitted here — comms templates cannot use it (see
+// pre-flight finding in the Slice 4b commit log).
+const COMMS_TRIGGER_KINDS = ['on_attacked', 'on_destroyed', 'on_hailed'];
+
+/**
+ * Render the comms template editor.
+ *
+ * @param {HTMLElement} host
+ * @param {object} selection  { type:'comms', commsIndex, layer }
+ * @param {object} deps
+ * @param {Array<{path,worldState}>} deps.allLayers
+ * @param {object} deps.canvasManager
+ * @param {object} [deps.layerManager]
+ */
+export function renderCommsPanel(host, selection, deps) {
+  const layer = selection.layer;
+  const idx = selection.commsIndex;
+
+  if (!layer || !layer.toml) {
+    host.innerHTML = '<p class="placeholder">Comms template no longer exists</p>';
+    return;
+  }
+  if (!Array.isArray(layer.toml.comms)) {
+    host.innerHTML = '<p class="placeholder">No comms templates in this layer</p>';
+    return;
+  }
+  const tomlTemplate = layer.toml.comms[idx];
+  if (!tomlTemplate) {
+    host.innerHTML = '<p class="placeholder">Comms template no longer exists</p>';
+    return;
+  }
+
+  // Load the editor model from the live TOML each render so we always see
+  // the freshest data after a re-render or undo.
+  const editor = new CommsEditor();
+  editor.load(worldCommsToEditor(layer.toml.comms));
+
+  const rerender = () => renderCommsPanel(host, selection, deps);
+
+  // Apply current editor templates back to layer.toml.comms.
+  const writeback = () => {
+    layer.toml.comms = editorCommsToWorld(editor.getTemplates());
+    layer.isDirty = true;
+    if (typeof deps.canvasManager?.renderAll === 'function') {
+      deps.canvasManager.renderAll();
+    }
+  };
+
+  // Convenience: snapshot → editor mutator → writeback → rerender.
+  const mutate = (fn) => {
+    snapshotForUndo(layer);
+    fn();
+    writeback();
+    rerender();
+  };
+
+  host.innerHTML = '';
+
+  const panel = document.createElement('div');
+  panel.className = 'comms-panel';
+
+  // ── Header ────────────────────────────────────────────────────────────
+  const h4 = document.createElement('h4');
+  h4.textContent = 'Comms Template';
+  panel.appendChild(h4);
+
+  const headerWrap = document.createElement('div');
+  headerWrap.className = 'comms-trigger-header';
+  panel.appendChild(headerWrap);
+
+  // From.
+  headerWrap.appendChild(makeFromRow(editor, idx, mutate));
+
+  // Trigger kind.
+  headerWrap.appendChild(makeTriggerKindRow(editor, idx, mutate));
+
+  // Entity (always shown for the three supported triggers).
+  headerWrap.appendChild(makeEntityRow(editor, idx, deps, mutate));
+
+  // ── Body ──────────────────────────────────────────────────────────────
+  const bodyH4 = document.createElement('h4');
+  bodyH4.textContent = 'Prompt';
+  panel.appendChild(bodyH4);
+
+  panel.appendChild(makeBodyRow(editor, idx, [], mutate));
+
+  // ── Responses (recursive walk via nodePath) ───────────────────────────
+  const responsesH4 = document.createElement('h4');
+  responsesH4.textContent = 'Responses';
+  panel.appendChild(responsesH4);
+
+  panel.appendChild(renderResponsesForNode(editor, idx, [], deps, mutate));
+
+  host.appendChild(panel);
+}
+
+// ── Header rows ─────────────────────────────────────────────────────────
+
+function makeFromRow(editor, idx, mutate) {
+  const group = document.createElement('div');
+  group.className = 'property-group';
+
+  const label = document.createElement('label');
+  label.textContent = 'From:';
+  group.appendChild(label);
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.id = 'commsFrom';
+  const tpl = editor.getTemplates()[idx];
+  input.value = tpl?.from ?? '';
+  input.addEventListener('input', (e) => {
+    mutate(() => editor.setTemplateField(idx, 'from', e.target.value));
+  });
+  group.appendChild(input);
+  return group;
+}
+
+function makeTriggerKindRow(editor, idx, mutate) {
+  const group = document.createElement('div');
+  group.className = 'property-group';
+
+  const label = document.createElement('label');
+  label.textContent = 'Trigger:';
+  group.appendChild(label);
+
+  const select = document.createElement('select');
+  select.id = 'commsTriggerKind';
+  for (const k of COMMS_TRIGGER_KINDS) {
+    const opt = document.createElement('option');
+    opt.value = k;
+    opt.textContent = k;
+    select.appendChild(opt);
+  }
+
+  const tpl = editor.getTemplates()[idx];
+  const current = tpl?.trigger?.kind ?? '';
+  if (current && !COMMS_TRIGGER_KINDS.includes(current)) {
+    const opt = document.createElement('option');
+    opt.value = current;
+    opt.textContent = `${current} (unknown)`;
+    select.appendChild(opt);
+  }
+  select.value = current || COMMS_TRIGGER_KINDS[0];
+  select.addEventListener('change', (e) => {
+    mutate(() => editor.setTemplateField(idx, 'trigger.kind', e.target.value));
+  });
+  group.appendChild(select);
+  return group;
+}
+
+function makeEntityRow(editor, idx, deps, mutate) {
+  const group = document.createElement('div');
+  group.className = 'property-group';
+
+  const label = document.createElement('label');
+  label.textContent = 'Entity:';
+  group.appendChild(label);
+
+  const tpl = editor.getTemplates()[idx];
+  const value = tpl?.trigger?.entity ?? '';
+
+  renderEntitySelect(
+    group,
+    value,
+    deps.allLayers || [],
+    (newValue) => {
+      mutate(() => editor.setTemplateField(idx, 'trigger.entity', newValue || ''));
+    },
+  );
+  return group;
+}
+
+// ── Body row ────────────────────────────────────────────────────────────
+
+function makeBodyRow(editor, templateIdx, nodePath, mutate) {
+  const group = document.createElement('div');
+  group.className = 'property-group';
+
+  const ta = document.createElement('textarea');
+  ta.className = 'comms-body-input';
+  ta.rows = 3;
+  const node = editor.getNode(templateIdx, nodePath);
+  ta.value = node?.body ?? '';
+  ta.addEventListener('input', (e) => {
+    mutate(() => editor.setNodeBody(templateIdx, nodePath, e.target.value));
+  });
+  group.appendChild(ta);
+  return group;
+}
+
+// ── Responses (recursive) ───────────────────────────────────────────────
+
+function renderResponsesForNode(editor, templateIdx, nodePath, deps, mutate) {
+  const wrap = document.createElement('div');
+  wrap.className = 'response-list';
+
+  const node = editor.getNode(templateIdx, nodePath) || { responses: [] };
+  const responses = node.responses || [];
+
+  responses.forEach((resp, respIdx) => {
+    wrap.appendChild(
+      renderResponseCard(editor, templateIdx, nodePath, respIdx, resp, deps, mutate),
+    );
+  });
+
+  // + Add Response button.
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.className = 'btn-add-response';
+  addBtn.textContent = '+ Add Response';
+  addBtn.addEventListener('click', () => {
+    mutate(() => editor.addResponse(templateIdx, nodePath));
+  });
+  wrap.appendChild(addBtn);
+
+  return wrap;
+}
+
+function renderResponseCard(editor, templateIdx, nodePath, respIdx, resp, deps, mutate) {
+  const card = document.createElement('div');
+  card.className = 'response-card';
+
+  // ── Header: text + remove ─────────────────────────────────────────────
+  const header = document.createElement('div');
+  header.className = 'response-card-header';
+
+  const textInput = document.createElement('input');
+  textInput.type = 'text';
+  textInput.className = 'response-text-input';
+  textInput.placeholder = 'Player response text…';
+  textInput.value = resp.text ?? '';
+  textInput.addEventListener('input', (e) => {
+    mutate(() => editor.setResponseText(templateIdx, nodePath, respIdx, e.target.value));
+  });
+  header.appendChild(textInput);
+
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'btn-icon';
+  removeBtn.dataset.action = 'remove';
+  removeBtn.textContent = '✕';
+  removeBtn.addEventListener('click', () => {
+    mutate(() => editor.removeResponse(templateIdx, nodePath, respIdx));
+  });
+  header.appendChild(removeBtn);
+
+  card.appendChild(header);
+
+  // ── Actions list ──────────────────────────────────────────────────────
+  const actionsLabel = document.createElement('div');
+  actionsLabel.className = 'response-section-label';
+  actionsLabel.textContent = 'Actions';
+  card.appendChild(actionsLabel);
+
+  const actionsHost = document.createElement('div');
+  actionsHost.className = 'response-actions';
+  card.appendChild(actionsHost);
+
+  const actions = Array.isArray(resp.actions) ? resp.actions : [];
+  const layer = nearestLayer(deps);
+  actions.forEach((action, actionIdx) => {
+    renderActionCard(actionsHost, action, {
+      worldState: layer?.toml || {},
+      allLayers: deps.allLayers || [],
+      onChange: (updated) => {
+        mutate(() => {
+          editor.removeResponseAction(templateIdx, nodePath, respIdx, actionIdx);
+          // re-insert at same position to preserve order.
+          const node = editor._resolveNode(templateIdx, nodePath);
+          if (node?.responses?.[respIdx]) {
+            node.responses[respIdx].actions.splice(actionIdx, 0, { ...updated });
+          }
+        });
+      },
+      onMove: (direction) => {
+        mutate(() => {
+          const node = editor._resolveNode(templateIdx, nodePath);
+          if (!node?.responses?.[respIdx]?.actions) return;
+          const arr = node.responses[respIdx].actions;
+          const j = direction === 'up' ? actionIdx - 1 : actionIdx + 1;
+          if (j < 0 || j >= arr.length) return;
+          [arr[actionIdx], arr[j]] = [arr[j], arr[actionIdx]];
+        });
+      },
+      onRemove: () => {
+        mutate(() => editor.removeResponseAction(templateIdx, nodePath, respIdx, actionIdx));
+      },
+      openFilePicker: deps.openFilePicker,
+    });
+  });
+
+  // ── + Add Action composer ─────────────────────────────────────────────
+  const addActionRow = document.createElement('div');
+  addActionRow.className = 'action-add-row';
+
+  const select = document.createElement('select');
+  select.className = 'newCommsActionType';
+  for (const key of Object.keys(ACTION_SCHEMA)) {
+    const opt = document.createElement('option');
+    opt.value = key;
+    opt.textContent = ACTION_SCHEMA[key].label;
+    select.appendChild(opt);
+  }
+  addActionRow.appendChild(select);
+
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.className = 'btn-add-comms-action';
+  addBtn.textContent = '+ Add Action';
+  addBtn.addEventListener('click', () => {
+    const type = select.value;
+    const action = buildDefaultAction(type);
+    if (!action) return;
+    mutate(() => editor.addResponseAction(templateIdx, nodePath, respIdx, action));
+  });
+  addActionRow.appendChild(addBtn);
+  card.appendChild(addActionRow);
+
+  // ── Follow-up ─────────────────────────────────────────────────────────
+  if (!resp.follow_up) {
+    const addFollowBtn = document.createElement('button');
+    addFollowBtn.type = 'button';
+    addFollowBtn.className = 'btn-add-follow-up';
+    addFollowBtn.textContent = '+ Add Follow-Up Node';
+    addFollowBtn.addEventListener('click', () => {
+      mutate(() => editor.addFollowUp(templateIdx, nodePath, respIdx));
+    });
+    card.appendChild(addFollowBtn);
+  } else {
+    const followWrap = document.createElement('div');
+    followWrap.className = 'follow-up-node';
+
+    const followHeader = document.createElement('div');
+    followHeader.className = 'follow-up-header';
+    const followLabel = document.createElement('span');
+    followLabel.textContent = '↳ Follow-Up Node';
+    followHeader.appendChild(followLabel);
+    const removeFollowBtn = document.createElement('button');
+    removeFollowBtn.type = 'button';
+    removeFollowBtn.className = 'btn-icon';
+    removeFollowBtn.textContent = '✕';
+    removeFollowBtn.addEventListener('click', () => {
+      mutate(() => editor.removeFollowUp(templateIdx, nodePath, respIdx));
+    });
+    followHeader.appendChild(removeFollowBtn);
+    followWrap.appendChild(followHeader);
+
+    const childPath = [...nodePath, respIdx];
+
+    followWrap.appendChild(makeBodyRow(editor, templateIdx, childPath, mutate));
+
+    const innerResponsesLabel = document.createElement('div');
+    innerResponsesLabel.className = 'response-section-label';
+    innerResponsesLabel.textContent = 'Responses';
+    followWrap.appendChild(innerResponsesLabel);
+
+    followWrap.appendChild(
+      renderResponsesForNode(editor, templateIdx, childPath, deps, mutate),
+    );
+
+    card.appendChild(followWrap);
+  }
+
+  return card;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function nearestLayer(deps) {
+  // The trigger panel uses the active layer's `toml` as the `worldState`
+  // for picker context. Comms editor: use the selection's layer (passed
+  // through deps when sidebar.js forwards layerManager).
+  if (deps.layerManager?.getActiveLayer) {
+    return deps.layerManager.getActiveLayer();
+  }
+  return null;
+}

--- a/editor/entity-select-view.js
+++ b/editor/entity-select-view.js
@@ -1,0 +1,91 @@
+/**
+ * entity-select-view.js
+ *
+ * Shared helper that renders the entity-name `<select>` dropdown used by
+ * action cards (`action-card-view.js`), trigger headers (`trigger-view.js`),
+ * and comms templates (`comms-view.js`).
+ *
+ * Behaviour:
+ *   - Options sourced via `getEntityNameOptions(allLayers)`.
+ *   - Deduplication key is `value + ':' + (layerPath || '')` — NOT bare
+ *     `value`. This preserves multiple `<option>` entries when the same
+ *     entity name appears in more than one open layer (collision-suffix
+ *     labels stay visible).
+ *   - `<option>.value` is the bare `name` (the wire format). Only
+ *     `option.textContent` carries the collision-suffixed label.
+ *   - Unknown-name warning: if the saved value is non-empty and not in any
+ *     option, a `(value) ⚠ unknown` option is appended and a sibling
+ *     `<span class="action-field-warning">⚠ unknown</span>` is rendered.
+ */
+
+import { getEntityNameOptions } from './trigger-pickers.js';
+
+/**
+ * Render an entity-name dropdown into `host`.
+ *
+ * @param {HTMLElement} host          Container to append into.
+ * @param {string|null|undefined} value  Current saved entity name.
+ * @param {Array<{path:string, worldState:object}>} allLayers
+ * @param {(newValue: string) => void} onChange  Called with the new value
+ *                                                whenever the `<select>` fires
+ *                                                a `change` event.
+ * @param {object} [opts]
+ * @param {boolean} [opts.includeNone=true]  Prepend a `(none)` placeholder.
+ * @returns {HTMLElement} The wrapper span (also already appended to host).
+ */
+export function renderEntitySelect(host, value, allLayers, onChange, opts = {}) {
+  const includeNone = opts.includeNone !== false;
+
+  const wrap = document.createElement('span');
+  wrap.style.display = 'flex';
+  wrap.style.gap = '6px';
+  wrap.style.flex = '1';
+
+  const select = document.createElement('select');
+
+  if (includeNone) {
+    const empty = document.createElement('option');
+    empty.value = '';
+    empty.textContent = '(none)';
+    select.appendChild(empty);
+  }
+
+  const opts2 = getEntityNameOptions(allLayers || []);
+  const seenKeys = new Set();
+  const knownValues = new Set();
+  for (const o of opts2) {
+    const key = `${o.value}:${o.layerPath || ''}`;
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    knownValues.add(o.value);
+    const opt = document.createElement('option');
+    opt.value = o.value;
+    opt.textContent = o.label;
+    select.appendChild(opt);
+  }
+
+  const isUnknown = value != null && value !== '' && !knownValues.has(value);
+  if (isUnknown) {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = `${value} ⚠ unknown`;
+    select.appendChild(opt);
+  }
+
+  select.value = value ?? '';
+
+  select.addEventListener('change', (e) => {
+    if (typeof onChange === 'function') onChange(e.target.value);
+  });
+  wrap.appendChild(select);
+
+  if (isUnknown) {
+    const warn = document.createElement('span');
+    warn.className = 'action-field-warning';
+    warn.textContent = '⚠ unknown';
+    wrap.appendChild(warn);
+  }
+
+  host.appendChild(wrap);
+  return wrap;
+}

--- a/editor/layers.js
+++ b/editor/layers.js
@@ -44,6 +44,39 @@ export class LayerManager {
     }
   }
 
+  /**
+   * Add a layer whose TOML has already been parsed in-memory (e.g. a
+   * session-only "triggerable world" loaded via the side panel, with no
+   * dedicated `FileSystemFileHandle`). The layer is appended and becomes
+   * the active layer, matching `addLayer` behaviour.
+   *
+   * @param {string} filename — root-relative path used as the layer's id.
+   * @param {object} parsedToml — already-parsed TOML object.
+   * @param {object} [opts]
+   * @param {boolean} [opts.sessionOnly=false] — when true, marks the
+   *   layer with `_sessionOnly: true` so `SaveFlow.getDirtyFiles()` skips
+   *   it (the session loader has no write surface for these).
+   * @returns {object} the new layer
+   */
+  addInMemoryLayer(filename, parsedToml, opts = {}) {
+    const sessionOnly = !!opts.sessionOnly;
+    const layer = {
+      fileHandle: null,
+      filename,
+      toml: parsedToml,
+      kind: inferLayerKind(parsedToml),
+      visible: true,
+      active: false,
+      konvaLayer: null,
+      originalText: null,
+      isDirty: false,
+      _sessionOnly: sessionOnly,
+    };
+    this.layers.push(layer);
+    this.activeLayer = layer;
+    return layer;
+  }
+
   removeLayer(layer) {
     const idx = this.layers.indexOf(layer);
     if (idx !== -1) {

--- a/editor/new-world-dialog.js
+++ b/editor/new-world-dialog.js
@@ -1,0 +1,122 @@
+/**
+ * new-world-dialog.js
+ *
+ * Mounts a "+ New World" button next to `#addLayerBtn`. On click:
+ *   1. prompt() for a filename (default "new_world.toml").
+ *   2. Derive `assets/worlds/<name>`.
+ *   3. validateNewWorldPath against the existing paths set.
+ *   4. prepareNewWorld(path) → { content, parsedContent }.
+ *   5. writeFile(path, content).
+ *   6. Push the layer onto layerManager (mirroring app.js layer shape).
+ *   7. Invoke onCreated() so the host can renderAll().
+ */
+
+import {
+  validateNewWorldPath,
+  prepareNewWorld,
+  getDefaultNewWorldPath,
+} from './new-world.js';
+import { inferLayerKind } from './layers.js';
+
+/**
+ * Mount the "+ New World" button.
+ *
+ * @param {object} deps
+ * @param {object} deps.layerManager
+ * @param {(path:string, content:string) => Promise<void>} deps.writeFile
+ * @param {(text:string) => object} [deps.tomlParse]  Falls back to window.tomlParse.
+ * @param {() => void} deps.onCreated
+ * @param {() => string[]} [deps.getExistingPaths]
+ * @param {string} [deps.buttonId='newWorldBtn']
+ * @param {string} [deps.siblingId='addLayerBtn']
+ * @returns {HTMLButtonElement|null} the mounted button, or null when DOM
+ *   structure is missing.
+ */
+export function mountNewWorldButton(deps) {
+  const buttonId = deps.buttonId || 'newWorldBtn';
+  const siblingId = deps.siblingId || 'addLayerBtn';
+
+  let btn = document.getElementById(buttonId);
+
+  // If the editor.html template already provides the button, reuse it.
+  // Otherwise create + insert it next to addLayerBtn for runtime back-compat
+  // with older template snapshots.
+  if (!btn) {
+    const sibling = document.getElementById(siblingId);
+    if (!sibling) return null;
+    btn = document.createElement('button');
+    btn.id = buttonId;
+    btn.type = 'button';
+    btn.textContent = '+ New World';
+    sibling.parentElement?.appendChild(btn);
+  }
+
+  btn.addEventListener('click', () => handleClick(deps));
+  return btn;
+}
+
+async function handleClick(deps) {
+  const defaultPath = getDefaultNewWorldPath();
+  const defaultName = defaultPath.replace(/^assets\/worlds\//, '');
+  const promptFn = typeof window !== 'undefined' ? window.prompt : null;
+  const alertFn  = typeof window !== 'undefined' ? window.alert  : null;
+  if (typeof promptFn !== 'function') return;
+
+  const raw = promptFn('World filename:', defaultName);
+  if (raw == null) return;
+  const trimmed = String(raw).trim();
+  if (!trimmed) return;
+
+  // Allow either a bare filename or an explicit assets/worlds/ prefix.
+  const path = trimmed.startsWith('assets/worlds/')
+    ? trimmed
+    : `assets/worlds/${trimmed}`;
+
+  const existing = typeof deps.getExistingPaths === 'function'
+    ? (deps.getExistingPaths() || [])
+    : deps.layerManager.getLayers().map((l) => l.filename);
+
+  const validation = validateNewWorldPath(path, existing);
+  if (!validation.ok) {
+    if (typeof alertFn === 'function') alertFn(validation.error);
+    return;
+  }
+
+  const prepared = prepareNewWorld(path);
+  if (!prepared.ok) {
+    if (typeof alertFn === 'function') alertFn(prepared.error);
+    return;
+  }
+
+  try {
+    await deps.writeFile(path, prepared.content);
+  } catch (err) {
+    if (typeof alertFn === 'function') alertFn(`Write failed: ${err?.message || err}`);
+    return;
+  }
+
+  // Re-parse with the host's tomlParse (smol-toml) for consistency with
+  // the rest of the app. Falls back to the structure prepareNewWorld
+  // produced via parseWorldToml.
+  const parser = deps.tomlParse || (typeof window !== 'undefined' ? window.tomlParse : null);
+  let parsed = prepared.parsedContent;
+  if (typeof parser === 'function') {
+    try { parsed = parser(prepared.content); } catch { /* fall through */ }
+  }
+
+  const layer = {
+    fileHandle: null,
+    filename: path,
+    toml: parsed,
+    kind: inferLayerKind(parsed),
+    visible: true,
+    active: true,
+    konvaLayer: null,
+    originalText: prepared.content,
+    isDirty: false,
+  };
+  deps.layerManager.layers.push(layer);
+  deps.layerManager.activeLayer = layer;
+
+  if (typeof deps.onCreated === 'function') deps.onCreated();
+}

--- a/editor/save-flow.js
+++ b/editor/save-flow.js
@@ -17,6 +17,24 @@ export class SaveFlow {
     this._writeFile = writeFile || (async () => {});
     this._invalidationBus = invalidationBus || null;
     this._contentCache = {};
+    /**
+     * Optional predicate keyed by `${mode}:${path}` returning true if the
+     * file should be EXCLUDED from getDirtyFiles (and therefore from
+     * Save All). Wired by Slice 4b for session-only triggerable-world
+     * layers — see `LayerManager.addInMemoryLayer({ sessionOnly: true })`.
+     * Set via `setSessionOnlyChecker`.
+     */
+    this._isSessionOnly = null;
+  }
+
+  /**
+   * Register a predicate `(mode, path) => boolean` that returns true for
+   * files which should be excluded from getDirtyFiles. Used so the
+   * Triggerable-Worlds panel can layer session-only worlds without
+   * Save All trying to write them back (they have no FSA handle).
+   */
+  setSessionOnlyChecker(fn) {
+    this._isSessionOnly = typeof fn === 'function' ? fn : null;
   }
 
   setContent(mode, filePath, parsedContent) {
@@ -108,6 +126,7 @@ export class SaveFlow {
       const files = this._modeShell.getOpenFiles(mode);
       if (!files) continue;
       for (const file of files) {
+        if (this._isSessionOnly && this._isSessionOnly(mode, file)) continue;
         if (this._modeShell.isDirty(mode, file)) {
           result.push({ mode, path: file });
         }

--- a/editor/sidebar.js
+++ b/editor/sidebar.js
@@ -2,6 +2,7 @@ import { getSpawnName, getSpawnPosition, getEntityPath, getRelativeInfo, setSpaw
 import { getSpawnsFromAllLayers } from './toml-utils.js';
 import { snapshotForUndo } from './undo-controller.js';
 import { renderOverridePanel } from './override-view.js';
+import { renderTriggerPanel } from './trigger-view.js';
 
 export class PropertiesPanel {
   constructor(canvasManager, layerManager) {
@@ -12,14 +13,58 @@ export class PropertiesPanel {
     this.currentLayer = null;
   }
 
-  render(spawn, layer) {
-    this.currentSpawn = spawn;
-    this.currentLayer = layer;
+  /**
+   * Render the properties pane for the given selection.
+   *
+   * Accepts either the new discriminated-union form (`render(selection)`)
+   * or the legacy `(spawn, layer)` signature used by Slice 1-3 callers.
+   */
+  render(selectionOrSpawn, layer) {
+    const selection = this._coerceSelection(selectionOrSpawn, layer);
 
-    if (!spawn || !layer) {
+    if (!selection || selection.type === null) {
+      this.currentSpawn = null;
+      this.currentLayer = null;
       this.container.innerHTML = '<p class="placeholder">Select a spawn to edit properties</p>';
       return;
     }
+
+    if (selection.type === 'trigger') {
+      this.currentSpawn = null;
+      this.currentLayer = selection.layer ?? null;
+      this.container.innerHTML = '';
+      renderTriggerPanel(this.container, selection, {
+        allLayers: this.canvasManager.buildV2Layers(),
+        canvasManager: this.canvasManager,
+        layerManager: this.layerManager,
+      });
+      return;
+    }
+
+    if (selection.type === 'comms') {
+      this.currentSpawn = null;
+      this.currentLayer = selection.layer ?? null;
+      this.container.innerHTML = '<p class="placeholder">Comms editor coming in Slice 4b</p>';
+      return;
+    }
+
+    // selection.type === 'spawn' — existing V1 form + override panel.
+    this._renderSpawn(selection.spawn, selection.layer);
+  }
+
+  _coerceSelection(selectionOrSpawn, layer) {
+    if (selectionOrSpawn && typeof selectionOrSpawn === 'object' && 'type' in selectionOrSpawn) {
+      return selectionOrSpawn;
+    }
+    if (!selectionOrSpawn || !layer) {
+      return { type: null };
+    }
+    return { type: 'spawn', spawn: selectionOrSpawn, layer };
+  }
+
+  _renderSpawn(spawn, layer) {
+    this.currentSpawn = spawn;
+    this.currentLayer = layer;
 
     const name = getSpawnName(spawn);
     const entityPath = getEntityPath(spawn);

--- a/editor/sidebar.js
+++ b/editor/sidebar.js
@@ -3,6 +3,7 @@ import { getSpawnsFromAllLayers } from './toml-utils.js';
 import { snapshotForUndo } from './undo-controller.js';
 import { renderOverridePanel } from './override-view.js';
 import { renderTriggerPanel } from './trigger-view.js';
+import { renderCommsPanel } from './comms-view.js';
 
 export class PropertiesPanel {
   constructor(canvasManager, layerManager) {
@@ -44,7 +45,12 @@ export class PropertiesPanel {
     if (selection.type === 'comms') {
       this.currentSpawn = null;
       this.currentLayer = selection.layer ?? null;
-      this.container.innerHTML = '<p class="placeholder">Comms editor coming in Slice 4b</p>';
+      this.container.innerHTML = '';
+      renderCommsPanel(this.container, selection, {
+        allLayers: this.canvasManager.buildV2Layers(),
+        canvasManager: this.canvasManager,
+        layerManager: this.layerManager,
+      });
       return;
     }
 

--- a/editor/style.css
+++ b/editor/style.css
@@ -1209,3 +1209,19 @@ form {
   color: #666;
   font-style: italic;
 }
+
+/* -- Slice 4a: trigger + action-card editor ------------------------ */
+.action-card { background:#1e1f24; border:1px solid #2c2f36; border-radius:4px; padding:8px; margin-bottom:8px; }
+.action-card-header { display:flex; justify-content:space-between; align-items:center; }
+.action-card-title { font-weight:bold; }
+.action-card-controls { display:flex; gap:4px; }
+.action-card-body { display:flex; flex-direction:column; gap:6px; margin-top:6px; }
+.action-field { display:flex; align-items:center; gap:6px; }
+.action-field label { min-width:80px; color:#aaa; font-size:12px; }
+.action-field input, .action-field select, .action-field textarea { flex:1; }
+.action-field-warning { color:#f55; font-size:12px; }
+.action-field-hint { color:#888; font-style:italic; font-size:12px; }
+.btn-icon { background:none; border:none; color:#aaa; cursor:pointer; font-size:14px; padding:2px 4px; }
+.btn-icon:hover { color:#fff; }
+.action-add-row { display:flex; gap:6px; margin-top:8px; }
+.trigger-panel h4 { color:#aaa; font-size:11px; text-transform:uppercase; margin:12px 0 6px 0; }

--- a/editor/style.css
+++ b/editor/style.css
@@ -1225,3 +1225,57 @@ form {
 .btn-icon:hover { color:#fff; }
 .action-add-row { display:flex; gap:6px; margin-top:8px; }
 .trigger-panel h4 { color:#aaa; font-size:11px; text-transform:uppercase; margin:12px 0 6px 0; }
+
+/* -- Slice 4b: comms editor + triggerable worlds + new world ------- */
+.comms-panel h4 { color:#aaa; font-size:11px; text-transform:uppercase; margin:12px 0 6px 0; }
+.comms-trigger-header { display:flex; flex-direction:column; gap:6px; margin-bottom:8px; }
+.comms-body-input { width:100%; resize:vertical; font-family:inherit; font-size:13px; }
+
+.response-card {
+  background:#1e1f24;
+  border:1px solid #2c2f36;
+  border-radius:4px;
+  padding:8px;
+  margin-bottom:8px;
+}
+.response-card-header { display:flex; gap:6px; align-items:center; margin-bottom:6px; }
+.response-text-input { flex:1; }
+.response-section-label { color:#aaa; font-size:11px; text-transform:uppercase; margin:6px 0 4px 0; }
+.response-actions { display:flex; flex-direction:column; gap:4px; }
+.btn-add-response, .btn-add-comms-action, .btn-add-follow-up {
+  background:#2c2f36; border:1px solid #3a3d44; color:#ccc;
+  padding:4px 10px; border-radius:3px; cursor:pointer; font-size:12px;
+  margin-top:6px;
+}
+.btn-add-response:hover, .btn-add-comms-action:hover, .btn-add-follow-up:hover { background:#3a3d44; }
+.follow-up-node {
+  border-left:2px solid #3a3d44;
+  margin-left:8px;
+  margin-top:8px;
+  padding:6px 8px;
+  background:#1a1b1f;
+}
+.follow-up-header { display:flex; justify-content:space-between; align-items:center; color:#aaa; font-size:12px; margin-bottom:4px; }
+
+#triggerableWorldsSection { margin-bottom:12px; }
+#triggerableWorldsList { display:flex; flex-direction:column; gap:4px; }
+.triggerable-world-row {
+  display:flex; align-items:center; gap:6px;
+  padding:4px 6px; background:#1e1f24; border:1px solid #2c2f36;
+  border-radius:3px; font-size:12px;
+}
+.triggerable-world-path { flex:1; color:#ccc; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.btn-toggle-world {
+  background:#2c2f36; border:1px solid #3a3d44; color:#ccc;
+  padding:2px 8px; border-radius:3px; cursor:pointer; font-size:11px;
+}
+.btn-toggle-world:hover:not(:disabled) { background:#3a3d44; }
+.btn-toggle-world:disabled { opacity:0.5; cursor:default; }
+.badge {
+  font-size:10px; padding:1px 6px; border-radius:8px;
+  background:#3a3d44; color:#ccc; text-transform:uppercase;
+}
+.badge-session { background:#2d5a2d; color:#cfe6cf; }
+.badge-open { background:#3a3d44; color:#aaa; }
+.badge-referenced { background:#3a2d5a; color:#cfcfe6; }
+

--- a/editor/tests/comms-adapter.test.js
+++ b/editor/tests/comms-adapter.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { worldCommsToEditor, editorCommsToWorld } from '../comms-adapter.js';
+
+// Fixture mirroring the comms section of assets/worlds/default.toml.
+function defaultCommsFixture() {
+  return [
+    {
+      from: 'raider_alpha',
+      trigger: 'on_attacked',
+      entity: 'raider_alpha',
+      message: 'MAYDAY MAYDAY — Pirate raider calling for backup.',
+    },
+    {
+      from: 'Starbase Alpha',
+      trigger: 'on_attacked',
+      entity: 'Starbase Alpha',
+      message: 'Starbase Alpha to all vessels — we are under attack!',
+    },
+    {
+      from: 'Starbase Alpha',
+      trigger: 'on_hailed',
+      entity: 'Starbase Alpha',
+      message: 'USS Phoenix, this is Starbase Alpha. Please state your business.',
+      response: [
+        {
+          text: 'We are on a survey mission.',
+          action: [
+            {
+              type: 'add_objective',
+              id: 'obj-survey',
+              text: 'Complete the survey in this sector.',
+            },
+          ],
+        },
+        {
+          text: 'We require docking clearance.',
+          action: [
+            {
+              type: 'add_objective',
+              id: 'obj-dock',
+              text: 'Dock at Starbase Alpha.',
+              mandatory: true,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+describe('comms-adapter', () => {
+  it('worldCommsToEditor on empty / missing input returns empty array', () => {
+    expect(worldCommsToEditor(undefined)).toEqual([]);
+    expect(worldCommsToEditor(null)).toEqual([]);
+    expect(worldCommsToEditor([])).toEqual([]);
+  });
+
+  it('editorCommsToWorld on empty input returns empty array', () => {
+    expect(editorCommsToWorld(undefined)).toEqual([]);
+    expect(editorCommsToWorld([])).toEqual([]);
+  });
+
+  it('worldCommsToEditor maps message→node.body and trigger→{kind, entity}', () => {
+    const editor = worldCommsToEditor(defaultCommsFixture());
+
+    expect(editor).toHaveLength(3);
+    expect(editor[0].from).toBe('raider_alpha');
+    expect(editor[0].trigger.kind).toBe('on_attacked');
+    expect(editor[0].trigger.entity).toBe('raider_alpha');
+    expect(editor[0].node.body).toBe(
+      'MAYDAY MAYDAY — Pirate raider calling for backup.',
+    );
+    expect(editor[0].node.responses).toEqual([]);
+  });
+
+  it('worldCommsToEditor maps response[].action → responses[].actions', () => {
+    const editor = worldCommsToEditor(defaultCommsFixture());
+    const hail = editor[2];
+
+    expect(hail.trigger.kind).toBe('on_hailed');
+    expect(hail.node.responses).toHaveLength(2);
+    expect(hail.node.responses[0].text).toBe('We are on a survey mission.');
+    expect(hail.node.responses[0].actions).toEqual([
+      {
+        type: 'add_objective',
+        id: 'obj-survey',
+        text: 'Complete the survey in this sector.',
+      },
+    ]);
+    expect(hail.node.responses[0].follow_up).toBeUndefined();
+  });
+
+  it('round-trips default.toml comms: editorCommsToWorld(worldCommsToEditor(x)) ≈ x', () => {
+    const original = defaultCommsFixture();
+    const round = editorCommsToWorld(worldCommsToEditor(original));
+    expect(round).toEqual(original);
+  });
+
+  it('round-trips a follow_up nested node', () => {
+    const original = [
+      {
+        from: 'Starbase Alpha',
+        trigger: 'on_hailed',
+        entity: 'Starbase Alpha',
+        message: 'State your business.',
+        response: [
+          {
+            text: 'Trade.',
+            action: [{ type: 'add_objective', id: 'obj-trade', text: 'Trade.' }],
+            follow_up: {
+              message: 'Proceed to docking bay 3.',
+              response: [
+                {
+                  text: 'Acknowledged.',
+                  action: [
+                    { type: 'apply_flag', kind: 'CommsJammed' },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    const round = editorCommsToWorld(worldCommsToEditor(original));
+    expect(round).toEqual(original);
+  });
+
+  it('preserves comms templates with no entity field (drops `entity` cleanly)', () => {
+    const noEntity = [
+      {
+        from: 'Narrator',
+        trigger: 'on_hailed',
+        message: 'A voice from the dark.',
+      },
+    ];
+    const editor = worldCommsToEditor(noEntity);
+    expect(editor[0].trigger.entity).toBeUndefined();
+
+    const round = editorCommsToWorld(editor);
+    expect(round[0]).not.toHaveProperty('entity');
+    expect(round).toEqual(noEntity);
+  });
+
+  it('round-trips a patrol.toml-style empty comms array', () => {
+    // patrol.toml has no [[comms]] blocks at all.
+    expect(editorCommsToWorld(worldCommsToEditor([]))).toEqual([]);
+  });
+
+  it('strips empty responses array from the round-tripped output', () => {
+    const original = [
+      {
+        from: 'Drone',
+        trigger: 'on_attacked',
+        entity: 'drone',
+        message: 'Threat detected.',
+      },
+    ];
+    const round = editorCommsToWorld(worldCommsToEditor(original));
+    expect(round[0]).not.toHaveProperty('response');
+  });
+
+  it('strips empty actions array from a response in the round-tripped output', () => {
+    const original = [
+      {
+        from: 'Starbase Alpha',
+        trigger: 'on_hailed',
+        entity: 'Starbase Alpha',
+        message: 'Hello.',
+        response: [{ text: 'Ack.' }],
+      },
+    ];
+    const round = editorCommsToWorld(worldCommsToEditor(original));
+    expect(round[0].response[0]).not.toHaveProperty('action');
+    expect(round).toEqual(original);
+  });
+});

--- a/editor/tests/slice-4a-trigger-edit.test.js
+++ b/editor/tests/slice-4a-trigger-edit.test.js
@@ -1,0 +1,318 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ModeShell } from '../mode-shell.js';
+
+/**
+ * Slice 4a integration test: trigger editor.
+ *
+ * Exercises `renderTriggerPanel` end-to-end (build, mutate, add-action)
+ * against a fixture world that mirrors `assets/worlds/default.toml`'s
+ * raider-alpha trigger. Verifies the snapshot-before-mutate contract,
+ * the dirty flag, and the schema-driven picker integrations (entity,
+ * objective-id, file-picker).
+ *
+ * Vitest runs in node mode without jsdom, so we install a minimal DOM
+ * shim — just enough for createElement / appendChild / event dispatch /
+ * value & checked properties. Lives in this file to avoid a new dep.
+ */
+
+// ── Minimal DOM shim ────────────────────────────────────────────────────
+
+class FakeClassList {
+  constructor() { this._set = new Set(); }
+  add(c)    { this._set.add(c); }
+  remove(c) { this._set.delete(c); }
+  toggle(c, force) {
+    const has = this._set.has(c);
+    const want = force === undefined ? !has : !!force;
+    if (want) this._set.add(c); else this._set.delete(c);
+    return want;
+  }
+  contains(c) { return this._set.has(c); }
+}
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag.toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this._listeners = new Map();
+    this.attributes = {};
+    this.dataset = {};
+    this.style = {};
+    this.classList = new FakeClassList();
+    this._innerHTML = '';
+    this.textContent = '';
+    this.value = '';
+    this.checked = false;
+    this.type = '';
+    this.step = '';
+    this.rows = 0;
+    this.id = '';
+    this._className = '';
+  }
+  get className() { return this._className; }
+  set className(v) {
+    this._className = v;
+    // Mirror to classList so .contains() and querySelectorAll('.cls') work.
+    this.classList = new FakeClassList();
+    for (const c of String(v || '').split(/\s+/).filter(Boolean)) {
+      this.classList.add(c);
+    }
+  }
+  appendChild(child) {
+    if (child.parentElement) {
+      const idx = child.parentElement.children.indexOf(child);
+      if (idx !== -1) child.parentElement.children.splice(idx, 1);
+    }
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+  replaceWith(other) {
+    if (!this.parentElement) return;
+    const idx = this.parentElement.children.indexOf(this);
+    if (idx === -1) return;
+    other.parentElement = this.parentElement;
+    this.parentElement.children[idx] = other;
+    this.parentElement = null;
+  }
+  addEventListener(type, fn) {
+    if (!this._listeners.has(type)) this._listeners.set(type, []);
+    this._listeners.get(type).push(fn);
+  }
+  dispatchEvent(ev) {
+    const list = this._listeners.get(ev.type) || [];
+    for (const fn of list) fn(ev);
+  }
+  set innerHTML(v) {
+    this._innerHTML = v;
+    this.children = [];
+  }
+  get innerHTML() { return this._innerHTML; }
+  // Helpers for tests.
+  _findAll(predicate, out = []) {
+    if (predicate(this)) out.push(this);
+    for (const c of this.children) c._findAll(predicate, out);
+    return out;
+  }
+  querySelectorAll(sel) {
+    // Supports `tag`, `#id`, `tag#id`, and `.class`.
+    const match = parseSelector(sel);
+    return this._findAll(match);
+  }
+  querySelector(sel) {
+    return this.querySelectorAll(sel)[0] || null;
+  }
+}
+
+function parseSelector(sel) {
+  return (el) => {
+    let s = sel;
+    // .class
+    if (s.startsWith('.')) return el.classList.contains(s.slice(1));
+    // #id
+    if (s.startsWith('#')) return el.id === s.slice(1);
+    // tag#id
+    const m = s.match(/^([a-z]+)#(.+)$/i);
+    if (m) return el.tagName === m[1].toUpperCase() && el.id === m[2];
+    // tag
+    return el.tagName === s.toUpperCase();
+  };
+}
+
+class FakeDocument {
+  createElement(tag) { return new FakeElement(tag); }
+  getElementById(_id) { return null; }
+}
+
+function installDom() {
+  globalThis.document = new FakeDocument();
+}
+
+function fireChange(el, value) {
+  el.value = value;
+  el.dispatchEvent({ type: 'change', target: el });
+}
+function fireInput(el, value) {
+  el.value = value;
+  el.dispatchEvent({ type: 'input', target: el });
+}
+function fireClick(el) {
+  el.dispatchEvent({ type: 'click', target: el });
+}
+
+// ── Fixture ─────────────────────────────────────────────────────────────
+
+function makeWorld() {
+  return {
+    global: { seed: 42 },
+    anchors: { patrol_alpha: [300.0, 0.0, -300.0] },
+    entity: [
+      {
+        template_path: 'assets/entities/pirate_raider.toml',
+        name: 'raider_alpha',
+        anchor: 'patrol_alpha',
+      },
+    ],
+    trigger: [
+      {
+        condition: 'on_destroyed',
+        entity: 'raider_alpha',
+        action: [
+          {
+            type: 'add_objective',
+            id: 'obj-raider-destroyed',
+            text: 'Destroy the raider patrol',
+            mandatory: true,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('Slice 4a: trigger editor + action-card', () => {
+  let modeShell;
+  let layer;
+  let host;
+  let renderTriggerPanel;
+
+  beforeEach(async () => {
+    installDom();
+    modeShell = new ModeShell();
+    globalThis.window = { __editorV2: { modeShell } };
+
+    layer = {
+      filename: 'assets/worlds/default.toml',
+      toml: makeWorld(),
+      isDirty: false,
+    };
+    host = new FakeElement('div');
+
+    // Import after globals are in place (module-level code is minimal but
+    // safer to re-evaluate fresh each test). Vitest caches; we tolerate that.
+    ({ renderTriggerPanel } = await import('../trigger-view.js'));
+  });
+
+  function getDeps(overrides = {}) {
+    return {
+      allLayers: [{ path: layer.filename, worldState: layer.toml }],
+      canvasManager: { renderAll: () => {} },
+      layerManager: { getLayers: () => [layer] },
+      ...overrides,
+    };
+  }
+
+  it('renders the existing add_objective action for raider_alpha', () => {
+    renderTriggerPanel(host, { type: 'trigger', triggerIndex: 0, layer }, getDeps());
+
+    const titles = host.querySelectorAll('span')
+      .filter((e) => e.classList.contains('action-card-title'))
+      .map((e) => e.textContent);
+    expect(titles).toContain('▾ Add Objective');
+
+    // The action list contains one card.
+    const cards = host.querySelectorAll('div').filter((e) => e.classList.contains('action-card'));
+    expect(cards).toHaveLength(1);
+  });
+
+  it('editing the action text writes back via onChange and pushes one undo snapshot', () => {
+    renderTriggerPanel(host, { type: 'trigger', triggerIndex: 0, layer }, getDeps());
+
+    // Find the input whose preceding sibling is the label "text".
+    const fieldRows = host.querySelectorAll('div').filter((e) => e.classList.contains('action-field'));
+    let textInput = null;
+    for (const row of fieldRows) {
+      const label = row.children.find((c) => c.tagName === 'LABEL');
+      if (label && label.textContent === 'text') {
+        textInput = row.children.find((c) => c.tagName === 'INPUT');
+        break;
+      }
+    }
+    expect(textInput).not.toBeNull();
+    expect(textInput.value).toBe('Destroy the raider patrol');
+
+    fireInput(textInput, 'Destroy the patrol now');
+
+    expect(layer.toml.trigger[0].action[0].text).toBe('Destroy the patrol now');
+    expect(layer.toml.trigger[0].action[0].id).toBe('obj-raider-destroyed');
+    expect(layer.isDirty).toBe(true);
+
+    const undoEntries = modeShell.getUndoHistory('Scenario', layer.filename);
+    expect(undoEntries.length).toBe(1);
+    // The snapshot is the PRE-mutation state — the original text.
+    expect(undoEntries[0].trigger[0].action[0].text).toBe('Destroy the raider patrol');
+  });
+
+  it('+ Add Action with complete_objective surfaces the same-world objective id picker', () => {
+    renderTriggerPanel(host, { type: 'trigger', triggerIndex: 0, layer }, getDeps());
+
+    const select = host.querySelectorAll('select').find((s) => s.id === 'newActionType');
+    expect(select).toBeDefined();
+    select.value = 'complete_objective';
+    const addBtn = host.querySelectorAll('button').find((b) => b.id === 'addActionBtn');
+    fireClick(addBtn);
+
+    // World now has two actions.
+    expect(layer.toml.trigger[0].action).toHaveLength(2);
+    const newAction = layer.toml.trigger[0].action[1];
+    expect(newAction.type).toBe('complete_objective');
+    expect(newAction.id).toBe(''); // default for required string
+
+    // After re-render, the second card's `id` field is a <select>
+    // populated from add_objective in the same world.
+    const titles = host.querySelectorAll('span')
+      .filter((e) => e.classList.contains('action-card-title'))
+      .map((e) => e.textContent);
+    expect(titles).toEqual(['▾ Add Objective', '▾ Complete Objective']);
+
+    // Find the 'id' select inside the second card.
+    const cards = host.querySelectorAll('div').filter((e) => e.classList.contains('action-card'));
+    const completeCard = cards[1];
+    const idRow = completeCard.querySelectorAll('div')
+      .filter((e) => e.classList.contains('action-field'))
+      .find((row) => row.children.find((c) => c.tagName === 'LABEL' && c.textContent === 'id'));
+    expect(idRow).toBeDefined();
+
+    const idSelect = idRow.children.find((c) => c.tagName === 'SELECT');
+    expect(idSelect).toBeDefined();
+    const optionValues = idSelect.children.map((o) => o.value);
+    expect(optionValues).toContain('obj-raider-destroyed');
+  });
+
+  it('+ Add Action with load_world renders a Pick… button using openFilePicker', async () => {
+    let pickerCalls = 0;
+    const deps = getDeps({
+      openFilePicker: async (root) => {
+        pickerCalls++;
+        expect(root).toBe('assets/worlds/');
+        return 'assets/worlds/patrol.toml';
+      },
+    });
+
+    renderTriggerPanel(host, { type: 'trigger', triggerIndex: 0, layer }, deps);
+
+    const select = host.querySelectorAll('select').find((s) => s.id === 'newActionType');
+    select.value = 'load_world';
+    const addBtn = host.querySelectorAll('button').find((b) => b.id === 'addActionBtn');
+    fireClick(addBtn);
+
+    // After re-render, second card should have a Pick… button.
+    const cards = host.querySelectorAll('div').filter((e) => e.classList.contains('action-card'));
+    const loadCard = cards[1];
+    const pickBtn = loadCard.querySelectorAll('button').find((b) => b.textContent === 'Pick…');
+    expect(pickBtn).toBeDefined();
+
+    // Click it; this returns a promise via the async handler.
+    fireClick(pickBtn);
+
+    // Await microtasks to allow async picker to resolve.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(pickerCalls).toBe(1);
+    expect(layer.toml.trigger[0].action[1].path).toBe('assets/worlds/patrol.toml');
+  });
+});

--- a/editor/tests/slice-4b-comms-edit.test.js
+++ b/editor/tests/slice-4b-comms-edit.test.js
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ModeShell } from '../mode-shell.js';
+
+/**
+ * Slice 4b integration test: comms editor.
+ *
+ * Exercises `renderCommsPanel` end-to-end against a fixture world that
+ * mirrors `assets/worlds/default.toml`'s "Starbase Alpha on_hailed" comms
+ * template. Verifies:
+ *   - Editing the body textarea mutates layer.toml.comms[i].message.
+ *   - Adding an action to a response appends to
+ *     layer.toml.comms[i].response[j].action[].
+ *   - Adding a follow-up creates
+ *     layer.toml.comms[i].response[j].follow_up = { message, response }.
+ *   - snapshotForUndo is called on every mutation (undo stack grows by 1).
+ *   - Trigger <select> only exposes the three supported variants
+ *     (on_attacked / on_destroyed / on_hailed).
+ *
+ * Uses the same FakeElement DOM shim style as slice-4a-trigger-edit.test.js.
+ */
+
+// ── Minimal DOM shim (reused from slice-4a-trigger-edit.test.js) ────────
+
+class FakeClassList {
+  constructor() { this._set = new Set(); }
+  add(c)    { this._set.add(c); }
+  remove(c) { this._set.delete(c); }
+  toggle(c, force) {
+    const has = this._set.has(c);
+    const want = force === undefined ? !has : !!force;
+    if (want) this._set.add(c); else this._set.delete(c);
+    return want;
+  }
+  contains(c) { return this._set.has(c); }
+}
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag.toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this._listeners = new Map();
+    this.attributes = {};
+    this.dataset = {};
+    this.style = {};
+    this.classList = new FakeClassList();
+    this._innerHTML = '';
+    this.textContent = '';
+    this.value = '';
+    this.checked = false;
+    this.type = '';
+    this.step = '';
+    this.rows = 0;
+    this.id = '';
+    this.placeholder = '';
+    this._className = '';
+  }
+  get className() { return this._className; }
+  set className(v) {
+    this._className = v;
+    this.classList = new FakeClassList();
+    for (const c of String(v || '').split(/\s+/).filter(Boolean)) {
+      this.classList.add(c);
+    }
+  }
+  appendChild(child) {
+    if (child.parentElement) {
+      const idx = child.parentElement.children.indexOf(child);
+      if (idx !== -1) child.parentElement.children.splice(idx, 1);
+    }
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+  addEventListener(type, fn) {
+    if (!this._listeners.has(type)) this._listeners.set(type, []);
+    this._listeners.get(type).push(fn);
+  }
+  dispatchEvent(ev) {
+    const list = this._listeners.get(ev.type) || [];
+    for (const fn of list) fn(ev);
+  }
+  set innerHTML(v) { this._innerHTML = v; this.children = []; }
+  get innerHTML() { return this._innerHTML; }
+  _findAll(predicate, out = []) {
+    if (predicate(this)) out.push(this);
+    for (const c of this.children) c._findAll(predicate, out);
+    return out;
+  }
+  querySelectorAll(sel) {
+    const match = parseSelector(sel);
+    return this._findAll(match);
+  }
+  querySelector(sel) { return this.querySelectorAll(sel)[0] || null; }
+}
+
+function parseSelector(sel) {
+  return (el) => {
+    let s = sel;
+    if (s.startsWith('.')) return el.classList.contains(s.slice(1));
+    if (s.startsWith('#')) return el.id === s.slice(1);
+    const m = s.match(/^([a-z]+)#(.+)$/i);
+    if (m) return el.tagName === m[1].toUpperCase() && el.id === m[2];
+    return el.tagName === s.toUpperCase();
+  };
+}
+
+class FakeDocument {
+  createElement(tag) { return new FakeElement(tag); }
+  getElementById() { return null; }
+}
+
+function installDom() {
+  globalThis.document = new FakeDocument();
+}
+
+function fireInput(el, value) {
+  el.value = value;
+  el.dispatchEvent({ type: 'input', target: el });
+}
+function fireChange(el, value) {
+  el.value = value;
+  el.dispatchEvent({ type: 'change', target: el });
+}
+function fireClick(el) {
+  el.dispatchEvent({ type: 'click', target: el });
+}
+
+// ── Fixture ─────────────────────────────────────────────────────────────
+
+function makeWorld() {
+  return {
+    global: { seed: 42 },
+    entity: [
+      { template_path: 'assets/entities/starbase.toml', name: 'Starbase Alpha' },
+    ],
+    comms: [
+      {
+        from: 'Starbase Alpha',
+        trigger: 'on_hailed',
+        entity: 'Starbase Alpha',
+        message: 'USS Phoenix, this is Starbase Alpha. Please state your business.',
+        response: [
+          {
+            text: 'We are on a survey mission.',
+            action: [
+              {
+                type: 'add_objective',
+                id: 'obj-survey',
+                text: 'Complete the survey in this sector.',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('Slice 4b: comms editor', () => {
+  let modeShell;
+  let layer;
+  let host;
+  let renderCommsPanel;
+
+  beforeEach(async () => {
+    installDom();
+    modeShell = new ModeShell();
+    globalThis.window = { __editorV2: { modeShell } };
+
+    layer = {
+      filename: 'assets/worlds/default.toml',
+      toml: makeWorld(),
+      isDirty: false,
+    };
+    host = new FakeElement('div');
+
+    ({ renderCommsPanel } = await import('../comms-view.js'));
+  });
+
+  function getDeps() {
+    return {
+      allLayers: [{ path: layer.filename, worldState: layer.toml }],
+      canvasManager: { renderAll: () => {} },
+      layerManager: { getLayers: () => [layer], getActiveLayer: () => layer },
+    };
+  }
+
+  it('renders the initial comms template body and response', () => {
+    renderCommsPanel(host, { type: 'comms', commsIndex: 0, layer }, getDeps());
+
+    const ta = host.querySelectorAll('textarea').find((t) => t.classList.contains('comms-body-input'));
+    expect(ta).toBeDefined();
+    expect(ta.value).toContain('Please state your business.');
+
+    const responseCards = host.querySelectorAll('div').filter((d) => d.classList.contains('response-card'));
+    expect(responseCards).toHaveLength(1);
+
+    const respTextInput = responseCards[0]
+      .querySelectorAll('input')
+      .find((i) => i.classList.contains('response-text-input'));
+    expect(respTextInput).toBeDefined();
+    expect(respTextInput.value).toBe('We are on a survey mission.');
+  });
+
+  it('trigger select exposes only on_attacked / on_destroyed / on_hailed', () => {
+    renderCommsPanel(host, { type: 'comms', commsIndex: 0, layer }, getDeps());
+
+    const triggerSelect = host.querySelectorAll('select').find((s) => s.id === 'commsTriggerKind');
+    expect(triggerSelect).toBeDefined();
+    const values = triggerSelect.children.map((o) => o.value);
+    // Three known + zero extras (current value 'on_hailed' is in the list).
+    expect(values).toEqual(['on_attacked', 'on_destroyed', 'on_hailed']);
+    expect(values).not.toContain('on_timer');
+  });
+
+  it('editing the body textarea writes back to layer.toml.comms[0].message + 1 undo snapshot', () => {
+    renderCommsPanel(host, { type: 'comms', commsIndex: 0, layer }, getDeps());
+
+    const ta = host.querySelectorAll('textarea').find((t) => t.classList.contains('comms-body-input'));
+    fireInput(ta, 'New hail message.');
+
+    expect(layer.toml.comms[0].message).toBe('New hail message.');
+    expect(layer.isDirty).toBe(true);
+
+    const undoEntries = modeShell.getUndoHistory('Scenario', layer.filename);
+    expect(undoEntries.length).toBe(1);
+    // Snapshot is PRE-mutation → original message.
+    expect(undoEntries[0].comms[0].message).toContain('Please state your business.');
+  });
+
+  it('+ Add Action on a response appends to layer.toml.comms[0].response[0].action', () => {
+    renderCommsPanel(host, { type: 'comms', commsIndex: 0, layer }, getDeps());
+
+    const card = host.querySelectorAll('div').find((d) => d.classList.contains('response-card'));
+    const select = card.querySelectorAll('select').find((s) => s.classList.contains('newCommsActionType'));
+    expect(select).toBeDefined();
+    select.value = 'complete_objective';
+    const addBtn = card.querySelectorAll('button').find((b) => b.classList.contains('btn-add-comms-action'));
+    fireClick(addBtn);
+
+    const actions = layer.toml.comms[0].response[0].action;
+    expect(actions).toHaveLength(2);
+    expect(actions[1].type).toBe('complete_objective');
+    expect(layer.isDirty).toBe(true);
+
+    const undoEntries = modeShell.getUndoHistory('Scenario', layer.filename);
+    expect(undoEntries.length).toBe(1);
+  });
+
+  it('+ Add Follow-Up Node creates comms[0].response[0].follow_up = { message, response? }', () => {
+    renderCommsPanel(host, { type: 'comms', commsIndex: 0, layer }, getDeps());
+
+    const card = host.querySelectorAll('div').find((d) => d.classList.contains('response-card'));
+    const addBtn = card.querySelectorAll('button').find((b) => b.classList.contains('btn-add-follow-up'));
+    expect(addBtn).toBeDefined();
+    fireClick(addBtn);
+
+    const follow = layer.toml.comms[0].response[0].follow_up;
+    expect(follow).toBeDefined();
+    expect(follow.message).toBe('');
+    // The adapter strips empty responses arrays on the write-back path; OK.
+    expect(follow.response === undefined || Array.isArray(follow.response)).toBe(true);
+    expect(layer.isDirty).toBe(true);
+
+    const undoEntries = modeShell.getUndoHistory('Scenario', layer.filename);
+    expect(undoEntries.length).toBe(1);
+  });
+
+  it('editing the from input mutates layer.toml.comms[0].from + 1 undo snapshot', () => {
+    renderCommsPanel(host, { type: 'comms', commsIndex: 0, layer }, getDeps());
+
+    const fromInput = host.querySelectorAll('input').find((i) => i.id === 'commsFrom');
+    expect(fromInput).toBeDefined();
+    fireInput(fromInput, 'Federation Command');
+
+    expect(layer.toml.comms[0].from).toBe('Federation Command');
+    expect(layer.isDirty).toBe(true);
+
+    const undoEntries = modeShell.getUndoHistory('Scenario', layer.filename);
+    expect(undoEntries.length).toBe(1);
+  });
+});

--- a/editor/tests/slice-4b-new-world.test.js
+++ b/editor/tests/slice-4b-new-world.test.js
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LayerManager } from '../layers.js';
+
+/**
+ * Slice 4b: new-world-dialog test.
+ *
+ * Verifies:
+ *  - Click with a unique filename → writeFile(path, content) called once.
+ *  - Collision filename → validation error, NO writeFile call.
+ *  - On success, new layer appended + active.
+ *  - prompt() returning null cancels cleanly.
+ */
+
+class FakeClassList {
+  constructor() { this._set = new Set(); }
+  add(c) { this._set.add(c); }
+  remove() {}
+  toggle() {}
+  contains(c) { return this._set.has(c); }
+}
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag.toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this._listeners = new Map();
+    this.dataset = {};
+    this.style = {};
+    this.classList = new FakeClassList();
+    this.textContent = '';
+    this.id = '';
+    this.type = '';
+    this.value = '';
+    this.disabled = false;
+  }
+  appendChild(child) {
+    if (child.parentElement) {
+      const idx = child.parentElement.children.indexOf(child);
+      if (idx !== -1) child.parentElement.children.splice(idx, 1);
+    }
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+  addEventListener(t, f) {
+    if (!this._listeners.has(t)) this._listeners.set(t, []);
+    this._listeners.get(t).push(f);
+  }
+  dispatchEvent(ev) {
+    const list = this._listeners.get(ev.type) || [];
+    for (const fn of list) fn(ev);
+  }
+}
+
+class FakeDocument {
+  constructor() { this._byId = new Map(); }
+  createElement(tag) { return new FakeElement(tag); }
+  getElementById(id) { return this._byId.get(id) || null; }
+  register(id, el) { el.id = id; this._byId.set(id, el); }
+}
+
+function fireClick(el) {
+  el.dispatchEvent({ type: 'click', target: el });
+}
+
+describe('Slice 4b: new-world-dialog', () => {
+  let layerManager;
+  let parent;
+  let sibling;
+  let writeCalls;
+  let alerts;
+  let onCreatedCount;
+  let mountNewWorldButton;
+
+  beforeEach(async () => {
+    globalThis.document = new FakeDocument();
+    parent = new FakeElement('div');
+    sibling = new FakeElement('button');
+    sibling.parentElement = parent;
+    parent.children.push(sibling);
+    document.register('addLayerBtn', sibling);
+
+    layerManager = new LayerManager();
+    writeCalls = [];
+    alerts = [];
+    onCreatedCount = 0;
+
+    globalThis.window = {
+      prompt: (msg, def) => 'fresh_world.toml',
+      alert: (msg) => alerts.push(msg),
+      tomlParse: (text) => ({ global: { seed: 42 } }),
+    };
+
+    ({ mountNewWorldButton } = await import('../new-world-dialog.js'));
+  });
+
+  function makeDeps(overrides = {}) {
+    return {
+      layerManager,
+      writeFile: async (path, content) => { writeCalls.push({ path, content }); },
+      tomlParse: (text) => ({ global: { seed: 42 } }),
+      onCreated: () => { onCreatedCount++; },
+      getExistingPaths: () => layerManager.getLayers().map((l) => l.filename),
+      ...overrides,
+    };
+  }
+
+  it('click with unique filename → writeFile called once + layer appended', async () => {
+    const btn = mountNewWorldButton(makeDeps());
+    expect(btn).toBeDefined();
+    expect(btn.textContent).toBe('+ New World');
+
+    fireClick(btn);
+
+    // drain microtasks from the async handler
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(writeCalls).toHaveLength(1);
+    expect(writeCalls[0].path).toBe('assets/worlds/fresh_world.toml');
+    expect(writeCalls[0].content).toContain('[global]');
+    expect(alerts).toHaveLength(0);
+
+    const added = layerManager.getLayers().find((l) => l.filename === 'assets/worlds/fresh_world.toml');
+    expect(added).toBeDefined();
+    expect(layerManager.getActiveLayer()).toBe(added);
+    expect(added.toml.global.seed).toBe(42);
+    expect(onCreatedCount).toBe(1);
+  });
+
+  it('collision filename → validation error, NO writeFile call', async () => {
+    layerManager.addInMemoryLayer('assets/worlds/dupe.toml', { global: { seed: 1 } });
+    window.prompt = () => 'dupe.toml';
+
+    const btn = mountNewWorldButton(makeDeps());
+    fireClick(btn);
+
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(writeCalls).toHaveLength(0);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toMatch(/already exists/i);
+    expect(onCreatedCount).toBe(0);
+  });
+
+  it('prompt cancelled (null) → no writeFile, no alert', async () => {
+    window.prompt = () => null;
+    const btn = mountNewWorldButton(makeDeps());
+    fireClick(btn);
+
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(writeCalls).toHaveLength(0);
+    expect(alerts).toHaveLength(0);
+    expect(onCreatedCount).toBe(0);
+  });
+
+  it('writeFile rejection surfaces an alert and does not push a layer', async () => {
+    const btn = mountNewWorldButton(makeDeps({
+      writeFile: async () => { throw new Error('Disk full'); },
+    }));
+
+    fireClick(btn);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toMatch(/Disk full/);
+    expect(layerManager.getLayers()).toHaveLength(0);
+    expect(onCreatedCount).toBe(0);
+  });
+});

--- a/editor/tests/slice-4b-triggerable-worlds.test.js
+++ b/editor/tests/slice-4b-triggerable-worlds.test.js
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LayerManager } from '../layers.js';
+
+/**
+ * Slice 4b: triggerable-worlds-panel test.
+ *
+ * Verifies:
+ *  - Panel lists union of listDirectory(assets/worlds) and load_world
+ *    references, deduped, excluding nothing (file-backed open layers get
+ *    an "Open" badge instead of an Activate button).
+ *  - Activate adds a session-only layer with `_sessionOnly: true`.
+ *  - Deactivate removes the session-only layer; non-session layers are
+ *    NOT given a Deactivate button.
+ *  - buildV2Layers-equivalent (layerManager.getLayers + filename/toml)
+ *    includes the new layer after activation.
+ */
+
+// Minimal DOM shim — same shape as the other Slice 4 tests.
+
+class FakeClassList {
+  constructor() { this._set = new Set(); }
+  add(c) { this._set.add(c); }
+  remove(c) { this._set.delete(c); }
+  toggle(c, force) {
+    const has = this._set.has(c);
+    const want = force === undefined ? !has : !!force;
+    if (want) this._set.add(c); else this._set.delete(c);
+    return want;
+  }
+  contains(c) { return this._set.has(c); }
+}
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag.toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this._listeners = new Map();
+    this.attributes = {};
+    this.dataset = {};
+    this.style = {};
+    this.classList = new FakeClassList();
+    this._innerHTML = '';
+    this.textContent = '';
+    this.value = '';
+    this.disabled = false;
+    this.id = '';
+    this.type = '';
+    this._className = '';
+  }
+  get className() { return this._className; }
+  set className(v) {
+    this._className = v;
+    this.classList = new FakeClassList();
+    for (const c of String(v || '').split(/\s+/).filter(Boolean)) {
+      this.classList.add(c);
+    }
+  }
+  appendChild(child) {
+    if (child.parentElement) {
+      const idx = child.parentElement.children.indexOf(child);
+      if (idx !== -1) child.parentElement.children.splice(idx, 1);
+    }
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+  addEventListener(type, fn) {
+    if (!this._listeners.has(type)) this._listeners.set(type, []);
+    this._listeners.get(type).push(fn);
+  }
+  dispatchEvent(ev) {
+    const list = this._listeners.get(ev.type) || [];
+    for (const fn of list) fn(ev);
+  }
+  set innerHTML(v) { this._innerHTML = v; this.children = []; }
+  get innerHTML() { return this._innerHTML; }
+  _findAll(predicate, out = []) {
+    if (predicate(this)) out.push(this);
+    for (const c of this.children) c._findAll(predicate, out);
+    return out;
+  }
+  querySelectorAll(sel) {
+    const match = parseSelector(sel);
+    return this._findAll(match);
+  }
+  querySelector(sel) { return this.querySelectorAll(sel)[0] || null; }
+}
+
+function parseSelector(sel) {
+  return (el) => {
+    let s = sel;
+    if (s.startsWith('.')) return el.classList.contains(s.slice(1));
+    if (s.startsWith('#')) return el.id === s.slice(1);
+    return el.tagName === s.toUpperCase();
+  };
+}
+
+class FakeDocument {
+  constructor() { this._byId = new Map(); }
+  createElement(tag) { return new FakeElement(tag); }
+  getElementById(id) { return this._byId.get(id) || null; }
+  register(id, el) { el.id = id; this._byId.set(id, el); }
+}
+
+function installDom() {
+  globalThis.document = new FakeDocument();
+}
+function fireClick(el) {
+  el.dispatchEvent({ type: 'click', target: el });
+}
+
+describe('Slice 4b: triggerable-worlds-panel', () => {
+  let layerManager;
+  let container;
+  let renderTriggerableWorldsPanel;
+  let onLayersChangedCount;
+
+  beforeEach(async () => {
+    installDom();
+    globalThis.window = { alert: () => {} };
+
+    layerManager = new LayerManager();
+    container = new FakeElement('div');
+    document.register('triggerableWorldsList', container);
+    onLayersChangedCount = 0;
+
+    ({ renderTriggerableWorldsPanel } = await import('../triggerable-worlds-panel.js'));
+  });
+
+  function getDeps(overrides = {}) {
+    return {
+      layerManager,
+      onLayersChanged: () => { onLayersChangedCount++; },
+      readFile: async () => '[global]\nseed = 7\n',
+      listDirectory: async () => [
+        { name: 'default.toml', kind: 'file' },
+        { name: 'patrol.toml',  kind: 'file' },
+        { name: 'README.md',    kind: 'file' },
+      ],
+      tomlParse: (text) => ({ global: { seed: 7 } }),
+      ...overrides,
+    };
+  }
+
+  it('lists candidates from listDirectory + referenced load_world paths', async () => {
+    // Open a layer that references "assets/worlds/secret.toml" via load_world.
+    layerManager.addInMemoryLayer('assets/worlds/default.toml', {
+      global: { seed: 1 },
+      trigger: [
+        {
+          condition: 'on_destroyed',
+          entity: 'foo',
+          action: [{ type: 'load_world', path: 'assets/worlds/secret.toml' }],
+        },
+      ],
+    }, { sessionOnly: false });
+
+    await renderTriggerableWorldsPanel(getDeps());
+
+    const rows = container.querySelectorAll('div').filter((d) => d.classList.contains('triggerable-world-row'));
+    const paths = rows.map((r) => r.dataset.path).sort();
+    expect(paths).toEqual([
+      'assets/worlds/default.toml',
+      'assets/worlds/patrol.toml',
+      'assets/worlds/secret.toml',
+    ]);
+
+    // The referenced-but-not-on-disk world has the (referenced) badge.
+    const secretRow = rows.find((r) => r.dataset.path === 'assets/worlds/secret.toml');
+    const referencedBadge = secretRow.children.find((c) => c.classList.contains('badge-referenced'));
+    expect(referencedBadge).toBeDefined();
+  });
+
+  it('Activate button reads + parses the file and adds a session-only layer', async () => {
+    await renderTriggerableWorldsPanel(getDeps());
+
+    const rows = container.querySelectorAll('div').filter((d) => d.classList.contains('triggerable-world-row'));
+    const patrolRow = rows.find((r) => r.dataset.path === 'assets/worlds/patrol.toml');
+    expect(patrolRow).toBeDefined();
+    const activateBtn = patrolRow.children.find((c) => c.tagName === 'BUTTON');
+    expect(activateBtn.textContent).toBe('Activate');
+
+    fireClick(activateBtn);
+
+    // Activation is async (readFile + tomlParse). Drain microtasks.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const added = layerManager.getLayers().find((l) => l.filename === 'assets/worlds/patrol.toml');
+    expect(added).toBeDefined();
+    expect(added._sessionOnly).toBe(true);
+    expect(added.toml.global.seed).toBe(7);
+    expect(onLayersChangedCount).toBe(1);
+  });
+
+  it('Deactivate removes a session-only layer; file-backed layers stay put', async () => {
+    // Pre-seed: one session-only, one file-backed.
+    layerManager.addInMemoryLayer('assets/worlds/default.toml', { global: { seed: 1 } }, { sessionOnly: false });
+    layerManager.addInMemoryLayer('assets/worlds/patrol.toml', { global: { seed: 2 } }, { sessionOnly: true });
+
+    await renderTriggerableWorldsPanel(getDeps());
+
+    const rows = container.querySelectorAll('div').filter((d) => d.classList.contains('triggerable-world-row'));
+
+    // File-backed default.toml row: button says "Open" and is disabled.
+    const defaultRow = rows.find((r) => r.dataset.path === 'assets/worlds/default.toml');
+    const defaultBtn = defaultRow.children.find((c) => c.tagName === 'BUTTON');
+    expect(defaultBtn.disabled).toBe(true);
+    expect(defaultBtn.textContent).toBe('Open');
+
+    // Session-only patrol row: button says "Deactivate".
+    const patrolRow = rows.find((r) => r.dataset.path === 'assets/worlds/patrol.toml');
+    const deactivateBtn = patrolRow.children.find((c) => c.tagName === 'BUTTON');
+    expect(deactivateBtn.textContent).toBe('Deactivate');
+
+    fireClick(deactivateBtn);
+
+    expect(layerManager.getLayers().find((l) => l.filename === 'assets/worlds/patrol.toml')).toBeUndefined();
+    // default.toml (file-backed) remains.
+    expect(layerManager.getLayers().find((l) => l.filename === 'assets/worlds/default.toml')).toBeDefined();
+    expect(onLayersChangedCount).toBe(1);
+  });
+
+  it('after activation, layerManager.getLayers (V2 view) includes the new layer', async () => {
+    await renderTriggerableWorldsPanel(getDeps());
+
+    const rows = container.querySelectorAll('div').filter((d) => d.classList.contains('triggerable-world-row'));
+    const activateBtn = rows
+      .find((r) => r.dataset.path === 'assets/worlds/default.toml')
+      .children.find((c) => c.tagName === 'BUTTON');
+    fireClick(activateBtn);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const v2Layers = layerManager.getLayers().map((l) => ({ path: l.filename, worldState: l.toml }));
+    expect(v2Layers.find((l) => l.path === 'assets/worlds/default.toml')).toBeDefined();
+  });
+
+  it('shows placeholder when no root picked AND no layers open', async () => {
+    await renderTriggerableWorldsPanel(getDeps({
+      listDirectory: async () => { throw new Error('no root'); },
+    }));
+
+    const placeholder = container.querySelectorAll('p').find((p) => p.classList.contains('placeholder'));
+    expect(placeholder).toBeDefined();
+    expect(placeholder.textContent).toMatch(/pick project root/i);
+  });
+});

--- a/editor/trigger-view.js
+++ b/editor/trigger-view.js
@@ -1,0 +1,326 @@
+/**
+ * trigger-view.js
+ *
+ * Renders the trigger editor inside the right-hand properties pane.
+ * Composed of:
+ *   - A condition `<select>` (on_destroyed | on_attacked | on_timer | on_hailed)
+ *   - An entity picker (hidden when condition === 'on_timer')
+ *   - An `after_secs` input (shown only when condition === 'on_timer')
+ *   - One `<action-card>` per action in the trigger
+ *   - An "+ Add Action" composer
+ *
+ * All mutations follow the snapshot-BEFORE-mutate contract via
+ * `snapshotForUndo(layer)`.  After each mutation `canvasManager.renderAll()`
+ * is called so the World Content panel + canvas refresh.
+ *
+ * Scope: ACs #1, #2, #3, #4 of Slice 4a (PRD #350).  The file picker
+ * surface is stubbed via `window.prompt`; Slice 4b will swap in a real
+ * project-root-anchored file dialog.
+ */
+
+import { ACTION_SCHEMA } from './action-schema.js';
+import { renderActionCard } from './action-card-view.js';
+import { snapshotForUndo } from './undo-controller.js';
+
+const TRIGGER_CONDITIONS = ['on_destroyed', 'on_attacked', 'on_timer', 'on_hailed'];
+
+/**
+ * Render a trigger editor.
+ *
+ * @param {HTMLElement} host
+ * @param {object} selection      { type:'trigger', triggerIndex, layer }
+ * @param {object} deps
+ * @param {Array<{path, worldState}>} deps.allLayers
+ * @param {object} deps.canvasManager  Provides `renderAll()`.
+ * @param {object} [deps.layerManager]
+ * @param {(rootPath: string) => Promise<string|null>} [deps.openFilePicker]
+ *        Optional override (mainly for tests). Defaults to a window.prompt
+ *        stub.
+ */
+export function renderTriggerPanel(host, selection, deps) {
+  const layer = selection.layer;
+  const triggerIndex = selection.triggerIndex;
+
+  if (!layer || !layer.toml || !Array.isArray(layer.toml.trigger)) {
+    host.innerHTML = '<p class="placeholder">Trigger no longer exists</p>';
+    return;
+  }
+  const trigger = layer.toml.trigger[triggerIndex];
+  if (!trigger) {
+    host.innerHTML = '<p class="placeholder">Trigger no longer exists</p>';
+    return;
+  }
+
+  const openFilePicker = deps.openFilePicker || defaultFilePicker;
+
+  // Re-render the entire panel on any change.  Triggers are small; the
+  // simplicity (and the need for state-dependent visibility — entity vs.
+  // after_secs — driven by condition) outweighs the diff cost.
+  const rerender = () => renderTriggerPanel(host, selection, deps);
+
+  host.innerHTML = '';
+
+  const panel = document.createElement('div');
+  panel.className = 'trigger-panel';
+
+  // ── Header ────────────────────────────────────────────────────────────
+  const h4 = document.createElement('h4');
+  h4.textContent = 'Trigger';
+  panel.appendChild(h4);
+
+  // Condition.
+  panel.appendChild(makeConditionRow(trigger, layer, rerender));
+
+  // Entity (hidden for on_timer).
+  if (trigger.condition !== 'on_timer') {
+    panel.appendChild(makeEntityRow(trigger, layer, deps, rerender));
+  }
+
+  // after_secs (only for on_timer).
+  if (trigger.condition === 'on_timer') {
+    panel.appendChild(makeAfterSecsRow(trigger, layer, rerender));
+  }
+
+  // ── Actions ───────────────────────────────────────────────────────────
+  const actionsH4 = document.createElement('h4');
+  actionsH4.textContent = 'Actions';
+  panel.appendChild(actionsH4);
+
+  const actionList = document.createElement('div');
+  actionList.id = 'actionList';
+  panel.appendChild(actionList);
+
+  const actions = Array.isArray(trigger.action) ? trigger.action : [];
+  actions.forEach((action, actionIndex) => {
+    renderActionCard(actionList, action, {
+      worldState: layer.toml,
+      allLayers: deps.allLayers || [],
+      onChange: (updated) => {
+        snapshotForUndo(layer);
+        ensureActionArray(trigger);
+        trigger.action[actionIndex] = updated;
+        markDirtyAndRender(layer, deps);
+        rerender();
+      },
+      onMove: (direction) => {
+        snapshotForUndo(layer);
+        ensureActionArray(trigger);
+        const arr = trigger.action;
+        const j = direction === 'up' ? actionIndex - 1 : actionIndex + 1;
+        if (j < 0 || j >= arr.length) return;
+        [arr[actionIndex], arr[j]] = [arr[j], arr[actionIndex]];
+        markDirtyAndRender(layer, deps);
+        rerender();
+      },
+      onRemove: () => {
+        snapshotForUndo(layer);
+        ensureActionArray(trigger);
+        trigger.action.splice(actionIndex, 1);
+        markDirtyAndRender(layer, deps);
+        rerender();
+      },
+      openFilePicker,
+    });
+  });
+
+  // ── + Add Action ──────────────────────────────────────────────────────
+  panel.appendChild(makeAddActionRow(trigger, layer, deps, rerender));
+
+  host.appendChild(panel);
+}
+
+// ── Row builders ────────────────────────────────────────────────────────
+
+function makeConditionRow(trigger, layer, rerender) {
+  const group = document.createElement('div');
+  group.className = 'property-group';
+
+  const label = document.createElement('label');
+  label.textContent = 'Condition:';
+  group.appendChild(label);
+
+  const select = document.createElement('select');
+  select.id = 'trigCondition';
+  for (const c of TRIGGER_CONDITIONS) {
+    const opt = document.createElement('option');
+    opt.value = c;
+    opt.textContent = c;
+    select.appendChild(opt);
+  }
+  // Allow the saved value through even if not in our known list.
+  if (trigger.condition && !TRIGGER_CONDITIONS.includes(trigger.condition)) {
+    const opt = document.createElement('option');
+    opt.value = trigger.condition;
+    opt.textContent = `${trigger.condition} (unknown)`;
+    select.appendChild(opt);
+  }
+  select.value = trigger.condition ?? TRIGGER_CONDITIONS[0];
+  select.addEventListener('change', (e) => {
+    snapshotForUndo(layer);
+    trigger.condition = e.target.value;
+    layer.isDirty = true;
+    rerender();
+  });
+  group.appendChild(select);
+  return group;
+}
+
+function makeEntityRow(trigger, layer, deps, rerender) {
+  const group = document.createElement('div');
+  group.className = 'property-group';
+
+  const label = document.createElement('label');
+  label.textContent = 'Entity:';
+  group.appendChild(label);
+
+  const select = document.createElement('select');
+  select.id = 'trigEntity';
+
+  const empty = document.createElement('option');
+  empty.value = '';
+  empty.textContent = '(none)';
+  select.appendChild(empty);
+
+  // Gather every named entity from every open layer.
+  const seen = new Set();
+  for (const l of (deps.allLayers || [])) {
+    const ws = l.worldState;
+    if (!ws || !Array.isArray(ws.entity)) continue;
+    for (const ent of ws.entity) {
+      if (!ent.name || seen.has(ent.name)) continue;
+      seen.add(ent.name);
+      const opt = document.createElement('option');
+      opt.value = ent.name;
+      opt.textContent = ent.name;
+      select.appendChild(opt);
+    }
+  }
+
+  let unknown = false;
+  if (trigger.entity && !seen.has(trigger.entity)) {
+    unknown = true;
+    const opt = document.createElement('option');
+    opt.value = trigger.entity;
+    opt.textContent = `${trigger.entity} ⚠ unknown`;
+    select.appendChild(opt);
+  }
+  select.value = trigger.entity ?? '';
+
+  select.addEventListener('change', (e) => {
+    snapshotForUndo(layer);
+    trigger.entity = e.target.value;
+    layer.isDirty = true;
+    rerender();
+  });
+  group.appendChild(select);
+
+  if (unknown) {
+    const warn = document.createElement('span');
+    warn.className = 'action-field-warning';
+    warn.textContent = '⚠ unknown';
+    group.appendChild(warn);
+  }
+  return group;
+}
+
+function makeAfterSecsRow(trigger, layer, rerender) {
+  const group = document.createElement('div');
+  group.className = 'property-group';
+
+  const label = document.createElement('label');
+  label.textContent = 'After (s):';
+  group.appendChild(label);
+
+  const input = document.createElement('input');
+  input.id = 'trigAfterSecs';
+  input.type = 'number';
+  input.step = '0.1';
+  input.value = (trigger.after_secs ?? 0).toString();
+  input.addEventListener('input', (e) => {
+    const n = parseFloat(e.target.value);
+    snapshotForUndo(layer);
+    trigger.after_secs = Number.isNaN(n) ? 0 : n;
+    layer.isDirty = true;
+  });
+  group.appendChild(input);
+  return group;
+}
+
+function makeAddActionRow(trigger, layer, deps, rerender) {
+  const wrap = document.createElement('div');
+  wrap.className = 'action-add-row';
+
+  const select = document.createElement('select');
+  select.id = 'newActionType';
+  for (const key of Object.keys(ACTION_SCHEMA)) {
+    const opt = document.createElement('option');
+    opt.value = key;
+    opt.textContent = ACTION_SCHEMA[key].label;
+    select.appendChild(opt);
+  }
+  wrap.appendChild(select);
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.id = 'addActionBtn';
+  btn.textContent = '+ Add Action';
+  btn.addEventListener('click', () => {
+    const type = select.value;
+    const action = buildDefaultAction(type);
+    if (!action) return;
+    snapshotForUndo(layer);
+    ensureActionArray(trigger);
+    trigger.action.push(action);
+    markDirtyAndRender(layer, deps);
+    if (typeof rerender === 'function') rerender();
+  });
+  wrap.appendChild(btn);
+  return wrap;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function ensureActionArray(trigger) {
+  if (!Array.isArray(trigger.action)) trigger.action = [];
+}
+
+function markDirtyAndRender(layer, deps) {
+  layer.isDirty = true;
+  if (typeof deps.canvasManager?.renderAll === 'function') {
+    deps.canvasManager.renderAll();
+  }
+}
+
+/**
+ * Build a default-valued action for the given type.  Exported for the
+ * integration test.
+ */
+export function buildDefaultAction(type) {
+  const schema = ACTION_SCHEMA[type];
+  if (!schema) return null;
+  const action = { type };
+  for (const f of schema.fields) {
+    if (f.default !== undefined) {
+      action[f.key] = f.default;
+    } else if (f.required && f.enum) {
+      action[f.key] = f.enum[0];
+    } else if (f.required && f.type === 'string') {
+      action[f.key] = '';
+    } else if (f.required && f.type === 'number') {
+      action[f.key] = 0;
+    } else if (f.required && f.type === 'boolean') {
+      action[f.key] = false;
+    }
+  }
+  return action;
+}
+
+async function defaultFilePicker(root) {
+  if (typeof window === 'undefined' || typeof window.prompt !== 'function') {
+    return null;
+  }
+  const result = window.prompt('Enter world TOML path', root);
+  if (result == null) return null;
+  const trimmed = String(result).trim();
+  return trimmed || null;
+}

--- a/editor/trigger-view.js
+++ b/editor/trigger-view.js
@@ -21,6 +21,7 @@
 import { ACTION_SCHEMA } from './action-schema.js';
 import { renderActionCard } from './action-card-view.js';
 import { snapshotForUndo } from './undo-controller.js';
+import { renderEntitySelect } from './entity-select-view.js';
 
 const TRIGGER_CONDITIONS = ['on_destroyed', 'on_attacked', 'on_timer', 'on_hailed'];
 
@@ -173,53 +174,17 @@ function makeEntityRow(trigger, layer, deps, rerender) {
   label.textContent = 'Entity:';
   group.appendChild(label);
 
-  const select = document.createElement('select');
-  select.id = 'trigEntity';
-
-  const empty = document.createElement('option');
-  empty.value = '';
-  empty.textContent = '(none)';
-  select.appendChild(empty);
-
-  // Gather every named entity from every open layer.
-  const seen = new Set();
-  for (const l of (deps.allLayers || [])) {
-    const ws = l.worldState;
-    if (!ws || !Array.isArray(ws.entity)) continue;
-    for (const ent of ws.entity) {
-      if (!ent.name || seen.has(ent.name)) continue;
-      seen.add(ent.name);
-      const opt = document.createElement('option');
-      opt.value = ent.name;
-      opt.textContent = ent.name;
-      select.appendChild(opt);
-    }
-  }
-
-  let unknown = false;
-  if (trigger.entity && !seen.has(trigger.entity)) {
-    unknown = true;
-    const opt = document.createElement('option');
-    opt.value = trigger.entity;
-    opt.textContent = `${trigger.entity} ⚠ unknown`;
-    select.appendChild(opt);
-  }
-  select.value = trigger.entity ?? '';
-
-  select.addEventListener('change', (e) => {
-    snapshotForUndo(layer);
-    trigger.entity = e.target.value;
-    layer.isDirty = true;
-    rerender();
-  });
-  group.appendChild(select);
-
-  if (unknown) {
-    const warn = document.createElement('span');
-    warn.className = 'action-field-warning';
-    warn.textContent = '⚠ unknown';
-    group.appendChild(warn);
-  }
+  renderEntitySelect(
+    group,
+    trigger.entity ?? '',
+    deps.allLayers || [],
+    (newValue) => {
+      snapshotForUndo(layer);
+      trigger.entity = newValue;
+      layer.isDirty = true;
+      rerender();
+    },
+  );
   return group;
 }
 

--- a/editor/triggerable-worlds-panel.js
+++ b/editor/triggerable-worlds-panel.js
@@ -1,0 +1,170 @@
+/**
+ * triggerable-worlds-panel.js
+ *
+ * Renders the "TRIGGERABLE WORLDS" collapsible panel into
+ * `#triggerableWorldsList`. Lists candidate world TOMLs the user can
+ * activate as session-only layers, so they can author and tweak triggers
+ * that target entities living in those worlds.
+ *
+ * Candidate set:
+ *   1. Every `assets/worlds/*.toml` returned by listDirectory (if a
+ *      project root has been picked).
+ *   2. Every path referenced by a `load_world` trigger action in any
+ *      already-open layer (via `TriggerableWorlds.scanLayers`). These
+ *      get a `(referenced)` badge.
+ *
+ * Activation:
+ *   - readFile(path) → window.tomlParse → layerManager.addInMemoryLayer(
+ *     path, parsedToml, { sessionOnly: true })
+ *   - "Active (session)" badge shown.
+ *
+ * Deactivation:
+ *   - Only allowed for layers whose `_sessionOnly === true`.
+ *   - Removes from layerManager.layers via removeLayer.
+ *
+ * Defensive: if no project root picked AND no layers open, render a
+ * placeholder pointing the user at "Pick Project Root".
+ */
+
+import { TriggerableWorlds } from './triggerable-worlds.js';
+
+/**
+ * Render the Triggerable Worlds panel.
+ *
+ * @param {object} deps
+ * @param {object} deps.layerManager
+ * @param {() => void} deps.onLayersChanged
+ * @param {(path: string) => Promise<string>} deps.readFile
+ * @param {(path?: string) => Promise<Array<{name:string, kind:string}>>} deps.listDirectory
+ * @param {(text: string) => object} deps.tomlParse
+ * @param {string} [deps.containerId='triggerableWorldsList']  Override for tests.
+ */
+export async function renderTriggerableWorldsPanel(deps) {
+  const containerId = deps.containerId || 'triggerableWorldsList';
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  container.innerHTML = '';
+
+  const layers = deps.layerManager.getLayers();
+  const openPathSet = new Set(layers.map((l) => l.filename));
+
+  // 1. Worlds reachable via load_world actions in open layers.
+  const tw = new TriggerableWorlds();
+  const v2Layers = layers.map((l) => ({ path: l.filename, worldState: l.toml }));
+  tw.scanLayers(v2Layers);
+  const referencedPaths = new Set(tw.getPaths());
+
+  // 2. Worlds living under assets/worlds/.
+  let dirEntries = null;
+  if (typeof deps.listDirectory === 'function') {
+    try {
+      dirEntries = await deps.listDirectory('assets/worlds');
+    } catch (err) {
+      dirEntries = null;
+    }
+  }
+  const diskPaths = new Set();
+  if (Array.isArray(dirEntries)) {
+    for (const entry of dirEntries) {
+      if (entry.kind === 'file' && entry.name.endsWith('.toml')) {
+        diskPaths.add(`assets/worlds/${entry.name}`);
+      }
+    }
+  }
+
+  const allCandidates = new Set([...diskPaths, ...referencedPaths]);
+
+  // Placeholder: no root picked AND nothing referenced.
+  if (allCandidates.size === 0 && layers.length === 0) {
+    const p = document.createElement('p');
+    p.className = 'placeholder';
+    p.textContent = 'Pick project root to see triggerable worlds';
+    container.appendChild(p);
+    return;
+  }
+
+  // Render one row per candidate path, then any session-only layer that
+  // somehow isn't in the candidate set (rare, but defensive).
+  const allPaths = new Set(allCandidates);
+  for (const layer of layers) {
+    if (layer._sessionOnly) allPaths.add(layer.filename);
+  }
+  const sortedPaths = [...allPaths].sort();
+
+  for (const path of sortedPaths) {
+    const row = makeRow(path, {
+      isOpen: openPathSet.has(path),
+      isSessionOnly: layers.some((l) => l.filename === path && l._sessionOnly),
+      isReferenced: referencedPaths.has(path),
+      deps,
+    });
+    container.appendChild(row);
+  }
+}
+
+function makeRow(path, { isOpen, isSessionOnly, isReferenced, deps }) {
+  const row = document.createElement('div');
+  row.className = 'triggerable-world-row';
+  row.dataset.path = path;
+
+  const label = document.createElement('span');
+  label.className = 'triggerable-world-path';
+  label.textContent = path.replace(/^assets\/worlds\//, '');
+  row.appendChild(label);
+
+  if (isSessionOnly) {
+    const badge = document.createElement('span');
+    badge.className = 'badge badge-session';
+    badge.textContent = 'Active (session)';
+    row.appendChild(badge);
+  } else if (isOpen) {
+    const badge = document.createElement('span');
+    badge.className = 'badge badge-open';
+    badge.textContent = 'Open';
+    row.appendChild(badge);
+  }
+  if (isReferenced) {
+    const badge = document.createElement('span');
+    badge.className = 'badge badge-referenced';
+    badge.textContent = '(referenced)';
+    row.appendChild(badge);
+  }
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'btn-toggle-world';
+  if (isSessionOnly) {
+    btn.textContent = 'Deactivate';
+    btn.addEventListener('click', () => deactivate(path, deps));
+  } else if (isOpen) {
+    // File-backed layer already open: no toggle.
+    btn.textContent = 'Open';
+    btn.disabled = true;
+  } else {
+    btn.textContent = 'Activate';
+    btn.addEventListener('click', () => activate(path, deps));
+  }
+  row.appendChild(btn);
+  return row;
+}
+
+async function activate(path, deps) {
+  try {
+    const text = await deps.readFile(path);
+    const parsed = await deps.tomlParse(text);
+    deps.layerManager.addInMemoryLayer(path, parsed, { sessionOnly: true });
+    if (typeof deps.onLayersChanged === 'function') deps.onLayersChanged();
+  } catch (err) {
+    if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+      window.alert(`Failed to activate world: ${err?.message || err}`);
+    }
+  }
+}
+
+function deactivate(path, deps) {
+  const layers = deps.layerManager.getLayers();
+  const layer = layers.find((l) => l.filename === path && l._sessionOnly);
+  if (!layer) return;
+  deps.layerManager.removeLayer(layer);
+  if (typeof deps.onLayersChanged === 'function') deps.onLayersChanged();
+}

--- a/editor/world-content-view.js
+++ b/editor/world-content-view.js
@@ -9,6 +9,12 @@
  * preserved across re-renders via module-local Set.  Clicking a named
  * entity (or a trigger/comms row whose `entity` is set) dispatches
  * `onSelectEntity(name)`; otherwise rows are inert.
+ *
+ * Slice 4a addition: trigger rows additionally fire
+ * `onSelectTrigger(triggerIndex)`, and comms rows fire
+ * `onSelectComms(commsIndex)`.  Both callbacks are wired alongside
+ * `onSelectEntity` (no replacement) — the right-hand pane picks which
+ * takes precedence in its selection state.
  */
 
 import { getWorldContentData } from './world-content-panel.js';
@@ -31,14 +37,21 @@ const SECTIONS = [
  * @param {object|null} opts.worldState          Active layer's toml object.
  * @param {object}      opts.crossRefIndex       CrossReferenceIndex instance.
  * @param {string|null} opts.activeLayerPath     Filename of the active layer.
- * @param {(name: string) => void} opts.onSelectEntity
+ * @param {(name: string) => void}    [opts.onSelectEntity]
  *        Called when a clickable row identifies an entity to highlight.
+ * @param {(triggerIndex: number) => void} [opts.onSelectTrigger]
+ *        Called when a trigger row is clicked (Slice 4a). Fires in
+ *        addition to `onSelectEntity` if the trigger has an entity.
+ * @param {(commsIndex: number) => void} [opts.onSelectComms]
+ *        Called when a comms row is clicked (Slice 4a stub for 4b).
  */
 export function renderWorldContentPanel({
   worldState,
   crossRefIndex,
   activeLayerPath,
   onSelectEntity,
+  onSelectTrigger,
+  onSelectComms,
 }) {
   const host = document.getElementById('worldContentList');
   if (!host) return;
@@ -50,14 +63,21 @@ export function renderWorldContentPanel({
 
   const data = getWorldContentData(worldState, crossRefIndex, activeLayerPath);
 
+  // Inject array indices so trigger/comms rows can dispatch index-based
+  // selection callbacks even though the pure data module doesn't track them.
+  (data.triggers || []).forEach((r, i) => { r.triggerIndex = i; });
+  (data.commsTemplates || []).forEach((r, i) => { r.commsIndex = i; });
+
+  const callbacks = { onSelectEntity, onSelectTrigger, onSelectComms };
+
   host.innerHTML = '';
   for (const section of SECTIONS) {
     const rows = data[section.key] || [];
-    host.appendChild(buildSection(section, rows, onSelectEntity));
+    host.appendChild(buildSection(section, rows, callbacks));
   }
 }
 
-function buildSection(section, rows, onSelectEntity) {
+function buildSection(section, rows, callbacks) {
   const wrap = document.createElement('div');
   wrap.className = 'world-content-section';
   if (collapsed.has(section.key)) wrap.classList.add('collapsed');
@@ -72,7 +92,7 @@ function buildSection(section, rows, onSelectEntity) {
       collapsed.add(section.key);
     }
     // Cheap local re-render: regenerate just this section.
-    const fresh = buildSection(section, rows, onSelectEntity);
+    const fresh = buildSection(section, rows, callbacks);
     wrap.replaceWith(fresh);
   });
   wrap.appendChild(header);
@@ -87,7 +107,7 @@ function buildSection(section, rows, onSelectEntity) {
       body.appendChild(empty);
     } else {
       for (const row of rows) {
-        body.appendChild(section.render(row, section.icon, onSelectEntity));
+        body.appendChild(section.render(row, section.icon, callbacks));
       }
     }
     wrap.appendChild(body);
@@ -95,43 +115,62 @@ function buildSection(section, rows, onSelectEntity) {
   return wrap;
 }
 
-function makeRow(icon, label, refCount, targetEntity, onSelectEntity) {
+function makeRow(icon, label, refCount, clickHandler) {
   const row = document.createElement('div');
   row.className = 'world-content-row';
-  if (targetEntity) row.classList.add('clickable');
+  if (clickHandler) row.classList.add('clickable');
   row.innerHTML = `<span class="wc-icon">${icon}</span><span class="wc-label">${escapeHtml(label)}</span>` +
     (refCount != null ? `<span class="wc-refcount">(${refCount})</span>` : '');
-  if (targetEntity && typeof onSelectEntity === 'function') {
-    row.addEventListener('click', () => onSelectEntity(targetEntity));
+  if (clickHandler) {
+    row.addEventListener('click', clickHandler);
   }
   return row;
 }
 
-function renderAnchorRow(row, icon, onSelectEntity) {
+function renderAnchorRow(row, icon, _callbacks) {
   // Anchors are not directly entity-clickable; show the count of spawns
   // anchored to them but no highlight (per audit §4 decision).
-  return makeRow(icon, row.name, row.refCount, null, onSelectEntity);
+  return makeRow(icon, row.name, row.refCount, null);
 }
 
-function renderEntityRow(row, icon, onSelectEntity) {
+function renderEntityRow(row, icon, callbacks) {
   const tail = row.template_path ? ` ← ${shortPath(row.template_path)}` : '';
-  return makeRow(icon, `${row.name}${tail}`, row.refCount, row.name, onSelectEntity);
+  const handler = (typeof callbacks.onSelectEntity === 'function')
+    ? () => callbacks.onSelectEntity(row.name)
+    : null;
+  return makeRow(icon, `${row.name}${tail}`, row.refCount, handler);
 }
 
-function renderTriggerRow(row, icon, onSelectEntity) {
+function renderTriggerRow(row, icon, callbacks) {
   const cond = row.condition || '*';
   const ent  = row.entity ? `:${row.entity}` : '';
-  return makeRow(icon, `${cond}${ent} (×${row.actionCount})`, null, row.entity || null, onSelectEntity);
+  const handler = () => {
+    if (typeof callbacks.onSelectTrigger === 'function') {
+      callbacks.onSelectTrigger(row.triggerIndex);
+    }
+    if (row.entity && typeof callbacks.onSelectEntity === 'function') {
+      callbacks.onSelectEntity(row.entity);
+    }
+  };
+  return makeRow(icon, `${cond}${ent} (×${row.actionCount})`, null, handler);
 }
 
-function renderCommsRow(row, icon, onSelectEntity) {
+function renderCommsRow(row, icon, callbacks) {
   const parts = [row.from, row.trigger].filter(Boolean).join(' / ');
-  return makeRow(icon, parts || '(unnamed)', null, row.entity || null, onSelectEntity);
+  const handler = () => {
+    if (typeof callbacks.onSelectComms === 'function') {
+      callbacks.onSelectComms(row.commsIndex);
+    }
+    if (row.entity && typeof callbacks.onSelectEntity === 'function') {
+      callbacks.onSelectEntity(row.entity);
+    }
+  };
+  return makeRow(icon, parts || '(unnamed)', null, handler);
 }
 
-function renderObjectiveRow(row, icon, onSelectEntity) {
+function renderObjectiveRow(row, icon, _callbacks) {
   const text = row.text ? `: ${row.text}` : '';
-  return makeRow(icon, `${row.id}${text}`, row.refCount, null, onSelectEntity);
+  return makeRow(icon, `${row.id}${text}`, row.refCount, null);
 }
 
 function shortPath(p) {


### PR DESCRIPTION
# Slice 4 — Triggers, Comms, Triggerable Worlds, New World (#385)

Complete editor wiring for triggers, comms templates, triggerable-worlds session manager, and "New World" creation. Closes #385.

Originally opened as Slice 4a (ACs #1-4). Slice 4b (ACs #5-7) was committed onto the same branch and pushed here, so this single PR now covers all seven ACs.

Stacked on #391 (Slice 3 — World Content).

## ACs delivered

### AC #1 — Trigger selection opens stacked action-card editor
- `world-content-view.js` → `onSelectTrigger(triggerIndex)`
- `app.js` sets `selection = {type:'trigger', triggerIndex, layer}` and calls `propertiesPanel.render(selection)`
- `sidebar.js` dispatches `selection.type === 'trigger'` → `renderTriggerPanel`

### AC #2 — Entity-name picker across all open layers + unknown warning
- `action-card-view.js` builds via `getEntityNameOptions(deps.allLayers)`
- Unknown branch injects `<option selected>` + `.action-field-warning` span; save not blocked
- Collision-suffix surfacing fixed via `entity-select-view.js` (see carryover below)

### AC #3 — `complete_objective` / `fail_objective` objective-id dropdown
- Sourced from same-world `add_objective` via `getObjectiveIdOptions(deps.worldState)`

### AC #4 — `load_world` / `unload_world` / `load_scenario` file picker
- Routes all three through `renderFilePickerField` rooted at `assets/worlds/`
- Uses `window.prompt` stub for path entry (acceptable per ACs)

### AC #5 — Comms message editor
- `editor/sidebar.js` — `selection.type === 'comms'` dispatches to `renderCommsPanel`
- `editor/comms-view.js` (new) — Renders from/trigger/entity header + body textarea + recursive response cards with action stacks + follow-up sub-editors. Reuses `renderActionCard` verbatim.
- `editor/comms-adapter.js` (new, pure) — Round-trip between live TOML shape (`message`/`response`/`action`/`follow_up`) and CommsEditor internal shape (`node.body`/`node.responses`/`actions`)
- **Pre-flight finding:** `on_timer` is NOT supported at the `[[comms]]` template level. `RawCommsEntry` (`src/world/config.rs:142-151`) has no `after_secs`; the parser hard-codes `None` at `:481-486`. Trigger select restricted to `on_attacked` / `on_destroyed` / `on_hailed`. Unknown saved values surface as `(unknown)` fallback option.
- All edits go through `mutate(fn)` helper that calls `snapshotForUndo(layer)` **before** the mutation; writeback assigns `layer.toml.comms = editorCommsToWorld(...)`

### AC #6 — Triggerable-worlds session manager
- `editor/triggerable-worlds-panel.js` (new) — Candidates = union of `listDirectory('assets/worlds')` (filtered to `.toml`) AND worlds referenced by `load_world` actions
- `editor/layers.js` — New `addInMemoryLayer(filename, parsedToml, {sessionOnly})` method. Sets `_sessionOnly: true` on session layers
- `editor/save-flow.js` — New `setSessionOnlyChecker(fn)` hook; `getDirtyFiles` skips session layers. Wired in `app.js:53-61`
- File-backed layers cannot be deactivated; "Pick project root" placeholder when no FSA root chosen AND no layers open

### AC #7 — New World button
- `editor/new-world-dialog.js` (new) — `prompt` → `validateNewWorldPath` (collision + prefix) → `prepareNewWorld` → `await writeFile` → push file-backed layer
- `editor.html` — `<button id="newWorldBtn">+ New World</button>` next to `#addLayerBtn`
- Layer shape mirrors the FSA-load flow at `app.js:203-213`. NO `_sessionOnly` flag (file-backed)

### Carryover fix from 4a review — collision suffix surfacing
- `editor/entity-select-view.js` (new) — Dedup is by `value + ':' + (layerPath || '')`, NOT bare value. Collision-suffixed labels survive in DOM (option text); `option.value` stays bare (wire format)
- Used by `action-card-view.js`, `trigger-view.js`, and `comms-view.js`

## Architectural changes

- **Selection model** is a discriminated union: `{type: 'spawn'|'trigger'|'comms'|null, ...}`. Legacy `propertiesPanel.render(spawn, layer)` callers still work via `_coerceSelection` (sidebar.js:55-63).
- New shared helper `renderEntitySelect` consolidates entity dropdown rendering across triggers, action cards, and comms.
- `SaveFlow` gains a session-only predicate hook to skip non-file-backed layers.

## Verification

- `npm run test:editor` → **841/841 passed** (43 files; +29 from Slice 3's 812):
  - `slice-4a-trigger-edit.test.js` — 4
  - `comms-adapter.test.js` — 10
  - `slice-4b-comms-edit.test.js` — 6
  - `slice-4b-triggerable-worlds.test.js` — 5
  - `slice-4b-new-world.test.js` — 4
- `cargo check` — clean
- Two strict review passes: both PASS, no required fixes

## New modules

- `editor/trigger-view.js`
- `editor/action-card-view.js`
- `editor/entity-select-view.js`
- `editor/comms-view.js`
- `editor/comms-adapter.js`
- `editor/triggerable-worlds-panel.js`
- `editor/new-world-dialog.js`

## Flagged for follow-up (non-blocking)

- Triggerable-worlds panel re-renders on every `renderAll()`; `listDirectory('assets/worlds')` could be cached for large directories.
- `new-world-dialog.js` pushes directly onto `layerManager.layers` instead of going through a constructor. Future cleanup could unify with `addInMemoryLayer` under a single `addLoadedLayer` API.
- Adapter strips empty `action: []` and `response: []` arrays (matches Rust `#[serde(default)]`). Documented in adapter tests.
- Action-card inline styles could be moved to CSS utility classes.

Closes #385.
