### PR TITLE
fix(html): no-cache meta on entry HTML to avoid stale hashed JS refs

### DIFF
--- a/client.html
+++ b/client.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <!-- Prevent the entry HTML from being cached so users always pick up the
+       latest Trunk-hashed JS/WASM filenames after a deploy. The hashed
+       assets themselves remain cacheable forever via their content hash. -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <title>Project Phoenix — Console</title>
   <script src="https://unpkg.com/peerjs@1.5.4/dist/peerjs.min.js"></script>
   <style>

--- a/server.html
+++ b/server.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- Prevent the entry HTML from being cached so users always pick up the
+       latest Trunk-hashed JS/WASM filenames after a deploy. The hashed
+       assets themselves remain cacheable forever via their content hash. -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <title>Project Phoenix — View Screen</title>
 
   <!-- CDN deps loaded before our script so they're in scope synchronously -->


### PR DESCRIPTION
After a Trunk deploy the hashed JS/WASM filenames change, but browsers may still hold the old index.html in cache and try to fetch a JS hash that no longer exists, producing a 404 on the page. Tell browsers not to cache the small entry HTML; the hashed assets it references remain cacheable forever via their content hash.