### PR TITLE
Slice 5 — Entity Mode: three-pane shell + component cards + preview (#386)

### DIFF
--- a/editor/app.js
+++ b/editor/app.js
@@ -9,6 +9,7 @@ import { CrossReferenceIndex } from './cross-references.js';
 import { renderWorldContentPanel } from './world-content-view.js';
 import { renderTriggerableWorldsPanel } from './triggerable-worlds-panel.js';
 import { mountNewWorldButton } from './new-world-dialog.js';
+import { mountEntityMode } from './entity-mode-view.js';
 import { readFile, writeFile, listDirectory } from './project-root.js';
 
 const layerManager = new LayerManager();
@@ -39,6 +40,18 @@ async function init() {
 
   await preloadEntityCache();
   entityEditor.loadEntitiesPalette();
+
+  // Slice 5: mount Entity Mode three-pane shell into its placeholder.
+  const entityHost = document.getElementById('entity-mode-root');
+  const v2Boot = window.__editorV2;
+  if (entityHost && v2Boot && v2Boot.modeShell && v2Boot.saveFlow) {
+    mountEntityMode({
+      host: entityHost,
+      modeShell: v2Boot.modeShell,
+      saveFlow: v2Boot.saveFlow,
+      registerRestore: v2Boot.registerRestore,
+    });
+  }
 
   setupToolbar();
   setupLayersPanel();
@@ -287,9 +300,27 @@ function setupToolbar() {
 
   document.getElementById('saveLayerBtn').addEventListener('click', async () => {
     const v2 = window.__editorV2;
+    if (!v2 || !v2.saveFlow) {
+      console.warn('[editor] SaveFlow unavailable.');
+      return;
+    }
+    // Slice 5: Entity Mode owns its own save pipeline via mountEntityMode.
+    // The Save Layer button still triggers a save, but routes through the
+    // active mode rather than blindly grabbing the layer manager.
+    const currentMode = v2.modeShell && typeof v2.modeShell.getCurrentMode === 'function'
+      ? v2.modeShell.getCurrentMode()
+      : 'Scenario';
+    if (currentMode === 'Entity') {
+      const result = await v2.saveFlow.saveActive(null);
+      if (!result.ok) {
+        console.error('Entity save failed:', result.errors);
+      }
+      return;
+    }
+
     const activeLayer = layerManager.getActiveLayer();
-    if (!v2 || !v2.saveFlow || !activeLayer) {
-      console.warn('[editor] No active layer or SaveFlow unavailable.');
+    if (!activeLayer) {
+      console.warn('[editor] No active layer.');
       return;
     }
     // renderAll() already mirrored the parsed payload into saveFlow's cache,

--- a/editor/behaviour-editor.js
+++ b/editor/behaviour-editor.js
@@ -60,8 +60,15 @@ export class BehaviourEditor {
 
     if (Array.isArray(b.transition)) {
       for (const t of b.transition) {
+        // `from` in TOML may be either a string (single source state) or
+        // an array of strings. Normalise to an array so [...t.from] in
+        // cloneTransition doesn't spread a string into characters.
+        const fromRaw = t.from;
+        const fromArr = Array.isArray(fromRaw)
+          ? fromRaw
+          : (fromRaw == null ? [] : [fromRaw]);
         this._transitions.push(cloneTransition({
-          from: t.from || [],
+          from: fromArr,
           to: t.to,
           condition: t.condition || { kind: null, parameters: {} },
         }));

--- a/editor/entity-add-component-menu.js
+++ b/editor/entity-add-component-menu.js
@@ -1,0 +1,91 @@
+/**
+ * entity-add-component-menu.js
+ *
+ * Two-tier picker for the "+ Add Component" button in Entity Mode.
+ *
+ *   Top tier: combo templates (Ship, Station, Region, NPC, Asteroid,
+ *             Asteroid Field, Star, Planet) + a single "Raw section ▸"
+ *             entry that expands a flat submenu.
+ *   Bottom tier: one row per `ENTITY_CONFIG_SECTIONS` key.
+ *
+ * Selecting either tier returns the choice via the `onSelect` callback:
+ *   { kind: 'combo', name: 'Ship' }
+ *   { kind: 'raw',   sectionKey: 'hull' }
+ *
+ * Caller is responsible for hiding/removing the menu on selection.
+ */
+
+import { getPickerModel } from './component-templates.js';
+
+/**
+ * Render the picker into `host`. Returns the root <div> element so the
+ * caller can position/remove it.
+ *
+ * @param {HTMLElement} host
+ * @param {(choice:{kind:'combo'|'raw',name?:string,sectionKey?:string}) => void} onSelect
+ * @returns {HTMLElement}
+ */
+export function renderAddComponentMenu(host, onSelect) {
+  if (!host) return null;
+  host.innerHTML = '';
+
+  const root = document.createElement('div');
+  root.className = 'entity-add-menu';
+  host.appendChild(root);
+
+  const model = getPickerModel();
+
+  const state = { mode: 'top' }; // 'top' | 'raw'
+
+  const renderTop = () => {
+    root.innerHTML = '';
+    for (const combo of model.combos) {
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'entity-add-menu-item entity-add-menu-combo';
+      item.dataset.combo = combo.name;
+      item.textContent = combo.label;
+      item.addEventListener('click', () => onSelect({ kind: 'combo', name: combo.name }));
+      root.appendChild(item);
+    }
+
+    const rawBtn = document.createElement('button');
+    rawBtn.type = 'button';
+    rawBtn.className = 'entity-add-menu-item entity-add-menu-raw-toggle';
+    rawBtn.textContent = 'Raw section ▸';
+    rawBtn.addEventListener('click', () => {
+      state.mode = 'raw';
+      renderRaw();
+    });
+    root.appendChild(rawBtn);
+  };
+
+  const renderRaw = () => {
+    root.innerHTML = '';
+    const back = document.createElement('button');
+    back.type = 'button';
+    back.className = 'entity-add-menu-item entity-add-menu-back';
+    back.textContent = '◂ Back';
+    back.addEventListener('click', () => {
+      state.mode = 'top';
+      renderTop();
+    });
+    root.appendChild(back);
+
+    const sub = document.createElement('div');
+    sub.className = 'entity-add-menu-submenu';
+    for (const r of model.rawSections) {
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'entity-add-menu-item entity-add-menu-raw-section';
+      item.dataset.section = r.key;
+      item.textContent = r.label;
+      item.addEventListener('click', () => onSelect({ kind: 'raw', sectionKey: r.key }));
+      sub.appendChild(item);
+    }
+    root.appendChild(sub);
+  };
+
+  renderTop();
+  return root;
+}

--- a/editor/entity-behaviour-view.js
+++ b/editor/entity-behaviour-view.js
@@ -1,0 +1,252 @@
+/**
+ * entity-behaviour-view.js
+ *
+ * DOM renderer for the [behaviour] component card. Wraps `BehaviourEditor`
+ * to provide:
+ *   - initial_state <select> over getStateNames()
+ *   - State list: each row = name + kind dropdown + raw parameters textarea.
+ *   - Transition list: from-multiselect (state names), to-select,
+ *     condition.kind-select.
+ *   - Inline validation banner from editor.validate().
+ *
+ * `onEdit(behaviourData)` is invoked on every mutation with the current
+ * `editor.toBehaviour()` value, so the caller can snapshot + setSection.
+ */
+
+import { BehaviourEditor } from './behaviour-editor.js';
+
+const STATE_KINDS = [
+  'idle', 'patrol', 'attack',
+  'patrolling', 'pursuing', 'attacking', 'fleeing', 'warping_out',
+];
+
+const CONDITION_KINDS = [
+  'on_attacked', 'enemy_in_range', 'in_weapons_range',
+  'target_destroyed', 'hull_below', 'on_timer', 'on_scenario_unloaded',
+];
+
+export function renderEntityBehaviourView(host, behaviour, { onEdit }) {
+  if (!host) return;
+  host.innerHTML = '';
+
+  const editor = new BehaviourEditor();
+  editor.load(behaviour || {});
+
+  const rerender = () => renderEntityBehaviourView(host, editor.toBehaviour(), { onEdit });
+
+  const mutate = (fn) => {
+    fn(editor);
+    onEdit(editor.toBehaviour());
+    rerender();
+  };
+
+  const root = document.createElement('div');
+  root.className = 'entity-behaviour';
+  host.appendChild(root);
+
+  // Validation banner.
+  const validation = editor.validate();
+  if (!validation.valid) {
+    const banner = document.createElement('div');
+    banner.className = 'entity-behaviour-error';
+    banner.textContent = validation.errors.join(' • ');
+    root.appendChild(banner);
+  }
+
+  // initial_state select.
+  const initialRow = document.createElement('div');
+  initialRow.className = 'entity-behaviour-initial';
+  const initialLabel = document.createElement('label');
+  initialLabel.textContent = 'initial_state';
+  initialRow.appendChild(initialLabel);
+  const initialSelect = document.createElement('select');
+  initialSelect.className = 'entity-behaviour-initial-select';
+  const blank = document.createElement('option');
+  blank.value = '';
+  blank.textContent = '(none)';
+  initialSelect.appendChild(blank);
+  for (const name of editor.getStateNames()) {
+    const o = document.createElement('option');
+    o.value = name;
+    o.textContent = name;
+    initialSelect.appendChild(o);
+  }
+  initialSelect.value = editor.getInitialState() || '';
+  initialSelect.addEventListener('change', (e) => {
+    mutate((ed) => ed.setInitialState(e.target.value || null));
+  });
+  initialRow.appendChild(initialSelect);
+  root.appendChild(initialRow);
+
+  // States section.
+  const statesH = document.createElement('h5');
+  statesH.textContent = 'States';
+  root.appendChild(statesH);
+
+  const statesList = document.createElement('div');
+  statesList.className = 'entity-behaviour-states';
+  root.appendChild(statesList);
+
+  for (const s of editor.getStates()) {
+    statesList.appendChild(renderStateRow(s, mutate));
+  }
+
+  const addStateBtn = document.createElement('button');
+  addStateBtn.type = 'button';
+  addStateBtn.className = 'entity-behaviour-add-state';
+  addStateBtn.textContent = '+ Add State';
+  addStateBtn.addEventListener('click', () => {
+    mutate((ed) => {
+      const baseName = `state_${ed.getStates().length + 1}`;
+      ed.addState(baseName, 'idle');
+    });
+  });
+  root.appendChild(addStateBtn);
+
+  // Transitions.
+  const transH = document.createElement('h5');
+  transH.textContent = 'Transitions';
+  root.appendChild(transH);
+
+  const transList = document.createElement('div');
+  transList.className = 'entity-behaviour-transitions';
+  root.appendChild(transList);
+
+  const stateNames = editor.getStateNames();
+  editor.getTransitions().forEach((t, idx) => {
+    transList.appendChild(renderTransitionRow(t, idx, stateNames, mutate));
+  });
+
+  const addTransBtn = document.createElement('button');
+  addTransBtn.type = 'button';
+  addTransBtn.className = 'entity-behaviour-add-transition';
+  addTransBtn.textContent = '+ Add Transition';
+  addTransBtn.addEventListener('click', () => {
+    mutate((ed) => {
+      const names = ed.getStateNames();
+      ed.addTransition(
+        names.length > 0 ? [names[0]] : [],
+        names.length > 0 ? names[0] : '',
+        { kind: CONDITION_KINDS[0], parameters: {} },
+      );
+    });
+  });
+  root.appendChild(addTransBtn);
+}
+
+function renderStateRow(state, mutate) {
+  const row = document.createElement('div');
+  row.className = 'entity-behaviour-state-row';
+
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.className = 'entity-behaviour-state-name';
+  nameInput.value = state.name;
+  nameInput.disabled = true; // rename via remove+add to keep things simple
+  row.appendChild(nameInput);
+
+  const kindSelect = document.createElement('select');
+  kindSelect.className = 'entity-behaviour-state-kind';
+  for (const k of STATE_KINDS) {
+    const o = document.createElement('option');
+    o.value = k;
+    o.textContent = k;
+    kindSelect.appendChild(o);
+  }
+  if (!STATE_KINDS.includes(state.kind) && state.kind) {
+    const o = document.createElement('option');
+    o.value = state.kind;
+    o.textContent = `${state.kind} (custom)`;
+    kindSelect.appendChild(o);
+  }
+  kindSelect.value = state.kind || STATE_KINDS[0];
+  kindSelect.addEventListener('change', (e) => {
+    mutate((ed) => ed.updateState(state.name, { kind: e.target.value }));
+  });
+  row.appendChild(kindSelect);
+
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'entity-behaviour-state-remove';
+  removeBtn.textContent = '✕';
+  removeBtn.addEventListener('click', () => {
+    mutate((ed) => ed.removeState(state.name));
+  });
+  row.appendChild(removeBtn);
+
+  return row;
+}
+
+function renderTransitionRow(t, idx, stateNames, mutate) {
+  const row = document.createElement('div');
+  row.className = 'entity-behaviour-transition-row';
+
+  // from multi-select (rendered as a select with multiple).
+  const fromSelect = document.createElement('select');
+  fromSelect.className = 'entity-behaviour-transition-from';
+  fromSelect.multiple = true;
+  for (const name of stateNames) {
+    const o = document.createElement('option');
+    o.value = name;
+    o.textContent = name;
+    if ((t.from || []).includes(name)) o.selected = true;
+    fromSelect.appendChild(o);
+  }
+  fromSelect.addEventListener('change', (e) => {
+    const opts = e.target.children || [];
+    const selected = Array.from(opts).filter((o) => o.selected).map((o) => o.value);
+    mutate((ed) => ed.updateTransition(idx, { from: selected }));
+  });
+  row.appendChild(fromSelect);
+
+  // to select.
+  const toSelect = document.createElement('select');
+  toSelect.className = 'entity-behaviour-transition-to';
+  for (const name of stateNames) {
+    const o = document.createElement('option');
+    o.value = name;
+    o.textContent = name;
+    toSelect.appendChild(o);
+  }
+  toSelect.value = t.to || '';
+  toSelect.addEventListener('change', (e) => {
+    mutate((ed) => ed.updateTransition(idx, { to: e.target.value }));
+  });
+  row.appendChild(toSelect);
+
+  // condition kind select.
+  const condSelect = document.createElement('select');
+  condSelect.className = 'entity-behaviour-transition-condition';
+  for (const k of CONDITION_KINDS) {
+    const o = document.createElement('option');
+    o.value = k;
+    o.textContent = k;
+    condSelect.appendChild(o);
+  }
+  const cKind = t.condition?.kind;
+  if (cKind && !CONDITION_KINDS.includes(cKind)) {
+    const o = document.createElement('option');
+    o.value = cKind;
+    o.textContent = `${cKind} (custom)`;
+    condSelect.appendChild(o);
+  }
+  condSelect.value = cKind || CONDITION_KINDS[0];
+  condSelect.addEventListener('change', (e) => {
+    mutate((ed) => ed.updateTransition(idx, {
+      condition: { kind: e.target.value, parameters: t.condition?.parameters || {} },
+    }));
+  });
+  row.appendChild(condSelect);
+
+  // remove button.
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'entity-behaviour-transition-remove';
+  removeBtn.textContent = '✕';
+  removeBtn.addEventListener('click', () => {
+    mutate((ed) => ed.removeTransition(idx));
+  });
+  row.appendChild(removeBtn);
+
+  return row;
+}

--- a/editor/entity-component-card-view.js
+++ b/editor/entity-component-card-view.js
@@ -1,0 +1,345 @@
+/**
+ * entity-component-card-view.js
+ *
+ * Per-card DOM renderer for one TOML section in Entity Mode.
+ *
+ * Header: section label, collapse toggle, "raw TOML" toggle, delete (✕).
+ * Body:
+ *   - When `card.showRaw` is true: <textarea> bound to `getRawToml()` and
+ *     parsed back on every input (a parse failure shows an inline error
+ *     without writing back).
+ *   - Otherwise: schema-driven inputs (string/number/boolean/array<…>),
+ *     with the following special-cases:
+ *       * `dropdownSource === 'factions'`  → <select> from getFactionDropdownOptions()
+ *       * `dropdownSource === 'complexity'` → <select> from getComplexityPaths()
+ *       * `section === 'behaviour'`        → delegates to entity-behaviour-view
+ *       * `section === 'stations'`          → delegates to entity-stations-view
+ *   - When `card.schema` is null: degrades to raw-TOML-only mode.
+ *
+ * Edits flow out via `onEdit(sectionKey, newData)`; the host is responsible
+ * for snapshotting + calling shell.setSection.
+ *
+ * Pure DOM module: no globals beyond `document`.
+ */
+
+import { parseEntityToml, stringifyEntityToml } from './entity-toml.js';
+import { renderEntityBehaviourView } from './entity-behaviour-view.js';
+import { renderEntityStationsView } from './entity-stations-view.js';
+
+/**
+ * @param {HTMLElement} host
+ * @param {import('./entity-mode.js').ComponentCard} card
+ * @param {object} deps
+ * @param {() => Array<{uuid:string,name:string}>} deps.getFactionOptions
+ * @param {() => string[]} deps.getComplexityPaths
+ * @param {(section:string, newData:any)=>void} deps.onEdit
+ * @param {(section:string)=>void} [deps.onDelete]
+ */
+export function renderEntityComponentCard(host, card, deps) {
+  if (!host) return;
+  host.innerHTML = '';
+
+  const root = document.createElement('div');
+  root.className = 'entity-card';
+  root.dataset.section = card.section;
+  host.appendChild(root);
+
+  // Header
+  root.appendChild(renderHeader(card, root, deps));
+
+  // Body
+  const body = document.createElement('div');
+  body.className = 'entity-card-body';
+  if (card.collapsed) body.classList.add('hidden');
+  root.appendChild(body);
+
+  // Special-cased sections delegate entirely.
+  if (card.section === 'behaviour' && !card.showRaw) {
+    renderEntityBehaviourView(body, card.data, {
+      onEdit: (newData) => deps.onEdit(card.section, newData),
+    });
+    return;
+  }
+  if (card.section === 'stations' && !card.showRaw) {
+    renderEntityStationsView(body, card.data, {
+      onEdit: (newData) => deps.onEdit(card.section, newData),
+    });
+    return;
+  }
+
+  // Raw OR no schema → textarea.
+  if (card.showRaw || !card.schema) {
+    renderRawTextarea(body, card, deps);
+    return;
+  }
+
+  renderSchemaFields(body, card, deps);
+}
+
+// ── Header ─────────────────────────────────────────────────────────────
+
+function renderHeader(card, root, deps) {
+  const header = document.createElement('div');
+  header.className = 'entity-card-header';
+
+  const label = document.createElement('span');
+  label.className = 'entity-card-label';
+  label.textContent = card.schema?.label || card.section;
+  header.appendChild(label);
+
+  const collapseBtn = makeIconButton(card.collapsed ? '▸' : '▾', () => {
+    card.toggle();
+    // Re-render entirely (host owns the re-render flow on edits, but
+    // toggle is a local UI concern; the easiest path is to re-render
+    // this single card in-place).
+    rerender(root, card, deps);
+  }, 'collapse');
+  header.appendChild(collapseBtn);
+
+  const rawBtn = makeIconButton(card.showRaw ? 'fields' : 'raw', () => {
+    card.toggleRaw();
+    rerender(root, card, deps);
+  }, 'raw-toggle');
+  header.appendChild(rawBtn);
+
+  if (typeof deps.onDelete === 'function') {
+    const delBtn = makeIconButton('✕', () => deps.onDelete(card.section), 'delete');
+    header.appendChild(delBtn);
+  }
+
+  return header;
+}
+
+function makeIconButton(text, fn, kind) {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.className = `entity-card-btn entity-card-btn-${kind}`;
+  b.textContent = text;
+  b.addEventListener('click', fn);
+  return b;
+}
+
+function rerender(root, card, deps) {
+  const host = root.parentElement;
+  if (!host) return;
+  renderEntityComponentCard(host, card, deps);
+}
+
+// ── Raw textarea ───────────────────────────────────────────────────────
+
+function renderRawTextarea(body, card, deps) {
+  const wrap = document.createElement('div');
+  wrap.className = 'entity-card-raw-wrap';
+  body.appendChild(wrap);
+
+  const ta = document.createElement('textarea');
+  ta.className = 'entity-card-raw-textarea';
+  ta.rows = 8;
+  ta.value = card.getRawToml();
+  wrap.appendChild(ta);
+
+  const err = document.createElement('div');
+  err.className = 'entity-card-raw-error';
+  wrap.appendChild(err);
+
+  ta.addEventListener('input', () => {
+    try {
+      const parsed = parseEntityToml(ta.value);
+      if (!parsed || typeof parsed !== 'object') throw new Error('Section TOML must be an object.');
+      const sectionData = parsed[card.section];
+      if (sectionData === undefined) {
+        err.textContent = `Expected a [${card.section}] section.`;
+        return;
+      }
+      err.textContent = '';
+      deps.onEdit(card.section, sectionData);
+    } catch (e) {
+      err.textContent = `Parse error: ${e.message}`;
+    }
+  });
+}
+
+// ── Schema-driven inputs ───────────────────────────────────────────────
+
+function renderSchemaFields(body, card, deps) {
+  const data = card.data;
+  // Top-level scalar (e.g. `faction = "uuid"`): the section name IS the key.
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    renderScalarSection(body, card, deps);
+    return;
+  }
+
+  for (const field of card.schema.fields) {
+    const row = renderField(card, field, deps);
+    if (row) body.appendChild(row);
+  }
+}
+
+function renderScalarSection(body, card, deps) {
+  // Treat as a single-field section where the field key matches the section.
+  const field = card.schema.fields[0];
+  if (!field) return;
+  const row = document.createElement('div');
+  row.className = 'entity-card-field';
+
+  const label = document.createElement('label');
+  label.textContent = field.key;
+  row.appendChild(label);
+
+  const input = makeInputForField(field, card.data, deps, (newValue) => {
+    deps.onEdit(card.section, newValue);
+  });
+  row.appendChild(input);
+  body.appendChild(row);
+}
+
+function renderField(card, field, deps) {
+  // Skip optional fields that are missing AND have no default value present?
+  // Render them anyway so the user can fill in. The faction dropdown is
+  // optional and we always want to show it.
+  const value = card.data?.[field.key];
+
+  const row = document.createElement('div');
+  row.className = 'entity-card-field';
+
+  const label = document.createElement('label');
+  label.textContent = field.key;
+  row.appendChild(label);
+
+  const input = makeInputForField(field, value, deps, (newValue) => {
+    const next = { ...card.data };
+    if (newValue === undefined || newValue === null || newValue === '') {
+      delete next[field.key];
+    } else {
+      next[field.key] = newValue;
+    }
+    deps.onEdit(card.section, next);
+  });
+  row.appendChild(input);
+
+  return row;
+}
+
+function makeInputForField(field, value, deps, onChange) {
+  // Faction dropdown.
+  if (field.dropdownSource === 'factions') {
+    const sel = document.createElement('select');
+    sel.className = 'entity-card-input entity-card-input-faction';
+    const blank = document.createElement('option');
+    blank.value = '';
+    blank.textContent = '(none)';
+    sel.appendChild(blank);
+    for (const { uuid, name } of deps.getFactionOptions()) {
+      const o = document.createElement('option');
+      o.value = uuid;
+      o.textContent = `${name} (${uuid})`;
+      sel.appendChild(o);
+    }
+    sel.value = value != null ? String(value) : '';
+    sel.addEventListener('change', (e) => onChange(e.target.value || null));
+    return sel;
+  }
+
+  // Complexity dropdown.
+  if (field.dropdownSource === 'complexity') {
+    const sel = document.createElement('select');
+    sel.className = 'entity-card-input entity-card-input-complexity';
+    const blank = document.createElement('option');
+    blank.value = '';
+    blank.textContent = '(none)';
+    sel.appendChild(blank);
+    for (const p of deps.getComplexityPaths()) {
+      const o = document.createElement('option');
+      o.value = p;
+      o.textContent = p;
+      sel.appendChild(o);
+    }
+    sel.value = value != null ? String(value) : '';
+    sel.addEventListener('change', (e) => onChange(e.target.value || null));
+    return sel;
+  }
+
+  // Enum.
+  if (Array.isArray(field.enum)) {
+    const sel = document.createElement('select');
+    sel.className = 'entity-card-input';
+    for (const opt of field.enum) {
+      const o = document.createElement('option');
+      o.value = opt;
+      o.textContent = opt;
+      sel.appendChild(o);
+    }
+    sel.value = value != null ? String(value) : field.enum[0];
+    sel.addEventListener('change', (e) => onChange(e.target.value));
+    return sel;
+  }
+
+  // Boolean.
+  if (field.type === 'boolean') {
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.className = 'entity-card-input';
+    cb.checked = !!value;
+    cb.addEventListener('change', (e) => onChange(!!e.target.checked));
+    return cb;
+  }
+
+  // Number.
+  if (field.type === 'number') {
+    const inp = document.createElement('input');
+    inp.type = 'number';
+    inp.step = 'any';
+    inp.className = 'entity-card-input';
+    inp.value = value != null ? String(value) : '';
+    inp.addEventListener('input', (e) => {
+      const s = e.target.value;
+      if (s === '') return onChange(undefined);
+      const n = Number(s);
+      if (Number.isFinite(n)) onChange(n);
+    });
+    return inp;
+  }
+
+  // Array.
+  if (field.type === 'array') {
+    const ta = document.createElement('textarea');
+    ta.className = 'entity-card-input entity-card-input-array';
+    ta.rows = 2;
+    ta.value = Array.isArray(value) ? value.join(', ') : '';
+    ta.addEventListener('input', (e) => {
+      const raw = e.target.value;
+      if (raw.trim() === '') return onChange([]);
+      const parts = raw.split(',').map((p) => p.trim()).filter((p) => p.length > 0);
+      if (field.items === 'number') {
+        const nums = parts.map(Number);
+        if (nums.some((n) => !Number.isFinite(n))) return; // skip until valid
+        onChange(nums);
+      } else {
+        onChange(parts);
+      }
+    });
+    return ta;
+  }
+
+  // Object → JSON-ish read-only display (advanced edits go through raw mode).
+  if (field.type === 'object') {
+    const ta = document.createElement('textarea');
+    ta.className = 'entity-card-input entity-card-input-object';
+    ta.rows = 3;
+    try {
+      ta.value = value !== undefined ? stringifyEntityToml({ [field.key]: value }) : '';
+    } catch {
+      ta.value = '';
+    }
+    ta.disabled = true;
+    return ta;
+  }
+
+  // String (default).
+  const inp = document.createElement('input');
+  inp.type = 'text';
+  inp.className = 'entity-card-input';
+  inp.value = value != null ? String(value) : '';
+  inp.addEventListener('input', (e) => onChange(e.target.value));
+  return inp;
+}

--- a/editor/entity-component-stack-view.js
+++ b/editor/entity-component-stack-view.js
@@ -1,0 +1,63 @@
+/**
+ * entity-component-stack-view.js
+ *
+ * Centre pane of Entity Mode. Stacks one card per `ComponentCard` plus a
+ * "+ Add Component" button that opens the two-tier picker.
+ */
+
+import { renderEntityComponentCard } from './entity-component-card-view.js';
+import { renderAddComponentMenu } from './entity-add-component-menu.js';
+
+export function renderEntityComponentStackView(host, { cards, deps, onAddChoice }) {
+  if (!host) return;
+  host.innerHTML = '';
+
+  const root = document.createElement('div');
+  root.className = 'entity-component-stack';
+  host.appendChild(root);
+
+  if (!cards || cards.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'placeholder';
+    empty.textContent = 'No components — add one below.';
+    root.appendChild(empty);
+  }
+
+  for (const card of cards || []) {
+    const cardHost = document.createElement('div');
+    cardHost.className = 'entity-component-stack-card-host';
+    root.appendChild(cardHost);
+    renderEntityComponentCard(cardHost, card, deps);
+  }
+
+  // Add-component composer.
+  const addWrap = document.createElement('div');
+  addWrap.className = 'entity-add-component';
+  root.appendChild(addWrap);
+
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.className = 'entity-add-component-btn';
+  addBtn.textContent = '+ Add Component';
+  addWrap.appendChild(addBtn);
+
+  const menuHost = document.createElement('div');
+  menuHost.className = 'entity-add-component-menu-host';
+  menuHost.style.display = 'none';
+  addWrap.appendChild(menuHost);
+
+  addBtn.addEventListener('click', () => {
+    const shown = menuHost.style.display !== 'none';
+    if (shown) {
+      menuHost.style.display = 'none';
+      menuHost.innerHTML = '';
+      return;
+    }
+    menuHost.style.display = '';
+    renderAddComponentMenu(menuHost, (choice) => {
+      menuHost.style.display = 'none';
+      menuHost.innerHTML = '';
+      onAddChoice(choice);
+    });
+  });
+}

--- a/editor/entity-file-list-view.js
+++ b/editor/entity-file-list-view.js
@@ -1,0 +1,46 @@
+/**
+ * entity-file-list-view.js
+ *
+ * Left pane of Entity Mode. Renders one row per entity TOML path, with a
+ * dirty-dot indicator (`modeShell.isDirty('Entity', path)`) and click →
+ * `onSelect(path)`.
+ */
+
+export function renderEntityFileListView(host, { paths, activePath, modeShell, onSelect }) {
+  if (!host) return;
+  host.innerHTML = '';
+
+  const root = document.createElement('div');
+  root.className = 'entity-file-list';
+  host.appendChild(root);
+
+  if (!paths || paths.length === 0) {
+    const p = document.createElement('p');
+    p.className = 'placeholder';
+    p.textContent = 'No entity files. Pick a project root.';
+    root.appendChild(p);
+    return;
+  }
+
+  for (const path of paths) {
+    const row = document.createElement('div');
+    row.className = 'entity-file-list-row';
+    row.dataset.path = path;
+    if (path === activePath) row.classList.add('entity-file-list-row-active');
+
+    if (modeShell && modeShell.isDirty('Entity', path)) {
+      const dot = document.createElement('span');
+      dot.className = 'dirty-dot';
+      dot.textContent = '●';
+      row.appendChild(dot);
+    }
+
+    const label = document.createElement('span');
+    label.className = 'entity-file-list-label';
+    label.textContent = path.replace(/^assets\/entities\//, '');
+    row.appendChild(label);
+
+    row.addEventListener('click', () => onSelect(path));
+    root.appendChild(row);
+  }
+}

--- a/editor/entity-mode-view.js
+++ b/editor/entity-mode-view.js
@@ -1,0 +1,278 @@
+/**
+ * entity-mode-view.js
+ *
+ * Top-level coordinator for the Entity Mode three-pane shell.
+ *
+ *   Left   — entity file list (entity-file-list-view)
+ *   Centre — component card stack + add menu (entity-component-stack-view)
+ *   Right  — Konva preview + overlay (entity-preview-view)
+ *
+ * Owns a single EntityModeShell instance and wires:
+ *   - file-list selection → readFile → shell.openFile → re-render
+ *   - card edits → snapshot-before-mutate → shell.setSection →
+ *     saveFlow.setContent('Entity', path, parsed) → markDirty
+ *   - registerRestore('Entity', …) for Ctrl+Z dispatch
+ *   - entityCache.onInvalidate → refresh file list
+ *
+ * Imports are deferred so unit-test seams stay clean: discovery / fs
+ * helpers are passed in as deps.
+ */
+
+import { EntityModeShell } from './entity-mode.js';
+import { discoverFactionsAndComplexity } from './faction-complexity-discovery.js';
+import { renderEntityFileListView } from './entity-file-list-view.js';
+import { renderEntityComponentStackView } from './entity-component-stack-view.js';
+import { renderEntityPreviewView } from './entity-preview-view.js';
+import { entityCache, onInvalidate, preloadEntityCache } from './entity-cache.js';
+import { readFile, listDirectory, getProjectRoot } from './project-root.js';
+
+/**
+ * Mount the Entity Mode UI into `host`.
+ *
+ * @param {object} opts
+ * @param {HTMLElement} opts.host
+ * @param {import('./mode-shell.js').ModeShell} opts.modeShell
+ * @param {import('./save-flow.js').SaveFlow} opts.saveFlow
+ * @param {(mode:string, fn:(modeShell, path, direction)=>void)=>void} opts.registerRestore
+ * @param {object} [opts.io]  Override I/O for tests: { readFile, listDirectory,
+ *                            preload, onCacheInvalidate, getProjectRoot, discover }.
+ * @returns {{ shell: EntityModeShell, render: () => void }}
+ */
+export function mountEntityMode({ host, modeShell, saveFlow, registerRestore, io }) {
+  if (!host) return null;
+
+  const shell = new EntityModeShell();
+
+  const ioDeps = {
+    readFile: io?.readFile || readFile,
+    listDirectory: io?.listDirectory || listDirectory,
+    preload: io?.preload || preloadEntityCache,
+    onCacheInvalidate: io?.onCacheInvalidate || onInvalidate,
+    getProjectRoot: io?.getProjectRoot || getProjectRoot,
+    discover: io?.discover || discoverFactionsAndComplexity,
+    Konva: io?.Konva,
+  };
+
+  // Three-pane skeleton.
+  host.innerHTML = '';
+  const wrap = document.createElement('div');
+  wrap.className = 'entity-three-pane';
+  host.appendChild(wrap);
+
+  const leftPane = document.createElement('div');
+  leftPane.className = 'entity-pane entity-pane-left';
+  wrap.appendChild(leftPane);
+
+  const centerPane = document.createElement('div');
+  centerPane.className = 'entity-pane entity-pane-center';
+  wrap.appendChild(centerPane);
+
+  const rightPane = document.createElement('div');
+  rightPane.className = 'entity-pane entity-pane-right';
+  wrap.appendChild(rightPane);
+
+  // ── State + render helpers ────────────────────────────────────────────
+  let rawTextCache = new Map(); // path → raw TOML (so we can re-open after edits)
+
+  function renderLeft() {
+    const paths = shell.getFileList();
+    renderEntityFileListView(leftPane, {
+      paths,
+      activePath: shell.getActiveFile(),
+      modeShell,
+      onSelect: (path) => loadEntity(path),
+    });
+  }
+
+  function renderCenter() {
+    const active = shell.getActiveFile();
+    if (!active) {
+      centerPane.innerHTML = '<p class="placeholder">Select an entity file from the left.</p>';
+      return;
+    }
+    renderEntityComponentStackView(centerPane, {
+      cards: shell.getComponentCards(),
+      deps: makeCardDeps(),
+      onAddChoice: (choice) => handleAddChoice(choice),
+    });
+  }
+
+  function renderRight() {
+    const preview = shell.getPreviewPane();
+    renderEntityPreviewView(rightPane, preview, { Konva: ioDeps.Konva });
+  }
+
+  function renderAll() {
+    renderLeft();
+    renderCenter();
+    renderRight();
+  }
+
+  function makeCardDeps() {
+    return {
+      getFactionOptions: () => shell.getFactionDropdownOptions(),
+      getComplexityPaths: () => shell.getComplexityPaths(),
+      onEdit: (section, newData) => handleCardEdit(section, newData),
+      onDelete: (section) => handleCardDelete(section),
+    };
+  }
+
+  // ── Edit pipeline ─────────────────────────────────────────────────────
+
+  function handleCardEdit(section, newData) {
+    const path = shell.getActiveFile();
+    if (!path) return;
+    snapshotBeforeMutate(path);
+    shell.setSection(section, newData);
+    const parsed = shell.getParsedEntity();
+    saveFlow.setContent('Entity', path, parsed);
+    modeShell.markDirty('Entity', path, true);
+    renderCenter();
+    renderRight();
+    renderLeft(); // dirty-dot indicator
+  }
+
+  function handleCardDelete(section) {
+    const path = shell.getActiveFile();
+    if (!path) return;
+    snapshotBeforeMutate(path);
+    shell.setSection(section, undefined);
+    const parsed = shell.getParsedEntity();
+    saveFlow.setContent('Entity', path, parsed);
+    modeShell.markDirty('Entity', path, true);
+    renderAll();
+  }
+
+  function handleAddChoice(choice) {
+    const path = shell.getActiveFile();
+    if (!path) return;
+    snapshotBeforeMutate(path);
+    if (choice.kind === 'combo') {
+      shell.addCombo(choice.name);
+    } else if (choice.kind === 'raw') {
+      shell.addComponent(choice.sectionKey);
+    }
+    const parsed = shell.getParsedEntity();
+    saveFlow.setContent('Entity', path, parsed);
+    modeShell.markDirty('Entity', path, true);
+    renderAll();
+  }
+
+  function snapshotBeforeMutate(path) {
+    const parsed = shell.getParsedEntity();
+    if (!parsed) return;
+    modeShell.pushUndoEntry('Entity', path, structuredClone(parsed));
+  }
+
+  // ── File load ─────────────────────────────────────────────────────────
+
+  async function loadEntity(path) {
+    let text = rawTextCache.get(path);
+    if (text === undefined) {
+      try {
+        text = await ioDeps.readFile(path);
+        rawTextCache.set(path, text);
+      } catch (err) {
+        console.warn(`[entity-mode-view] failed to read ${path}: ${err?.message || err}`);
+        return;
+      }
+    }
+    const result = shell.openFile(path, text);
+    if (!result.ok) {
+      console.warn(`[entity-mode-view] openFile failed for ${path}:`, result.errors);
+    }
+    modeShell.setActiveFile('Entity', path);
+    saveFlow.setContent('Entity', path, shell.getParsedEntity());
+    renderAll();
+  }
+
+  async function refreshFileList() {
+    let entries = [];
+    try {
+      entries = await ioDeps.listDirectory('assets/entities');
+    } catch {
+      entries = [];
+    }
+    const paths = (entries || [])
+      .filter((e) => e && e.kind === 'file' && typeof e.name === 'string' && e.name.endsWith('.toml'))
+      .map((e) => `assets/entities/${e.name}`)
+      .sort();
+    shell.setFileList(paths);
+    modeShell.setOpenFiles('Entity', paths);
+    renderLeft();
+  }
+
+  // ── Undo restore registration ─────────────────────────────────────────
+
+  if (typeof registerRestore === 'function') {
+    registerRestore('Entity', (ms, path, direction) => {
+      const current = structuredClone(shell.getParsedEntity());
+      const snap = direction === 'undo'
+        ? ms.swapUndoActive('Entity', path, current)
+        : ms.swapRedoActive('Entity', path, current);
+      if (!snap) return;
+      shell.restoreParsed(snap);
+      saveFlow.setContent('Entity', path, snap);
+      renderCenter();
+      renderRight();
+    });
+  }
+
+  // ── Cache invalidation ────────────────────────────────────────────────
+  let invalidationSub = null;
+  if (typeof ioDeps.onCacheInvalidate === 'function') {
+    invalidationSub = ioDeps.onCacheInvalidate((changedPath) => {
+      // Drop our local rawText cache for the changed file so the next
+      // openFile re-reads from disk.
+      if (changedPath) rawTextCache.delete(changedPath);
+      else rawTextCache.clear();
+      refreshFileList();
+    });
+  }
+
+  // ── Bootstrap ─────────────────────────────────────────────────────────
+  (async () => {
+    // Initial discovery (factions + complexity).
+    try {
+      const { factionMap, complexityPaths } = await ioDeps.discover({
+        listDirectory: ioDeps.listDirectory,
+        readFile: ioDeps.readFile,
+      });
+      shell.setFactionMap(factionMap);
+      shell.setComplexityPaths(complexityPaths);
+    } catch (err) {
+      console.warn('[entity-mode-view] discovery failed:', err?.message || err);
+    }
+
+    // If no project root is selected yet, show CTA in the left pane.
+    try {
+      const root = await ioDeps.getProjectRoot();
+      if (!root) {
+        leftPane.innerHTML = '<p class="placeholder">Pick a project root to load entity files.</p>';
+        return;
+      }
+    } catch {
+      // best-effort; carry on
+    }
+
+    // Preload entity cache so future Save → invalidate keeps tags etc. fresh.
+    try {
+      await ioDeps.preload();
+    } catch {
+      // Already warned upstream.
+    }
+
+    await refreshFileList();
+  })();
+
+  return {
+    shell,
+    render: renderAll,
+    _internal: {
+      loadEntity,
+      refreshFileList,
+      handleCardEdit,
+      handleAddChoice,
+    },
+  };
+}

--- a/editor/entity-mode.js
+++ b/editor/entity-mode.js
@@ -288,6 +288,41 @@ export class EntityModeShell {
     return { ok: true, warnings };
   }
 
+  // ── Mutation: section update + parsed-state restoration ──────────────────
+
+  /**
+   * Replace one section's data in the active entity. The card list is
+   * rebuilt so any newly-present or newly-removed section shows up.
+   * No-ops if no file is open.
+   * @param {string} sectionKey
+   * @param {any} newData
+   */
+  setSection(sectionKey, newData) {
+    if (!this._parsedEntity) return;
+    if (newData === undefined || newData === null) {
+      delete this._parsedEntity[sectionKey];
+    } else {
+      this._parsedEntity[sectionKey] = newData;
+    }
+    this._cards = this._buildCards(this._parsedEntity);
+  }
+
+  /**
+   * Replace the entire parsed entity (used by the undo restore callback).
+   * Card list is rebuilt. No-ops if `parsed` is falsy.
+   * @param {object} parsed
+   */
+  restoreParsed(parsed) {
+    if (!parsed || typeof parsed !== 'object') return;
+    this._parsedEntity = parsed;
+    this._cards = this._buildCards(parsed);
+  }
+
+  /** Internal getter used by the view to read the live parsed object. */
+  getParsedEntity() {
+    return this._parsedEntity;
+  }
+
   // ── Private helpers ───────────────────────────────────────────────────────
 
   /**

--- a/editor/entity-preview-view.js
+++ b/editor/entity-preview-view.js
@@ -1,0 +1,254 @@
+/**
+ * entity-preview-view.js
+ *
+ * DOM/Konva renderer for the Entity Mode right pane. Consumes the pure
+ * `computeEntityPreview` data and draws a single fixed-viewport stage with:
+ *
+ *   - Forward arrow at the origin (small triangle pointing -Z, drawn up).
+ *   - Collider outline (Ball → circle, Capsule → pill).
+ *   - Radar shape (via tag-shape-map): triangle/dot/diamond/ring/square.
+ *   - Region shape (sphere → ring, box → rect, torus → donut).
+ *   - Asteroid-field donut.
+ *   - Top-left text overlay: tags, faction name, consoles, hull total.
+ *
+ * The viewport is sized to the largest dimension across all primitives,
+ * with ~20% padding, and centred on (0,0). Konva is read off `window.Konva`
+ * (loaded by editor.html); tests inject a mock via the second argument.
+ */
+import { RADAR_SHAPE } from './tag-shape-map.js';
+
+const PADDING_RATIO = 0.2;
+const MIN_VIEW = 60;
+const DEFAULT_VIEW = 240;
+
+export function renderEntityPreviewView(host, preview, { Konva } = {}) {
+  if (!host) return null;
+  // Clear host
+  host.innerHTML = '';
+
+  const K = Konva ?? (typeof window !== 'undefined' ? window.Konva : null);
+  if (!K) {
+    const msg = document.createElement('p');
+    msg.className = 'entity-preview-error';
+    msg.textContent = 'Konva not available — preview disabled.';
+    host.appendChild(msg);
+    return null;
+  }
+
+  if (!preview || preview.placeholder) {
+    const ph = document.createElement('p');
+    ph.className = 'placeholder';
+    ph.textContent = preview?.activeFile ? 'Loading preview…' : 'No entity selected.';
+    host.appendChild(ph);
+    return null;
+  }
+
+  // Compute world extent (largest of collider/radar/region/field).
+  const extent = computeExtent(preview);
+  const viewSize = Math.max(MIN_VIEW, extent * (1 + PADDING_RATIO * 2)) || DEFAULT_VIEW;
+
+  const canvasHost = document.createElement('div');
+  canvasHost.className = 'entity-preview-canvas';
+  host.appendChild(canvasHost);
+
+  const overlay = renderOverlay(preview);
+  host.appendChild(overlay);
+
+  // We'd ideally pick a pixel size by container; use 480 default.
+  const pxSize = 480;
+  const scale = pxSize / viewSize;
+
+  const stage = new K.Stage({ container: canvasHost, width: pxSize, height: pxSize });
+  const layer = new K.Layer();
+  stage.add(layer);
+
+  const cx = pxSize / 2;
+  const cy = pxSize / 2;
+  const w2s = (v) => v * scale;
+
+  // ── Region shape ──────────────────────────────────────────────────────
+  if (preview.regionShape) {
+    drawRegionShape(K, layer, preview.regionShape, cx, cy, w2s);
+  }
+
+  // ── Asteroid-field donut ──────────────────────────────────────────────
+  if (preview.asteroidField) {
+    drawDonut(
+      K, layer, cx, cy,
+      w2s(preview.asteroidField.innerRadius || 0),
+      w2s(preview.asteroidField.outerRadius || 0),
+      '#aa9966', 0.25,
+    );
+  }
+
+  // ── Collider ──────────────────────────────────────────────────────────
+  if (preview.colliderShape) {
+    drawCollider(K, layer, preview, cx, cy, w2s);
+  }
+
+  // ── Radar shape ───────────────────────────────────────────────────────
+  if (preview.radarShape) {
+    drawRadarShape(K, layer, preview, cx, cy, w2s);
+  }
+
+  // ── Forward arrow ─────────────────────────────────────────────────────
+  if (preview.showForwardArrow) {
+    drawForwardArrow(K, layer, cx, cy);
+  }
+
+  layer.draw?.();
+  return stage;
+}
+
+function computeExtent(p) {
+  let max = 0;
+  if (p.colliderRadius) max = Math.max(max, Math.abs(p.colliderRadius));
+  if (p.colliderLength) max = Math.max(max, Math.abs(p.colliderLength) / 2);
+  if (p.radarRadius) max = Math.max(max, Math.abs(p.radarRadius));
+  const rs = p.regionShape;
+  if (rs) {
+    if (rs.type === 'sphere' && rs.radius) max = Math.max(max, Math.abs(rs.radius));
+    if (rs.type === 'torus' && rs.outerRadius) max = Math.max(max, Math.abs(rs.outerRadius));
+    if (rs.type === 'box' && Array.isArray(rs.halfExtents)) {
+      for (const v of rs.halfExtents) max = Math.max(max, Math.abs(v));
+    }
+  }
+  if (p.asteroidField?.outerRadius) max = Math.max(max, Math.abs(p.asteroidField.outerRadius));
+  return max;
+}
+
+function drawRegionShape(K, layer, rs, cx, cy, w2s) {
+  if (rs.type === 'sphere' && rs.radius != null) {
+    layer.add(new K.Circle({
+      x: cx, y: cy, radius: w2s(rs.radius),
+      stroke: '#88aaff', strokeWidth: 1.5, dash: [4, 3], opacity: 0.7,
+    }));
+  } else if (rs.type === 'box' && Array.isArray(rs.halfExtents)) {
+    const w = w2s(rs.halfExtents[0] || 0) * 2;
+    const h = w2s(rs.halfExtents[2] ?? rs.halfExtents[1] ?? 0) * 2;
+    layer.add(new K.Rect({
+      x: cx - w / 2, y: cy - h / 2,
+      width: w, height: h,
+      rotation: ((rs.yaw || 0) * 180) / Math.PI,
+      stroke: '#88aaff', strokeWidth: 1.5, dash: [4, 3], opacity: 0.7,
+    }));
+  } else if (rs.type === 'torus') {
+    drawDonut(K, layer, cx, cy, w2s(rs.innerRadius || 0), w2s(rs.outerRadius || 0), '#88aaff', 0.35);
+  }
+}
+
+function drawDonut(K, layer, cx, cy, innerR, outerR, fill, opacity) {
+  layer.add(new K.Ring({
+    x: cx, y: cy,
+    innerRadius: innerR, outerRadius: outerR,
+    fill, opacity, stroke: fill, strokeWidth: 1,
+  }));
+}
+
+function drawCollider(K, layer, p, cx, cy, w2s) {
+  const shape = p.colliderShape;
+  const r = w2s(p.colliderRadius || 0);
+  if (shape === 'Ball') {
+    layer.add(new K.Circle({
+      x: cx, y: cy, radius: r,
+      stroke: '#ffaa66', strokeWidth: 1.5, opacity: 0.9,
+    }));
+  } else if (shape === 'Capsule') {
+    const half = w2s((p.colliderLength || 0) / 2);
+    // Pill: two semicircles + a rect, oriented along Z (which we draw as Y).
+    layer.add(new K.Line({
+      points: [cx - r, cy - half, cx + r, cy - half],
+      stroke: '#ffaa66', strokeWidth: 1.5,
+    }));
+    layer.add(new K.Line({
+      points: [cx - r, cy + half, cx + r, cy + half],
+      stroke: '#ffaa66', strokeWidth: 1.5,
+    }));
+    layer.add(new K.Arc({
+      x: cx, y: cy - half, innerRadius: r, outerRadius: r,
+      angle: 180, rotation: 180,
+      stroke: '#ffaa66', strokeWidth: 1.5,
+    }));
+    layer.add(new K.Arc({
+      x: cx, y: cy + half, innerRadius: r, outerRadius: r,
+      angle: 180, rotation: 0,
+      stroke: '#ffaa66', strokeWidth: 1.5,
+    }));
+  }
+}
+
+function drawRadarShape(K, layer, p, cx, cy, w2s) {
+  const shape = p.radarShape;
+  const r = w2s(p.radarRadius || 4);
+  const fill = colourToHex(p.radarColour) ?? '#cccccc';
+  if (shape === RADAR_SHAPE.Triangle) {
+    layer.add(new K.RegularPolygon({
+      x: cx, y: cy, sides: 3, radius: r, fill, rotation: 0,
+    }));
+  } else if (shape === RADAR_SHAPE.Diamond) {
+    layer.add(new K.RegularPolygon({
+      x: cx, y: cy, sides: 4, radius: r, fill, rotation: 45,
+    }));
+  } else if (shape === RADAR_SHAPE.Ring) {
+    layer.add(new K.Ring({
+      x: cx, y: cy, innerRadius: r * 0.6, outerRadius: r, fill,
+    }));
+  } else if (shape === RADAR_SHAPE.Square) {
+    layer.add(new K.Rect({
+      x: cx - r, y: cy - r, width: r * 2, height: r * 2, fill,
+    }));
+  } else {
+    layer.add(new K.Circle({ x: cx, y: cy, radius: Math.max(r, 2), fill }));
+  }
+}
+
+function drawForwardArrow(K, layer, cx, cy) {
+  // -Z is forward; we draw Y-up so the arrow points up (negative pixel Y).
+  layer.add(new K.RegularPolygon({
+    x: cx, y: cy - 14, sides: 3, radius: 6, fill: '#33ff66', rotation: 0,
+  }));
+}
+
+function renderOverlay(preview) {
+  const overlay = document.createElement('div');
+  overlay.className = 'entity-preview-overlay';
+
+  const t = preview.textOverlay || {};
+
+  const tagsRow = document.createElement('div');
+  tagsRow.className = 'entity-preview-overlay-row';
+  tagsRow.textContent = `tags: ${Array.isArray(t.tags) ? t.tags.join(', ') : ''}`;
+  overlay.appendChild(tagsRow);
+
+  if (t.faction != null) {
+    const fRow = document.createElement('div');
+    fRow.className = 'entity-preview-overlay-row';
+    fRow.textContent = `faction: ${t.faction}`;
+    overlay.appendChild(fRow);
+  }
+
+  if (Array.isArray(t.consoles) && t.consoles.length > 0) {
+    const cRow = document.createElement('div');
+    cRow.className = 'entity-preview-overlay-row';
+    cRow.textContent = `consoles: ${t.consoles.join(', ')}`;
+    overlay.appendChild(cRow);
+  }
+
+  if (t.hullTotal != null) {
+    const hRow = document.createElement('div');
+    hRow.className = 'entity-preview-overlay-row';
+    hRow.textContent = `hull: ${t.hullTotal}`;
+    overlay.appendChild(hRow);
+  }
+
+  return overlay;
+}
+
+function colourToHex(c) {
+  if (!Array.isArray(c) || c.length < 3) return null;
+  const to255 = (v) => Math.max(0, Math.min(255, Math.round(Number(v) * 255)));
+  const r = to255(c[0]).toString(16).padStart(2, '0');
+  const g = to255(c[1]).toString(16).padStart(2, '0');
+  const b = to255(c[2]).toString(16).padStart(2, '0');
+  return `#${r}${g}${b}`;
+}

--- a/editor/entity-stations-view.js
+++ b/editor/entity-stations-view.js
@@ -1,0 +1,263 @@
+/**
+ * entity-stations-view.js
+ *
+ * DOM renderer for the [stations] component card.
+ *
+ * Wraps `StationsEditor`. Per-player-count tab strip; the active tab shows
+ * an editable list of station rows (description / consoles / rank /
+ * short_code / next / previous). `name` is read-only. Inline validation
+ * banner at the top of each tab and per-station error chip next to the
+ * offending field.
+ *
+ * `onEdit(stationsData)` is called with `editor.toStations()` after every
+ * mutation.
+ */
+
+import { StationsEditor } from './stations-editor.js';
+
+let _activeCount = null; // module-level (single editor active at a time)
+
+export function renderEntityStationsView(host, stations, { onEdit }) {
+  if (!host) return;
+  host.innerHTML = '';
+
+  const editor = new StationsEditor();
+  editor.load(stations || {});
+
+  const counts = editor.getCounts();
+  if (_activeCount == null || !counts.includes(_activeCount)) {
+    _activeCount = counts[0] ?? null;
+  }
+
+  const rerender = () => renderEntityStationsView(host, editor.toStations(), { onEdit });
+
+  const mutate = (fn) => {
+    fn(editor);
+    onEdit(editor.toStations());
+    rerender();
+  };
+
+  const root = document.createElement('div');
+  root.className = 'entity-stations';
+  host.appendChild(root);
+
+  // ── Player count range ────────────────────────────────────────────────
+  const rangeRow = document.createElement('div');
+  rangeRow.className = 'entity-stations-range';
+
+  const minLbl = document.createElement('label');
+  minLbl.textContent = 'min_players';
+  rangeRow.appendChild(minLbl);
+  const minInp = document.createElement('input');
+  minInp.type = 'number';
+  minInp.value = String(editor.getMinPlayers());
+  minInp.addEventListener('input', (e) => {
+    const n = Number(e.target.value);
+    if (Number.isInteger(n) && n >= 1) {
+      mutate(() => { editor._minPlayers = n; });
+    }
+  });
+  rangeRow.appendChild(minInp);
+
+  const maxLbl = document.createElement('label');
+  maxLbl.textContent = 'max_players';
+  rangeRow.appendChild(maxLbl);
+  const maxInp = document.createElement('input');
+  maxInp.type = 'number';
+  maxInp.value = String(editor.getMaxPlayers());
+  maxInp.addEventListener('input', (e) => {
+    const n = Number(e.target.value);
+    if (Number.isInteger(n) && n >= editor.getMinPlayers()) {
+      mutate(() => { editor._maxPlayers = n; });
+    }
+  });
+  rangeRow.appendChild(maxInp);
+
+  root.appendChild(rangeRow);
+
+  // ── Tab strip ─────────────────────────────────────────────────────────
+  const tabs = document.createElement('div');
+  tabs.className = 'entity-stations-tabs';
+  for (const c of counts) {
+    const tab = document.createElement('button');
+    tab.type = 'button';
+    tab.className = 'entity-stations-tab';
+    if (c === _activeCount) tab.classList.add('entity-stations-tab-active');
+    tab.textContent = String(c);
+    tab.addEventListener('click', () => {
+      _activeCount = c;
+      rerender();
+    });
+    tabs.appendChild(tab);
+  }
+  root.appendChild(tabs);
+
+  // ── Active tab content ────────────────────────────────────────────────
+  const tabBody = document.createElement('div');
+  tabBody.className = 'entity-stations-tab-body';
+  root.appendChild(tabBody);
+
+  if (_activeCount == null) {
+    const p = document.createElement('p');
+    p.className = 'placeholder';
+    p.textContent = 'No player counts configured.';
+    tabBody.appendChild(p);
+    return;
+  }
+
+  // Validation. Filter to errors that mention this count.
+  const validation = editor.validate();
+  const tabErrors = (validation.errors || []).filter((err) => {
+    if (err.count == null) return false;
+    return Number(err.count) === _activeCount;
+  });
+  if (tabErrors.length > 0) {
+    const errList = document.createElement('div');
+    errList.className = 'entity-stations-error-list';
+    for (const err of tabErrors) {
+      const chip = document.createElement('div');
+      chip.className = 'entity-stations-error';
+      chip.dataset.kind = err.type || '';
+      chip.textContent = err.message || `${err.type}: ${err.station || ''}`;
+      errList.appendChild(chip);
+    }
+    tabBody.appendChild(errList);
+  }
+
+  // Station rows.
+  const stationsList = editor.getStations(_activeCount);
+  for (const s of stationsList) {
+    tabBody.appendChild(renderStationRow(s, _activeCount, editor, tabErrors, mutate));
+  }
+
+  // + Add Station.
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.className = 'entity-stations-add';
+  addBtn.textContent = '+ Add Station';
+  addBtn.addEventListener('click', () => {
+    mutate((ed) => {
+      const baseName = `station_${ed.getStations(_activeCount).length + 1}`;
+      ed.addStation(_activeCount, baseName, [], '', '', '');
+    });
+  });
+  tabBody.appendChild(addBtn);
+}
+
+function renderStationRow(s, count, editor, tabErrors, mutate) {
+  const row = document.createElement('div');
+  row.className = 'entity-stations-row';
+  row.dataset.station = s.name;
+
+  appendField(row, 'name', s.name, true, null);
+  appendField(row, 'description', s.description, false, (v) => {
+    mutate((ed) => ed.updateStation(count, s.name, { description: v }));
+  });
+  appendField(row, 'consoles', (s.consoles || []).join(', '), false, (v) => {
+    const list = v.split(',').map((p) => p.trim()).filter(Boolean);
+    mutate((ed) => ed.updateStation(count, s.name, { consoles: list }));
+  });
+  appendField(row, 'rank', s.rank, false, (v) => {
+    mutate((ed) => ed.updateStation(count, s.name, { rank: v }));
+  });
+  appendField(row, 'short_code', s.short_code, false, (v) => {
+    mutate((ed) => ed.updateStation(count, s.name, { short_code: v }));
+  });
+
+  // next dropdown.
+  const nextSel = makeStationDropdown(
+    'next',
+    s.next || '',
+    editor.getNextOptions(count),
+    (v) => mutate((ed) => ed.updateStation(count, s.name, { next: v })),
+  );
+  row.appendChild(nextSel.wrap);
+  const nextErr = tabErrors.find((e) => e.station === s.name && e.type && e.type.includes('next'));
+  if (nextErr) attachInlineError(nextSel.wrap, nextErr);
+
+  // previous dropdown.
+  const prevSel = makeStationDropdown(
+    'previous',
+    s.previous || '',
+    editor.getPreviousOptions(count),
+    (v) => mutate((ed) => ed.updateStation(count, s.name, { previous: v })),
+  );
+  row.appendChild(prevSel.wrap);
+  const prevErr = tabErrors.find((e) => e.station === s.name && e.type && e.type.includes('previous'));
+  if (prevErr) attachInlineError(prevSel.wrap, prevErr);
+
+  // remove.
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'entity-stations-row-remove';
+  removeBtn.textContent = '✕';
+  removeBtn.addEventListener('click', () => {
+    mutate((ed) => ed.removeStation(count, s.name));
+  });
+  row.appendChild(removeBtn);
+
+  return row;
+}
+
+function appendField(row, key, value, disabled, onChange) {
+  const wrap = document.createElement('div');
+  wrap.className = `entity-stations-field entity-stations-field-${key}`;
+  const lbl = document.createElement('label');
+  lbl.textContent = key;
+  wrap.appendChild(lbl);
+  const inp = document.createElement('input');
+  inp.type = 'text';
+  inp.value = value != null ? String(value) : '';
+  if (disabled) inp.disabled = true;
+  if (!disabled && onChange) {
+    inp.addEventListener('input', (e) => onChange(e.target.value));
+  }
+  wrap.appendChild(inp);
+  row.appendChild(wrap);
+}
+
+function makeStationDropdown(key, value, options, onChange) {
+  const wrap = document.createElement('div');
+  wrap.className = `entity-stations-field entity-stations-field-${key}`;
+  const lbl = document.createElement('label');
+  lbl.textContent = key;
+  wrap.appendChild(lbl);
+
+  const sel = document.createElement('select');
+  sel.className = `entity-stations-${key}`;
+  const blank = document.createElement('option');
+  blank.value = '';
+  blank.textContent = '(none)';
+  sel.appendChild(blank);
+  for (const name of options) {
+    const o = document.createElement('option');
+    o.value = name;
+    o.textContent = name;
+    sel.appendChild(o);
+  }
+  // If current value isn't in options, add it as a "dangling" sentinel so
+  // the user can see what's set even when it doesn't resolve.
+  if (value && !options.includes(value)) {
+    const o = document.createElement('option');
+    o.value = value;
+    o.textContent = `${value} (dangling)`;
+    sel.appendChild(o);
+  }
+  sel.value = value || '';
+  sel.addEventListener('change', (e) => onChange(e.target.value));
+  wrap.appendChild(sel);
+  return { wrap, sel };
+}
+
+function attachInlineError(wrap, err) {
+  const chip = document.createElement('span');
+  chip.className = 'entity-stations-inline-error';
+  chip.dataset.kind = err.type || '';
+  chip.textContent = err.type || 'error';
+  wrap.appendChild(chip);
+}
+
+/** Test hook: reset active tab between renderings. */
+export function _resetActiveCountForTest() {
+  _activeCount = null;
+}

--- a/editor/faction-complexity-discovery.js
+++ b/editor/faction-complexity-discovery.js
@@ -1,0 +1,67 @@
+/**
+ * faction-complexity-discovery.js
+ *
+ * Pure async discovery helpers for Entity Mode. Walks
+ *   assets/factions/*.toml  → uuid→name map
+ *   assets/complexity/*.toml → sorted path list
+ *
+ * No DOM, no Bevy, no globals — accepts `listDirectory` and `readFile`
+ * as injected deps so tests can pass mocks.
+ *
+ * Missing directories degrade to empty results rather than throwing.
+ */
+import { buildFactionMap, buildComplexityPaths } from './entity-toml.js';
+
+/**
+ * Discover factions and complexity TOML paths under the project root.
+ *
+ * @param {object} deps
+ * @param {(rel: string) => Promise<Array<{name:string,kind:string}>>} deps.listDirectory
+ * @param {(rel: string) => Promise<string>} deps.readFile
+ * @returns {Promise<{ factionMap: Map<string,string>, complexityPaths: string[] }>}
+ */
+export async function discoverFactionsAndComplexity({ listDirectory, readFile }) {
+  const factionFiles = await readFactionFiles({ listDirectory, readFile });
+  const factionMap = buildFactionMap(factionFiles);
+
+  const complexityFilenames = await listComplexityFilenames({ listDirectory });
+  const complexityPaths = buildComplexityPaths(complexityFilenames);
+
+  return { factionMap, complexityPaths };
+}
+
+async function readFactionFiles({ listDirectory, readFile }) {
+  let entries;
+  try {
+    entries = await listDirectory('assets/factions');
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(entries)) return [];
+
+  const out = [];
+  for (const e of entries) {
+    if (!e || e.kind !== 'file') continue;
+    if (typeof e.name !== 'string' || !e.name.endsWith('.toml')) continue;
+    try {
+      const content = await readFile(`assets/factions/${e.name}`);
+      out.push({ name: e.name, content });
+    } catch {
+      // skip unreadable files
+    }
+  }
+  return out;
+}
+
+async function listComplexityFilenames({ listDirectory }) {
+  let entries;
+  try {
+    entries = await listDirectory('assets/complexity');
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(entries)) return [];
+  return entries
+    .filter((e) => e && e.kind === 'file' && typeof e.name === 'string' && e.name.endsWith('.toml'))
+    .map((e) => e.name);
+}

--- a/editor/style.css
+++ b/editor/style.css
@@ -1306,18 +1306,18 @@ form {
 
 /* File list */
 .entity-file-list { display: flex; flex-direction: column; gap: 1px; }
-.entity-file-row {
+.entity-file-list-row {
   display: flex; align-items: center; gap: 6px;
   padding: 4px 8px; border-radius: 3px;
   color: #ccc; font-size: 12px; cursor: pointer;
 }
-.entity-file-row:hover { background: #2a2d34; }
-.entity-file-row.active { background: #3a4a66; color: #fff; }
-.entity-file-row .dirty-dot {
+.entity-file-list-row:hover { background: #2a2d34; }
+.entity-file-list-row-active { background: #3a4a66; color: #fff; }
+.entity-file-list-row .dirty-dot {
   width: 6px; height: 6px; border-radius: 50%;
   background: #d6a64a; flex-shrink: 0;
 }
-.entity-file-row .entity-file-label {
+.entity-file-list-row .entity-file-list-label {
   flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 

--- a/editor/style.css
+++ b/editor/style.css
@@ -1279,3 +1279,172 @@ form {
 .badge-open { background:#3a3d44; color:#aaa; }
 .badge-referenced { background:#3a2d5a; color:#cfcfe6; }
 
+
+/* -- Entity Mode (Slice 5) --------------------------------------------- */
+
+.entity-three-pane {
+  display: grid;
+  grid-template-columns: 220px 1fr 320px;
+  gap: 8px;
+  height: 100%;
+  min-height: 0;
+}
+.entity-pane {
+  background: #1e2126;
+  border: 1px solid #2f323a;
+  border-radius: 4px;
+  overflow: auto;
+  min-height: 0;
+}
+.entity-pane-left   { padding: 6px; }
+.entity-pane-center { padding: 8px; }
+.entity-pane-right  { padding: 0; position: relative; }
+
+.entity-pane .placeholder {
+  color: #777; font-size: 12px; padding: 12px; font-style: italic;
+}
+
+/* File list */
+.entity-file-list { display: flex; flex-direction: column; gap: 1px; }
+.entity-file-row {
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 8px; border-radius: 3px;
+  color: #ccc; font-size: 12px; cursor: pointer;
+}
+.entity-file-row:hover { background: #2a2d34; }
+.entity-file-row.active { background: #3a4a66; color: #fff; }
+.entity-file-row .dirty-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: #d6a64a; flex-shrink: 0;
+}
+.entity-file-row .entity-file-label {
+  flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+/* Component stack */
+.entity-component-stack {
+  display: flex; flex-direction: column; gap: 8px;
+}
+
+/* Component card */
+.entity-card {
+  background: #23262c; border: 1px solid #333740; border-radius: 4px;
+}
+.entity-card-header {
+  display: flex; align-items: center; gap: 6px;
+  padding: 6px 8px; background: #2a2d34;
+  border-bottom: 1px solid #333740;
+  border-radius: 4px 4px 0 0;
+}
+.entity-card-title { flex: 1; font-size: 12px; font-weight: 600; color: #ddd; }
+.entity-card-btn {
+  background: #2c2f36; border: 1px solid #3a3d44; color: #ccc;
+  padding: 2px 8px; border-radius: 3px; cursor: pointer; font-size: 11px;
+}
+.entity-card-btn:hover { background: #3a3d44; }
+.entity-card-btn-delete:hover { background: #5a2d2d; color: #fff; }
+.entity-card-body { padding: 8px; }
+.entity-card-body.hidden { display: none; }
+
+.entity-card-field {
+  display: flex; align-items: center; gap: 8px; margin-bottom: 6px;
+}
+.entity-card-field-label {
+  width: 140px; color: #aaa; font-size: 11px; flex-shrink: 0;
+}
+.entity-card-field-input { flex: 1; }
+.entity-card-input,
+.entity-card-input-array,
+.entity-card-input-faction,
+.entity-card-input-complexity {
+  width: 100%;
+  background: #1a1c20; border: 1px solid #333740; color: #ddd;
+  padding: 3px 6px; border-radius: 3px; font-size: 12px;
+  font-family: inherit;
+}
+.entity-card-input-array { font-family: monospace; min-height: 24px; resize: vertical; }
+.entity-card-raw-textarea {
+  width: 100%; min-height: 120px;
+  background: #1a1c20; border: 1px solid #333740; color: #ddd;
+  padding: 6px; border-radius: 3px; font-family: monospace; font-size: 12px;
+  resize: vertical;
+}
+.entity-card-raw-error {
+  color: #d66; font-size: 11px; margin-top: 4px; font-family: monospace;
+}
+
+/* Behaviour card */
+.entity-behaviour-section { margin-bottom: 10px; }
+.entity-behaviour-section h4 {
+  margin: 0 0 6px 0; font-size: 11px; color: #aaa;
+  text-transform: uppercase; letter-spacing: 0.5px;
+}
+.entity-behaviour-row {
+  display: flex; align-items: center; gap: 6px; margin-bottom: 4px;
+}
+.entity-behaviour-row select,
+.entity-behaviour-row input {
+  background: #1a1c20; border: 1px solid #333740; color: #ddd;
+  padding: 2px 6px; border-radius: 3px; font-size: 11px;
+}
+.entity-behaviour-validation {
+  background: #3a2424; color: #d99; padding: 6px 8px;
+  border-radius: 3px; font-size: 11px; margin-bottom: 8px;
+}
+
+/* Stations card */
+.entity-stations-tabs {
+  display: flex; gap: 2px; border-bottom: 1px solid #333740; margin-bottom: 8px;
+}
+.entity-stations-tab {
+  background: #2a2d34; border: 1px solid #333740; border-bottom: none;
+  color: #aaa; padding: 4px 10px; cursor: pointer; font-size: 11px;
+  border-radius: 3px 3px 0 0;
+}
+.entity-stations-tab.active { background: #1e2126; color: #fff; }
+.entity-stations-tab.has-errors { color: #d99; }
+.entity-stations-row {
+  display: flex; align-items: center; gap: 6px; margin-bottom: 4px;
+  padding: 4px; background: #1a1c20; border-radius: 3px;
+}
+.entity-stations-validation {
+  background: #3a2424; color: #d99; padding: 6px 8px;
+  border-radius: 3px; font-size: 11px; margin-bottom: 8px;
+}
+
+/* Add Component menu */
+.entity-add-component {
+  margin-top: 8px; background: #23262c;
+  border: 1px dashed #444; border-radius: 4px; padding: 8px;
+}
+.entity-add-menu { display: flex; flex-direction: column; gap: 2px; }
+.entity-add-menu-combo,
+.entity-add-menu-raw-toggle,
+.entity-add-menu-raw-section,
+.entity-add-menu-back {
+  background: #2a2d34; border: 1px solid #333740; color: #ddd;
+  padding: 4px 8px; border-radius: 3px; cursor: pointer;
+  font-size: 12px; text-align: left;
+}
+.entity-add-menu-combo:hover,
+.entity-add-menu-raw-toggle:hover,
+.entity-add-menu-raw-section:hover,
+.entity-add-menu-back:hover { background: #3a3d44; }
+.entity-add-menu-raw-toggle { font-style: italic; color: #aaa; }
+.entity-add-menu-submenu { display: flex; flex-direction: column; gap: 2px; }
+.entity-add-menu-back { background: #1e2126; color: #888; }
+
+/* Preview pane */
+.entity-preview-canvas {
+  width: 100%; height: 100%; min-height: 240px;
+  background: #0c0d10;
+}
+.entity-preview-overlay {
+  position: absolute; bottom: 6px; left: 6px; right: 6px;
+  background: rgba(0,0,0,0.6); color: #ccc;
+  font-size: 11px; padding: 4px 8px; border-radius: 3px;
+  font-family: monospace;
+}
+.entity-preview-error {
+  padding: 12px; color: #d66; font-size: 12px; font-family: monospace;
+}

--- a/editor/tests/entity-add-component-menu.test.js
+++ b/editor/tests/entity-add-component-menu.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// Reuse the minimal DOM shim.
+
+class FakeClassList {
+  constructor() { this._set = new Set(); }
+  add(c) { this._set.add(c); }
+  remove(c) { this._set.delete(c); }
+  contains(c) { return this._set.has(c); }
+}
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = (tag || 'div').toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this._listeners = new Map();
+    this.classList = new FakeClassList();
+    this.dataset = {};
+    this.textContent = '';
+    this._innerHTML = '';
+  }
+  set className(v) {
+    this.classList = new FakeClassList();
+    for (const c of String(v || '').split(/\s+/).filter(Boolean)) this.classList.add(c);
+    this._className = v;
+  }
+  get className() { return this._className || ''; }
+  appendChild(c) {
+    if (c.parentElement) {
+      const i = c.parentElement.children.indexOf(c);
+      if (i >= 0) c.parentElement.children.splice(i, 1);
+    }
+    c.parentElement = this;
+    this.children.push(c);
+    return c;
+  }
+  addEventListener(type, fn) {
+    if (!this._listeners.has(type)) this._listeners.set(type, []);
+    this._listeners.get(type).push(fn);
+  }
+  dispatchEvent(ev) {
+    const list = this._listeners.get(ev.type) || [];
+    for (const fn of list) fn(ev);
+  }
+  set innerHTML(v) { this._innerHTML = v; this.children = []; }
+  get innerHTML() { return this._innerHTML; }
+  _walk(pred, out = []) {
+    if (pred(this)) out.push(this);
+    for (const c of this.children) c._walk(pred, out);
+    return out;
+  }
+  querySelectorAll(sel) {
+    return this._walk((el) => {
+      if (sel.startsWith('.')) return el.classList.contains(sel.slice(1));
+      return el.tagName === sel.toUpperCase();
+    });
+  }
+}
+
+function installDom() {
+  globalThis.document = { createElement: (tag) => new FakeElement(tag) };
+}
+function fireClick(el) { el.dispatchEvent({ type: 'click', target: el }); }
+
+describe('renderAddComponentMenu', () => {
+  let renderAddComponentMenu;
+  let host;
+  beforeEach(async () => {
+    installDom();
+    host = new FakeElement('div');
+    ({ renderAddComponentMenu } = await import('../entity-add-component-menu.js'));
+  });
+
+  it('opens at the top level with combo entries and a "Raw section" toggle', () => {
+    renderAddComponentMenu(host, () => {});
+    const combos = host.querySelectorAll('button').filter((b) => b.classList.contains('entity-add-menu-combo'));
+    expect(combos.length).toBeGreaterThanOrEqual(6); // Ship, Station, Region, NPC, Asteroid, Asteroid Field, Star, Planet
+    const rawToggle = host.querySelectorAll('button').find((b) => b.classList.contains('entity-add-menu-raw-toggle'));
+    expect(rawToggle).toBeDefined();
+  });
+
+  it('clicking the Raw section toggle shows the flat section submenu', () => {
+    renderAddComponentMenu(host, () => {});
+    const rawToggle = host.querySelectorAll('button').find((b) => b.classList.contains('entity-add-menu-raw-toggle'));
+    fireClick(rawToggle);
+    const submenu = host.querySelectorAll('div').find((d) => d.classList.contains('entity-add-menu-submenu'));
+    expect(submenu).toBeDefined();
+    const rawItems = host.querySelectorAll('button').filter((b) => b.classList.contains('entity-add-menu-raw-section'));
+    // ENTITY_CONFIG_SECTIONS has many sections (tags through stations).
+    expect(rawItems.length).toBeGreaterThan(10);
+  });
+
+  it('selecting a combo calls onSelect with { kind: "combo", name }', () => {
+    let choice = null;
+    renderAddComponentMenu(host, (c) => { choice = c; });
+    const shipBtn = host.querySelectorAll('button').find((b) => b.dataset.combo === 'Ship');
+    expect(shipBtn).toBeDefined();
+    fireClick(shipBtn);
+    expect(choice).toEqual({ kind: 'combo', name: 'Ship' });
+  });
+
+  it('selecting a raw section calls onSelect with { kind: "raw", sectionKey }', () => {
+    let choice = null;
+    renderAddComponentMenu(host, (c) => { choice = c; });
+    const rawToggle = host.querySelectorAll('button').find((b) => b.classList.contains('entity-add-menu-raw-toggle'));
+    fireClick(rawToggle);
+
+    const hullBtn = host.querySelectorAll('button').find((b) => b.dataset.section === 'hull');
+    expect(hullBtn).toBeDefined();
+    fireClick(hullBtn);
+    expect(choice).toEqual({ kind: 'raw', sectionKey: 'hull' });
+  });
+
+  it('Back button returns to the top level', () => {
+    renderAddComponentMenu(host, () => {});
+    const rawToggle = host.querySelectorAll('button').find((b) => b.classList.contains('entity-add-menu-raw-toggle'));
+    fireClick(rawToggle);
+    const back = host.querySelectorAll('button').find((b) => b.classList.contains('entity-add-menu-back'));
+    fireClick(back);
+    const combos = host.querySelectorAll('button').filter((b) => b.classList.contains('entity-add-menu-combo'));
+    expect(combos.length).toBeGreaterThan(0);
+  });
+});

--- a/editor/tests/entity-component-card-view.test.js
+++ b/editor/tests/entity-component-card-view.test.js
@@ -1,0 +1,265 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// ── DOM shim (shared with other view tests) ──────────────────────────────
+
+class FakeClassList {
+  constructor() { this._set = new Set(); }
+  add(c) { this._set.add(c); }
+  remove(c) { this._set.delete(c); }
+  contains(c) { return this._set.has(c); }
+}
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = (tag || 'div').toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this._listeners = new Map();
+    this.classList = new FakeClassList();
+    this.dataset = {};
+    this.style = {};
+    this._innerHTML = '';
+    this.textContent = '';
+    this.value = '';
+    this.checked = false;
+    this.disabled = false;
+    this.multiple = false;
+    this.type = '';
+    this.step = '';
+    this.rows = 0;
+  }
+  set className(v) {
+    this.classList = new FakeClassList();
+    for (const c of String(v || '').split(/\s+/).filter(Boolean)) this.classList.add(c);
+    this._className = v;
+  }
+  get className() { return this._className || ''; }
+  appendChild(c) {
+    if (c.parentElement) {
+      const i = c.parentElement.children.indexOf(c);
+      if (i >= 0) c.parentElement.children.splice(i, 1);
+    }
+    c.parentElement = this;
+    this.children.push(c);
+    return c;
+  }
+  addEventListener(type, fn) {
+    if (!this._listeners.has(type)) this._listeners.set(type, []);
+    this._listeners.get(type).push(fn);
+  }
+  dispatchEvent(ev) {
+    const list = this._listeners.get(ev.type) || [];
+    for (const fn of list) fn(ev);
+  }
+  set innerHTML(v) { this._innerHTML = v; this.children = []; }
+  get innerHTML() { return this._innerHTML; }
+  _walk(pred, out = []) {
+    if (pred(this)) out.push(this);
+    for (const c of this.children) c._walk(pred, out);
+    return out;
+  }
+  querySelectorAll(sel) {
+    return this._walk((el) => {
+      if (sel.startsWith('.')) return el.classList.contains(sel.slice(1));
+      if (sel.startsWith('#')) return false;
+      return el.tagName === sel.toUpperCase();
+    });
+  }
+  querySelector(sel) { return this.querySelectorAll(sel)[0] || null; }
+}
+
+function installDom() {
+  globalThis.document = { createElement: (tag) => new FakeElement(tag) };
+}
+
+function fireInput(el, value) {
+  el.value = value;
+  el.dispatchEvent({ type: 'input', target: el });
+}
+function fireChange(el, value) {
+  el.value = value;
+  el.dispatchEvent({ type: 'change', target: el });
+}
+function fireClick(el) {
+  el.dispatchEvent({ type: 'click', target: el });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('renderEntityComponentCard', () => {
+  let host;
+  let renderEntityComponentCard;
+  let ComponentCard;
+  let COMPONENT_SCHEMA;
+
+  beforeEach(async () => {
+    installDom();
+    host = new FakeElement('div');
+    ({ renderEntityComponentCard } = await import('../entity-component-card-view.js'));
+    ({ ComponentCard } = await import('../entity-mode.js'));
+    ({ COMPONENT_SCHEMA } = await import('../component-schema.js'));
+  });
+
+  function makeDeps(overrides = {}) {
+    const edits = [];
+    return {
+      edits,
+      deps: {
+        getFactionOptions: () => [{ uuid: 'f-1', name: 'Federation' }],
+        getComplexityPaths: () => ['assets/complexity/tactical.toml'],
+        onEdit: (section, data) => edits.push({ section, data }),
+        onDelete: (section) => edits.push({ section, deleted: true }),
+        ...overrides,
+      },
+    };
+  }
+
+  it('renders a numeric input for hull.captain_chair that coerces to a number', () => {
+    const card = new ComponentCard('hull', { captain_chair: 60 }, COMPONENT_SCHEMA.hull);
+    const { deps, edits } = makeDeps();
+    renderEntityComponentCard(host, card, deps);
+
+    const inputs = host.querySelectorAll('input').filter((i) => i.type === 'number');
+    const inp = inputs.find((i) => i.parentElement && i.parentElement.children[0]?.textContent === 'captain_chair');
+    expect(inp).toBeDefined();
+    expect(inp.value).toBe('60');
+
+    fireInput(inp, '99.5');
+    expect(edits.length).toBe(1);
+    expect(edits[0].section).toBe('hull');
+    expect(edits[0].data.captain_chair).toBe(99.5);
+    expect(typeof edits[0].data.captain_chair).toBe('number');
+  });
+
+  it('renders a string input that coerces to a string', () => {
+    const card = new ComponentCard('station', { name: 'Axiom', shape: 'torus', radius: 18, hull_integrity: 200 }, COMPONENT_SCHEMA.station);
+    const { deps, edits } = makeDeps();
+    renderEntityComponentCard(host, card, deps);
+
+    const inputs = host.querySelectorAll('input').filter((i) => i.type === 'text');
+    const nameInp = inputs.find((i) => i.parentElement?.children[0]?.textContent === 'name');
+    expect(nameInp).toBeDefined();
+    fireInput(nameInp, 'New Name');
+    expect(edits[0].data.name).toBe('New Name');
+  });
+
+  it('renders a checkbox for boolean helm_console.radar_shows', () => {
+    const card = new ComponentCard(
+      'helm_console',
+      { max_speed: 50, max_reverse_speed: 0, acceleration: 16, deceleration: 50, max_yaw_rate: 1.5, radar_range: 0, radar_shows: false, impulse_charge_duration: 3, impulse_speed_multiplier: 10 },
+      COMPONENT_SCHEMA.helm_console,
+    );
+    const { deps, edits } = makeDeps();
+    renderEntityComponentCard(host, card, deps);
+    const cb = host.querySelectorAll('input').find((i) => i.type === 'checkbox');
+    expect(cb).toBeDefined();
+    cb.checked = true;
+    cb.dispatchEvent({ type: 'change', target: cb });
+    const last = edits[edits.length - 1];
+    expect(last.data.radar_shows).toBe(true);
+  });
+
+  it('renders an array<number> textarea that coerces to numbers', () => {
+    const card = new ComponentCard('radar_appearance', { colour: [0.6, 0.8, 1.0] }, COMPONENT_SCHEMA.radar_appearance);
+    const { deps, edits } = makeDeps();
+    renderEntityComponentCard(host, card, deps);
+
+    const ta = host.querySelectorAll('textarea').find((t) => t.classList.contains('entity-card-input-array'));
+    expect(ta).toBeDefined();
+    expect(ta.value).toBe('0.6, 0.8, 1');
+    fireInput(ta, '0.1, 0.2, 0.3');
+    expect(edits[edits.length - 1].data.colour).toEqual([0.1, 0.2, 0.3]);
+  });
+
+  it('renders an array<string> textarea that coerces to strings', () => {
+    const card = new ComponentCard('tags', ['ship', 'npc'], COMPONENT_SCHEMA.tags);
+    // tags is an array section; the data IS the array. The schema treats it
+    // as scalar-section behaviour. We test that.
+    const { deps, edits } = makeDeps();
+    renderEntityComponentCard(host, card, deps);
+    const ta = host.querySelectorAll('textarea').find((t) => t.classList.contains('entity-card-input-array'));
+    expect(ta).toBeDefined();
+    fireInput(ta, 'ship, station, enemy');
+    expect(edits[edits.length - 1].data).toEqual(['ship', 'station', 'enemy']);
+  });
+
+  it('raw-toggle replaces body with a textarea containing the section TOML', () => {
+    const card = new ComponentCard('hull', { captain_chair: 60 }, COMPONENT_SCHEMA.hull);
+    card.toggleRaw();
+    const { deps, edits } = makeDeps();
+    renderEntityComponentCard(host, card, deps);
+
+    const ta = host.querySelectorAll('textarea').find((t) => t.classList.contains('entity-card-raw-textarea'));
+    expect(ta).toBeDefined();
+    expect(ta.value).toContain('hull');
+    expect(ta.value).toContain('60');
+
+    // Edit it: change captain_chair to 80.
+    fireInput(ta, '[hull]\ncaptain_chair = 80\n');
+    const last = edits[edits.length - 1];
+    expect(last.section).toBe('hull');
+    expect(last.data.captain_chair).toBe(80);
+  });
+
+  it('renders raw textarea when schema is null (null-schema fallback)', () => {
+    const card = new ComponentCard('unknown_section', { foo: 1 }, null);
+    const { deps } = makeDeps();
+    renderEntityComponentCard(host, card, deps);
+
+    const ta = host.querySelectorAll('textarea').find((t) => t.classList.contains('entity-card-raw-textarea'));
+    expect(ta).toBeDefined();
+    expect(ta.value).toContain('unknown_section');
+  });
+
+  it('faction field renders a <select> populated from getFactionOptions', () => {
+    const card = new ComponentCard('faction', 'f-1', COMPONENT_SCHEMA.faction);
+    const { deps, edits } = makeDeps();
+    renderEntityComponentCard(host, card, deps);
+
+    const sel = host.querySelectorAll('select').find((s) => s.classList.contains('entity-card-input-faction'));
+    expect(sel).toBeDefined();
+    // 1 blank + 1 federation option.
+    expect(sel.children.length).toBe(2);
+    expect(sel.value).toBe('f-1');
+
+    fireChange(sel, '');
+    expect(edits[edits.length - 1].data).toBeNull();
+  });
+
+  it('complexity_toml field renders a <select> populated from getComplexityPaths', () => {
+    const card = new ComponentCard(
+      'weapons_console',
+      { complexity_toml: 'assets/complexity/tactical.toml', radar_range: 0, target_range: 0, fire_arc: 0, beam_range: 0, beam_damage_per_sec: 0, beam_duration_secs: 0, cooldown_secs: 0, beam_color: [] },
+      COMPONENT_SCHEMA.weapons_console,
+    );
+    const { deps } = makeDeps();
+    renderEntityComponentCard(host, card, deps);
+
+    const sel = host.querySelectorAll('select').find((s) => s.classList.contains('entity-card-input-complexity'));
+    expect(sel).toBeDefined();
+    expect(sel.children.length).toBe(2);
+    expect(sel.value).toBe('assets/complexity/tactical.toml');
+  });
+
+  it('header delete button calls onDelete', () => {
+    const card = new ComponentCard('hull', { captain_chair: 60 }, COMPONENT_SCHEMA.hull);
+    const { deps, edits } = makeDeps();
+    renderEntityComponentCard(host, card, deps);
+
+    const delBtn = host.querySelectorAll('button').find((b) => b.classList.contains('entity-card-btn-delete'));
+    expect(delBtn).toBeDefined();
+    fireClick(delBtn);
+    expect(edits.find((e) => e.deleted)).toBeDefined();
+  });
+
+  it('collapse toggle hides body', () => {
+    const card = new ComponentCard('hull', { captain_chair: 60 }, COMPONENT_SCHEMA.hull);
+    const { deps } = makeDeps();
+    renderEntityComponentCard(host, card, deps);
+
+    const collapseBtn = host.querySelectorAll('button').find((b) => b.classList.contains('entity-card-btn-collapse'));
+    fireClick(collapseBtn);
+    const body = host.querySelectorAll('div').find((d) => d.classList.contains('entity-card-body'));
+    expect(body.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/editor/tests/entity-mode.test.js
+++ b/editor/tests/entity-mode.test.js
@@ -486,6 +486,37 @@ describe('EntityModeShell', () => {
     });
   });
 
+  describe('setSection + restoreParsed', () => {
+    beforeEach(() => {
+      shell.openFile('pirate_raider.toml', readEntity('pirate_raider.toml'));
+    });
+
+    it('setSection updates the active section and rebuilds cards', () => {
+      shell.setSection('hull', { captain_chair: 999.0 });
+      const card = shell.getCard('hull');
+      expect(card.data.captain_chair).toBe(999.0);
+    });
+
+    it('setSection with a brand-new section adds a card', () => {
+      expect(shell.getCard('shape')).toBeNull();
+      shell.setSection('shape', { type: 'sphere', radius: 50.0 });
+      expect(shell.getCard('shape')).not.toBeNull();
+    });
+
+    it('restoreParsed swaps the entire parsed object and rebuilds cards', () => {
+      const replacement = {
+        tags: ['region'],
+        shape: { type: 'sphere', radius: 100 },
+        effects: { comms_jammed: {} },
+      };
+      shell.restoreParsed(replacement);
+      expect(shell.getCard('hull')).toBeNull();
+      expect(shell.getCard('shape')).not.toBeNull();
+      expect(shell.getCard('effects')).not.toBeNull();
+      expect(shell.getParsedEntity()).toBe(replacement);
+    });
+  });
+
   describe('full integration scenario', () => {
     it('opens all shipped entities without error', () => {
       const filenames = listDir('assets/entities').filter((f) => f.endsWith('.toml'));

--- a/editor/tests/entity-preview-view.test.js
+++ b/editor/tests/entity-preview-view.test.js
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderEntityPreviewView } from '../entity-preview-view.js';
+import { computeEntityPreview } from '../entity-preview.js';
+
+// ── Minimal DOM shim ────────────────────────────────────────────────────
+
+class FakeClassList {
+  constructor() { this._set = new Set(); }
+  add(c) { this._set.add(c); }
+  remove(c) { this._set.delete(c); }
+  contains(c) { return this._set.has(c); }
+}
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = (tag || 'div').toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this.classList = new FakeClassList();
+    this._innerHTML = '';
+    this.textContent = '';
+  }
+  set className(v) {
+    this.classList = new FakeClassList();
+    for (const c of String(v || '').split(/\s+/).filter(Boolean)) this.classList.add(c);
+    this._className = v;
+  }
+  get className() { return this._className || ''; }
+  appendChild(c) {
+    if (c.parentElement) {
+      const i = c.parentElement.children.indexOf(c);
+      if (i >= 0) c.parentElement.children.splice(i, 1);
+    }
+    c.parentElement = this;
+    this.children.push(c);
+    return c;
+  }
+  set innerHTML(v) { this._innerHTML = v; this.children = []; }
+  get innerHTML() { return this._innerHTML; }
+  _walk(pred, out = []) {
+    if (pred(this)) out.push(this);
+    for (const c of this.children) c._walk(pred, out);
+    return out;
+  }
+}
+
+class FakeDocument {
+  createElement(tag) { return new FakeElement(tag); }
+}
+
+function installDom() {
+  globalThis.document = new FakeDocument();
+}
+
+// ── Mock Konva (records every shape constructed) ────────────────────────
+
+function makeMockKonva() {
+  const created = [];
+  function mk(name) {
+    return class {
+      constructor(opts) {
+        this._kind = name;
+        this._opts = opts;
+        created.push({ kind: name, opts });
+      }
+    };
+  }
+  const Stage = class {
+    constructor(opts) { this._opts = opts; this._layers = []; created.push({ kind: 'Stage', opts }); }
+    add(l) { this._layers.push(l); }
+  };
+  const Layer = class {
+    constructor() { this._children = []; created.push({ kind: 'Layer' }); }
+    add(s) { this._children.push(s); }
+    draw() {}
+  };
+  return {
+    Konva: {
+      Stage, Layer,
+      Circle: mk('Circle'),
+      Rect: mk('Rect'),
+      Ring: mk('Ring'),
+      Line: mk('Line'),
+      Arc: mk('Arc'),
+      RegularPolygon: mk('RegularPolygon'),
+    },
+    created,
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('renderEntityPreviewView', () => {
+  let host;
+
+  beforeEach(() => {
+    installDom();
+    host = new FakeElement('div');
+  });
+
+  it('renders placeholder when preview is placeholder', () => {
+    const { Konva } = makeMockKonva();
+    renderEntityPreviewView(host, { placeholder: true, activeFile: null }, { Konva });
+    expect(host.children).toHaveLength(1);
+    expect(host.children[0].classList.contains('placeholder')).toBe(true);
+  });
+
+  it('renders ship: capsule collider + triangle radar + forward arrow', () => {
+    const preview = computeEntityPreview({
+      tags: ['ship'],
+      collider: { shape: 'Capsule', radius: 3.0, length: 6.0 },
+      radar_appearance: { colour: [0.6, 0.8, 1.0], radius: 5.0 },
+    });
+    const { Konva, created } = makeMockKonva();
+    renderEntityPreviewView(host, preview, { Konva });
+
+    const kinds = created.map((c) => c.kind);
+    // Capsule = 2 lines + 2 arcs
+    expect(kinds.filter((k) => k === 'Line').length).toBe(2);
+    expect(kinds.filter((k) => k === 'Arc').length).toBe(2);
+    // Triangle radar + forward arrow = 2 RegularPolygons
+    expect(kinds.filter((k) => k === 'RegularPolygon').length).toBe(2);
+  });
+
+  it('renders station with diamond radar', () => {
+    const preview = computeEntityPreview({
+      tags: ['station'],
+      radar_appearance: { colour: [0.3, 0.8, 0.6], radius: 10.0 },
+    });
+    const { Konva, created } = makeMockKonva();
+    renderEntityPreviewView(host, preview, { Konva });
+
+    // Diamond is a RegularPolygon with sides=4
+    const polys = created.filter((c) => c.kind === 'RegularPolygon');
+    const diamond = polys.find((p) => p.opts.sides === 4);
+    expect(diamond).toBeDefined();
+  });
+
+  it('renders region with sphere shape (dashed circle)', () => {
+    const preview = computeEntityPreview({
+      tags: ['region'],
+      shape: { type: 'sphere', radius: 100.0 },
+    });
+    const { Konva, created } = makeMockKonva();
+    renderEntityPreviewView(host, preview, { Konva });
+
+    const circles = created.filter((c) => c.kind === 'Circle');
+    // One dashed sphere circle.
+    const dashed = circles.find((c) => Array.isArray(c.opts.dash));
+    expect(dashed).toBeDefined();
+  });
+
+  it('renders region with torus shape as a ring', () => {
+    const preview = computeEntityPreview({
+      tags: ['region'],
+      shape: { type: 'torus', inner_radius: 100, outer_radius: 250 },
+    });
+    const { Konva, created } = makeMockKonva();
+    renderEntityPreviewView(host, preview, { Konva });
+
+    const rings = created.filter((c) => c.kind === 'Ring');
+    expect(rings.length).toBeGreaterThan(0);
+    const r = rings[0];
+    expect(r.opts.outerRadius).toBeGreaterThan(r.opts.innerRadius);
+  });
+
+  it('renders asteroid_field donut', () => {
+    const preview = computeEntityPreview({
+      tags: ['asteroid_field'],
+      asteroid_field: { inner_radius: 100, outer_radius: 200, density: 0.005 },
+    });
+    const { Konva, created } = makeMockKonva();
+    renderEntityPreviewView(host, preview, { Konva });
+
+    const rings = created.filter((c) => c.kind === 'Ring');
+    expect(rings.length).toBeGreaterThan(0);
+  });
+
+  it('overlay shows resolved faction name (not raw UUID)', () => {
+    const factionMap = new Map([['ff-1', 'Federation']]);
+    const preview = computeEntityPreview(
+      { tags: ['ship'], faction: 'ff-1' },
+      factionMap,
+    );
+    const { Konva } = makeMockKonva();
+    renderEntityPreviewView(host, preview, { Konva });
+
+    const overlay = host.children.find((c) => c.classList.contains('entity-preview-overlay'));
+    expect(overlay).toBeDefined();
+    const text = overlay.children.map((r) => r.textContent).join('\n');
+    expect(text).toContain('Federation');
+    expect(text).not.toContain('ff-1');
+  });
+
+  it('emits an error placeholder when Konva is unavailable', () => {
+    renderEntityPreviewView(host, { textOverlay: { tags: [] }, showForwardArrow: false }, { Konva: null });
+    expect(host.children).toHaveLength(1);
+    expect(host.children[0].classList.contains('entity-preview-error')).toBe(true);
+  });
+});

--- a/editor/tests/faction-complexity-discovery.test.js
+++ b/editor/tests/faction-complexity-discovery.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+import { discoverFactionsAndComplexity } from '../faction-complexity-discovery.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '../..');
+
+function makeDeps({ factions, complexity, factionContent }) {
+  return {
+    listDirectory: async (rel) => {
+      if (rel === 'assets/factions') {
+        if (factions === '__throw__') throw new Error('missing dir');
+        return factions ?? [];
+      }
+      if (rel === 'assets/complexity') {
+        if (complexity === '__throw__') throw new Error('missing dir');
+        return complexity ?? [];
+      }
+      return [];
+    },
+    readFile: async (path) => {
+      if (factionContent && factionContent[path] !== undefined) {
+        return factionContent[path];
+      }
+      throw new Error(`no file: ${path}`);
+    },
+  };
+}
+
+describe('discoverFactionsAndComplexity', () => {
+  it('returns empty results when both directories are missing', async () => {
+    const result = await discoverFactionsAndComplexity(
+      makeDeps({ factions: '__throw__', complexity: '__throw__' }),
+    );
+    expect(result.factionMap.size).toBe(0);
+    expect(result.complexityPaths).toEqual([]);
+  });
+
+  it('returns empty results when both directories are empty', async () => {
+    const result = await discoverFactionsAndComplexity(
+      makeDeps({ factions: [], complexity: [] }),
+    );
+    expect(result.factionMap.size).toBe(0);
+    expect(result.complexityPaths).toEqual([]);
+  });
+
+  it('skips non-.toml files in factions', async () => {
+    const result = await discoverFactionsAndComplexity(
+      makeDeps({
+        factions: [
+          { name: 'README.md', kind: 'file' },
+          { name: 'fed.toml', kind: 'file' },
+        ],
+        factionContent: {
+          'assets/factions/fed.toml': 'uuid = "00000000-0000-4000-8000-000000000001"\nname = "Fed"\n',
+        },
+        complexity: [],
+      }),
+    );
+    expect(result.factionMap.size).toBe(1);
+    expect(result.factionMap.get('00000000-0000-4000-8000-000000000001')).toBe('Fed');
+  });
+
+  it('skips directory entries when scanning factions', async () => {
+    const result = await discoverFactionsAndComplexity(
+      makeDeps({
+        factions: [
+          { name: 'subdir', kind: 'directory' },
+          { name: 'good.toml', kind: 'file' },
+        ],
+        factionContent: {
+          'assets/factions/good.toml': 'uuid = "00000000-0000-4000-8000-000000000002"\nname = "Good"\n',
+        },
+        complexity: [],
+      }),
+    );
+    expect(result.factionMap.size).toBe(1);
+  });
+
+  it('skips malformed faction TOML', async () => {
+    const result = await discoverFactionsAndComplexity(
+      makeDeps({
+        factions: [
+          { name: 'bad.toml', kind: 'file' },
+          { name: 'ok.toml', kind: 'file' },
+        ],
+        factionContent: {
+          'assets/factions/bad.toml': 'this is not = valid ===',
+          'assets/factions/ok.toml': 'uuid = "00000000-0000-4000-8000-000000000003"\nname = "Ok"\n',
+        },
+        complexity: [],
+      }),
+    );
+    expect(result.factionMap.size).toBe(1);
+    expect(result.factionMap.get('00000000-0000-4000-8000-000000000003')).toBe('Ok');
+  });
+
+  it('skips non-.toml files in complexity', async () => {
+    const result = await discoverFactionsAndComplexity(
+      makeDeps({
+        factions: [],
+        complexity: [
+          { name: 'README.md', kind: 'file' },
+          { name: 'tactical.toml', kind: 'file' },
+          { name: 'power.toml', kind: 'file' },
+        ],
+      }),
+    );
+    expect(result.complexityPaths).toEqual([
+      'assets/complexity/power.toml',
+      'assets/complexity/tactical.toml',
+    ]);
+  });
+
+  it('handles only-factions-missing gracefully', async () => {
+    const result = await discoverFactionsAndComplexity(
+      makeDeps({
+        factions: '__throw__',
+        complexity: [{ name: 'tactical.toml', kind: 'file' }],
+      }),
+    );
+    expect(result.factionMap.size).toBe(0);
+    expect(result.complexityPaths).toEqual(['assets/complexity/tactical.toml']);
+  });
+
+  it('loads all real shipped faction and complexity files', async () => {
+    const factionEntries = readdirSync(resolve(projectRoot, 'assets/factions'));
+    const complexityEntries = readdirSync(resolve(projectRoot, 'assets/complexity'));
+    const factionContent = {};
+    for (const f of factionEntries) {
+      if (!f.endsWith('.toml')) continue;
+      factionContent[`assets/factions/${f}`] = readFileSync(
+        resolve(projectRoot, 'assets/factions', f), 'utf-8',
+      );
+    }
+    const result = await discoverFactionsAndComplexity({
+      listDirectory: async (rel) => {
+        if (rel === 'assets/factions') return factionEntries.map((n) => ({ name: n, kind: 'file' }));
+        if (rel === 'assets/complexity') return complexityEntries.map((n) => ({ name: n, kind: 'file' }));
+        return [];
+      },
+      readFile: async (path) => factionContent[path],
+    });
+    expect(result.factionMap.size).toBeGreaterThan(0);
+    expect(result.factionMap.get('aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa')).toBe('Federation');
+    expect(result.complexityPaths.length).toBe(
+      complexityEntries.filter((f) => f.endsWith('.toml')).length,
+    );
+    for (const p of result.complexityPaths) {
+      expect(p.startsWith('assets/complexity/')).toBe(true);
+    }
+  });
+});

--- a/editor/tests/slice-5-add-component.test.js
+++ b/editor/tests/slice-5-add-component.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setupEntityMode, fireClick } from './slice-5-helpers.js';
+
+/**
+ * Slice 5 integration test: + Add Component → Region combo.
+ *
+ * - Open pirate_raider.toml.
+ * - Click + Add Component → submenu opens.
+ * - Click Region combo.
+ * - Assert that the `shape` and `effects` cards now exist (new sections).
+ *   `tags` already existed on pirate_raider, so the Region combo's tags
+ *   section is skipped — verify the skip-warning surfaces via addCombo's
+ *   return shape and that the existing tags section is left untouched.
+ */
+
+describe('Slice 5: + Add Component → Region combo', () => {
+  let ctx;
+  beforeEach(async () => {
+    ctx = await setupEntityMode();
+    await ctx.view._internal.loadEntity('assets/entities/pirate_raider.toml');
+  });
+
+  it('opens the picker when + Add Component is clicked', () => {
+    const addBtn = ctx.host.querySelectorAll('button')
+      .find((b) => b.classList.contains('entity-add-component-btn'));
+    expect(addBtn).toBeDefined();
+    fireClick(addBtn);
+
+    const combos = ctx.host.querySelectorAll('button')
+      .filter((b) => b.classList.contains('entity-add-menu-combo'));
+    expect(combos.length).toBeGreaterThan(0);
+    const regionBtn = combos.find((b) => b.dataset.combo === 'Region');
+    expect(regionBtn).toBeDefined();
+  });
+
+  it('selecting Region adds shape + effects cards (and skips existing tags with a warning)', () => {
+    // Capture warn() to assert the skip warning surfaces.
+    const warnings = [];
+    const origWarn = console.warn;
+    console.warn = (msg) => { warnings.push(String(msg)); };
+
+    try {
+      // Drive the add directly via the internal handler — equivalent to
+      // clicking + Add Component → Region.
+      ctx.view._internal.handleAddChoice({ kind: 'combo', name: 'Region' });
+    } finally {
+      console.warn = origWarn;
+    }
+
+    const sections = ctx.view.shell.getComponentCards().map((c) => c.section);
+
+    // shape + effects are newly added.
+    expect(sections).toContain('shape');
+    expect(sections).toContain('effects');
+
+    // tags was already present and not duplicated.
+    const tagsCount = sections.filter((s) => s === 'tags').length;
+    expect(tagsCount).toBe(1);
+
+    // Original tags values are preserved (not overwritten with ['region']).
+    const tagsCard = ctx.view.shell.getCard('tags');
+    expect(tagsCard.data).toEqual(['ship', 'npc', 'enemy']);
+
+    // Skip warning surfaced.
+    expect(warnings.some((w) => /tags.*already present/i.test(w))).toBe(true);
+
+    // Dirty + undo snapshot recorded.
+    const path = 'assets/entities/pirate_raider.toml';
+    expect(ctx.modeShell.isDirty('Entity', path)).toBe(true);
+    const undo = ctx.modeShell.getUndoHistory('Entity', path);
+    expect(undo.length).toBe(1);
+    // Snapshot is pre-mutation, so shape/effects shouldn't be in it.
+    expect(undo[0].shape).toBeUndefined();
+    expect(undo[0].effects).toBeUndefined();
+  });
+});

--- a/editor/tests/slice-5-behaviour-edit.test.js
+++ b/editor/tests/slice-5-behaviour-edit.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setupEntityMode } from './slice-5-helpers.js';
+
+/**
+ * Slice 5 integration test: behaviour-view validation banner.
+ *
+ * Open pirate_raider.toml and set behaviour.initial_state to a name that
+ * isn't in the state list. After re-render, the inline
+ * `.entity-behaviour-error` banner should be present and reference the
+ * bad name.
+ */
+
+describe('Slice 5: behaviour validation surfaces inline', () => {
+  let ctx;
+  beforeEach(async () => {
+    ctx = await setupEntityMode();
+    await ctx.view._internal.loadEntity('assets/entities/pirate_raider.toml');
+  });
+
+  it('shows an inline validation banner when initial_state references a missing state', () => {
+    // Sanity: no banner before mutation — pirate_raider.toml validates cleanly.
+    const before = ctx.host.querySelectorAll('div')
+      .filter((d) => d.classList.contains('entity-behaviour-error'));
+    expect(before.length).toBe(0);
+
+    // Patch behaviour.initial_state to a name that's not in the state list.
+    const behaviour = ctx.view.shell.getCard('behaviour').data;
+    const patched = { ...behaviour, initial_state: 'does_not_exist' };
+    ctx.view._internal.handleCardEdit('behaviour', patched);
+
+    const banner = ctx.host.querySelectorAll('div')
+      .find((d) => d.classList.contains('entity-behaviour-error'));
+    expect(banner).toBeDefined();
+    expect(banner.textContent).toMatch(/initial_state/i);
+    expect(banner.textContent).toContain('does_not_exist');
+  });
+});

--- a/editor/tests/slice-5-entity-mode-cycle.test.js
+++ b/editor/tests/slice-5-entity-mode-cycle.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setupEntityMode } from './slice-5-helpers.js';
+
+/**
+ * Slice 5 integration test: full Entity Mode cycle.
+ *
+ * Mount → file list populated → load pirate_raider.toml → cards rendered
+ * for tags/hull/collider/helm_console/weapons_console/radar_appearance/mesh/
+ * behaviour/faction → edit hull.captain_chair → saveFlow.setContent called +
+ * isDirty → undo → value restored → save → writeFile called + dirty cleared.
+ */
+
+describe('Slice 5: Entity Mode full cycle', () => {
+  let ctx;
+  beforeEach(async () => {
+    ctx = await setupEntityMode();
+  });
+
+  it('populates the file list with both entity TOMLs', () => {
+    const rows = ctx.host.querySelectorAll('div')
+      .filter((d) => d.classList.contains('entity-file-list-row'));
+    expect(rows.length).toBe(2);
+    const labels = rows.map((r) => r.dataset.path).sort();
+    expect(labels).toEqual([
+      'assets/entities/pirate_raider.toml',
+      'assets/entities/player_ship.toml',
+    ]);
+  });
+
+  it('opens pirate_raider.toml and renders cards for all top-level sections', async () => {
+    await ctx.view._internal.loadEntity('assets/entities/pirate_raider.toml');
+
+    const cards = ctx.view.shell.getComponentCards().map((c) => c.section);
+    expect(cards).toEqual(expect.arrayContaining([
+      'tags', 'faction', 'hull', 'collider',
+      'helm_console', 'weapons_console',
+      'radar_appearance', 'mesh', 'behaviour',
+    ]));
+  });
+
+  it('editing hull.captain_chair updates parsed + saveFlow + marks dirty + snapshots undo', async () => {
+    await ctx.view._internal.loadEntity('assets/entities/pirate_raider.toml');
+
+    const hull = ctx.view.shell.getCard('hull');
+    expect(hull.data.captain_chair).toBe(60);
+
+    ctx.view._internal.handleCardEdit('hull', { captain_chair: 99.5 });
+
+    expect(ctx.view.shell.getParsedEntity().hull.captain_chair).toBe(99.5);
+    const path = 'assets/entities/pirate_raider.toml';
+    expect(ctx.modeShell.isDirty('Entity', path)).toBe(true);
+
+    const stash = ctx.saveFlow._contentCache.Entity[path];
+    expect(stash.hull.captain_chair).toBe(99.5);
+
+    const undoEntries = ctx.modeShell.getUndoHistory('Entity', path);
+    expect(undoEntries.length).toBe(1);
+    expect(undoEntries[0].hull.captain_chair).toBe(60);
+  });
+
+  it('undo restores the previous hull.captain_chair value', async () => {
+    await ctx.view._internal.loadEntity('assets/entities/pirate_raider.toml');
+    ctx.view._internal.handleCardEdit('hull', { captain_chair: 99.5 });
+
+    const restoreCb = ctx.getRestoreCb();
+    expect(restoreCb).toBeDefined();
+    restoreCb(ctx.modeShell, 'assets/entities/pirate_raider.toml', 'undo');
+
+    expect(ctx.view.shell.getParsedEntity().hull.captain_chair).toBe(60);
+  });
+
+  it('save writes the file and clears dirty', async () => {
+    await ctx.view._internal.loadEntity('assets/entities/pirate_raider.toml');
+    ctx.view._internal.handleCardEdit('hull', { captain_chair: 99.5 });
+
+    const path = 'assets/entities/pirate_raider.toml';
+    ctx.modeShell.setActiveFile('Entity', path);
+    const result = await ctx.saveFlow.saveActive(null);
+
+    expect(result.ok).toBe(true);
+    expect(ctx.writeFileCalls.length).toBe(1);
+    expect(ctx.writeFileCalls[0].path).toBe(path);
+    expect(ctx.writeFileCalls[0].content).toContain('captain_chair');
+    expect(ctx.writeFileCalls[0].content).toContain('99.5');
+    expect(ctx.modeShell.isDirty('Entity', path)).toBe(false);
+  });
+});

--- a/editor/tests/slice-5-helpers.js
+++ b/editor/tests/slice-5-helpers.js
@@ -1,0 +1,203 @@
+/**
+ * Shared scaffolding for Slice 5 Entity Mode integration tests.
+ *
+ *   import { setupEntityMode } from './slice-5-helpers.js';
+ *   const { view, host, modeShell, saveFlow, restoreCb, writeFileCalls } =
+ *     await setupEntityMode();
+ *
+ * The helper installs a minimal FakeElement DOM shim, a Konva stub, and
+ * mounts `entity-mode-view` with mocked I/O that reads real fixtures from
+ * `assets/entities/`.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ── DOM shim ──────────────────────────────────────────────────────────────
+
+class FakeClassList {
+  constructor() { this._set = new Set(); }
+  add(c) { this._set.add(c); }
+  remove(c) { this._set.delete(c); }
+  toggle(c, force) {
+    const has = this._set.has(c);
+    const want = force === undefined ? !has : !!force;
+    if (want) this._set.add(c); else this._set.delete(c);
+    return want;
+  }
+  contains(c) { return this._set.has(c); }
+}
+
+export class FakeElement {
+  constructor(tag) {
+    this.tagName = (tag || 'div').toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this._listeners = new Map();
+    this.classList = new FakeClassList();
+    this.dataset = {};
+    this.style = {};
+    this._innerHTML = '';
+    this.textContent = '';
+    this.value = '';
+    this.checked = false;
+    this.disabled = false;
+    this.multiple = false;
+    this.type = '';
+    this.id = '';
+    this.placeholder = '';
+    this.rows = 0;
+    this.step = '';
+    this._className = '';
+  }
+  get className() { return this._className; }
+  set className(v) {
+    this._className = v;
+    this.classList = new FakeClassList();
+    for (const c of String(v || '').split(/\s+/).filter(Boolean)) this.classList.add(c);
+  }
+  appendChild(c) {
+    if (c.parentElement) {
+      const i = c.parentElement.children.indexOf(c);
+      if (i >= 0) c.parentElement.children.splice(i, 1);
+    }
+    c.parentElement = this;
+    this.children.push(c);
+    return c;
+  }
+  addEventListener(type, fn) {
+    if (!this._listeners.has(type)) this._listeners.set(type, []);
+    this._listeners.get(type).push(fn);
+  }
+  dispatchEvent(ev) {
+    const list = this._listeners.get(ev.type) || [];
+    for (const fn of list) fn(ev);
+  }
+  set innerHTML(v) { this._innerHTML = v; this.children = []; }
+  get innerHTML() { return this._innerHTML; }
+  _walk(pred, out = []) {
+    if (pred(this)) out.push(this);
+    for (const c of this.children) c._walk(pred, out);
+    return out;
+  }
+  querySelectorAll(sel) {
+    return this._walk((el) => {
+      if (sel.startsWith('.')) return el.classList.contains(sel.slice(1));
+      if (sel.startsWith('#')) return el.id === sel.slice(1);
+      return el.tagName === sel.toUpperCase();
+    });
+  }
+  querySelector(sel) { return this.querySelectorAll(sel)[0] || null; }
+}
+
+export function installDom() {
+  globalThis.document = {
+    createElement: (tag) => new FakeElement(tag),
+    getElementById: () => null,
+  };
+}
+
+export function fireInput(el, value) {
+  el.value = value;
+  el.dispatchEvent({ type: 'input', target: el });
+}
+export function fireChange(el, value) {
+  el.value = value;
+  el.dispatchEvent({ type: 'change', target: el });
+}
+export function fireClick(el) {
+  el.dispatchEvent({ type: 'click', target: el });
+}
+
+// ── Konva stub ────────────────────────────────────────────────────────────
+
+export const KonvaStub = (() => {
+  class Stage { constructor() {} add() {} }
+  class Layer { add() {} }
+  const shape = function () {};
+  return {
+    Stage, Layer,
+    Circle: shape, Rect: shape, Ring: shape, Line: shape,
+    Arc: shape, RegularPolygon: shape,
+  };
+})();
+
+// ── Real fixtures ─────────────────────────────────────────────────────────
+
+const ROOT = resolve(import.meta.dirname, '..', '..');
+export function fixture(rel) {
+  return readFileSync(resolve(ROOT, rel), 'utf8');
+}
+
+// ── Mount helper ──────────────────────────────────────────────────────────
+
+/**
+ * @param {object} [opts]
+ * @param {string[]} [opts.files]  assets/entities/*.toml filenames in the listing
+ */
+export async function setupEntityMode(opts = {}) {
+  installDom();
+  globalThis.window = { Konva: KonvaStub };
+  const host = new FakeElement('div');
+
+  const { mountEntityMode } = await import('../entity-mode-view.js');
+  const { ModeShell } = await import('../mode-shell.js');
+  const { SaveFlow } = await import('../save-flow.js');
+  const { stringifyEntityToml } = await import('../entity-toml.js');
+
+  const writeFileCalls = [];
+  const writeFileFn = async (path, content) => {
+    writeFileCalls.push({ path, content });
+  };
+
+  const modeShell = new ModeShell();
+  modeShell.switchMode('Entity');
+  const saveFlow = new SaveFlow(
+    modeShell,
+    { world: () => '', entity: stringifyEntityToml },
+    writeFileFn,
+    null,
+  );
+
+  let restoreCb = null;
+  const registerRestore = (mode, fn) => {
+    if (mode === 'Entity') restoreCb = fn;
+  };
+
+  const files = opts.files ?? ['pirate_raider.toml', 'player_ship.toml'];
+
+  const io = {
+    readFile: async (path) => fixture(path),
+    listDirectory: async (rel) => {
+      if (rel === 'assets/entities') {
+        return files.map((name) => ({ name, kind: 'file' }));
+      }
+      return [];
+    },
+    preload: async () => {},
+    onCacheInvalidate: () => {},
+    getProjectRoot: async () => ({ stub: true }),
+    discover: async () => ({
+      factionMap: new Map([
+        ['aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa', 'Federation'],
+        ['bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb', 'Pirate'],
+      ]),
+      complexityPaths: ['assets/complexity/tactical.toml'],
+    }),
+    Konva: KonvaStub,
+  };
+
+  const view = mountEntityMode({ host, modeShell, saveFlow, registerRestore, io });
+
+  // Drain the fire-and-forget bootstrap.
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+  await view._internal.refreshFileList();
+
+  return {
+    view,
+    host,
+    modeShell,
+    saveFlow,
+    writeFileCalls,
+    getRestoreCb: () => restoreCb,
+  };
+}

--- a/editor/tests/slice-5-stations-tab.test.js
+++ b/editor/tests/slice-5-stations-tab.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setupEntityMode, fireClick } from './slice-5-helpers.js';
+
+/**
+ * Slice 5 integration test: stations-view tab + dangling-next error.
+ *
+ * Open player_ship.toml, click the count-4 tab, set a station's `next`
+ * to a name not present at count 5 → the inline `dangling-next` chip
+ * renders next to that station's `next` dropdown.
+ */
+
+describe('Slice 5: stations tab + dangling-next inline error', () => {
+  let ctx;
+  beforeEach(async () => {
+    const { _resetActiveCountForTest } = await import('../entity-stations-view.js');
+    _resetActiveCountForTest();
+    ctx = await setupEntityMode();
+    await ctx.view._internal.loadEntity('assets/entities/player_ship.toml');
+  });
+
+  it('clicking count tab 4 makes it the active tab', () => {
+    const tabs = ctx.host.querySelectorAll('button')
+      .filter((b) => b.classList.contains('entity-stations-tab'));
+    expect(tabs.length).toBeGreaterThan(0);
+
+    const tab4 = tabs.find((b) => b.textContent === '4');
+    expect(tab4).toBeDefined();
+    fireClick(tab4);
+
+    const tabsAfter = ctx.host.querySelectorAll('button')
+      .filter((b) => b.classList.contains('entity-stations-tab'));
+    const active = tabsAfter.find((b) => b.classList.contains('entity-stations-tab-active'));
+    expect(active).toBeDefined();
+    expect(active.textContent).toBe('4');
+  });
+
+  it('setting a station next to a dangling name surfaces inline dangling-next chip', () => {
+    // Activate count-4 tab.
+    const tabs = ctx.host.querySelectorAll('button')
+      .filter((b) => b.classList.contains('entity-stations-tab'));
+    const tab4 = tabs.find((b) => b.textContent === '4');
+    fireClick(tab4);
+
+    // Mutate count-4 station 'Helm' so its `next` points at a non-existent
+    // station at count 5. Edit through the data path so we can plant a
+    // value that the dropdown wouldn't normally allow.
+    const stations = structuredClone(ctx.view.shell.getCard('stations').data);
+    const helm4 = stations['4'].find((s) => s.name === 'Helm');
+    expect(helm4).toBeDefined();
+    helm4.next = 'NoSuchStation';
+    ctx.view._internal.handleCardEdit('stations', stations);
+
+    // After re-render, the count-4 tab must still be active so the
+    // validation block + per-row chip render here.
+    const activeAfter = ctx.host.querySelectorAll('button')
+      .filter((b) => b.classList.contains('entity-stations-tab-active'));
+    expect(activeAfter.length).toBe(1);
+    expect(activeAfter[0].textContent).toBe('4');
+
+    // The error list at the top of the tab body should mention dangling-next.
+    const chips = ctx.host.querySelectorAll('div')
+      .filter((d) => d.classList.contains('entity-stations-error'));
+    expect(chips.length).toBeGreaterThan(0);
+    expect(chips.some((c) => c.dataset.kind === 'dangling-next')).toBe(true);
+    expect(chips.some((c) => /dangling next/i.test(c.textContent))).toBe(true);
+
+    // The inline-error chip is attached next to the Helm row's `next` field.
+    const inlineChips = ctx.host.querySelectorAll('span')
+      .filter((s) => s.classList.contains('entity-stations-inline-error'));
+    expect(inlineChips.length).toBeGreaterThan(0);
+    expect(inlineChips.some((c) => c.dataset.kind === 'dangling-next')).toBe(true);
+  });
+});


### PR DESCRIPTION
# Slice 5 — Entity Mode: three-pane shell + component cards + preview (#386)

Closes #386. Land the Entity Mode UI: file list / component cards / static preview. All deep modules existed (entity-mode, component-schema, component-templates, entity-preview, behaviour-editor, stations-editor, stations-validate) and were tested — this slice wires them into the live editor.

Stacked on #392 (Slice 4).

## ACs delivered

- **#24** — Entity tab shows three-pane layout. `app.js:48` calls `mountEntityMode` after `preloadEntityCache`; `entity-mode-view.js:57-72` injects the `.entity-three-pane > .entity-pane-{left,center,right}` skeleton into the Slice-1 placeholder.
- **#25** — Selecting a file renders one component card per present TOML section. `entity-component-stack-view.js:26-31` iterates `shell.getComponentCards()`.
- **#26** — Each card has a raw-TOML toggle (header button → `<textarea>` round-trip). `entity-component-card-view.js:99-103,130-160`.
- **#27/28** — Two-tier `+ Add component` picker: combos at top, "Raw section ▸" expands flat list. `entity-add-component-menu.js:40-87`.
- **#29** — Preview pane renders collider (Ball circle / Capsule pill), radar shape via tag-shape-map, region shape (sphere/box/torus), asteroid-field donut, forward arrow. `entity-preview-view.js:69-210`.
- **#30** — Metadata overlay: tags, resolved faction name, console list, hull total. `entity-preview-view.js:212-245`.
- **#31/32** — Behaviour card: initial_state select + states list (8 kinds) + transitions list (7 conditions) + inline validation banner. `entity-behaviour-view.js`.
- **#33/34/35** — Stations card: per-count tab strip + next/previous dropdowns + inline dangling-next/duplicate-name errors. `entity-stations-view.js`.
- **#38/39** — Faction-UUID fields render `<select>` from `getFactionDropdownOptions()`; complexity_toml fields render `<select>` from `getComplexityPaths()`. Discovery via new `faction-complexity-discovery.js`.

## Contract guarantees

- **Snapshot-before-mutate**: every card edit calls `modeShell.pushUndoEntry('Entity', path, structuredClone(...))` BEFORE mutation (`entity-mode-view.js:161-165`, invoked from `handleCardEdit/handleCardDelete/handleAddChoice`).
- **Undo restore** registered via `registerRestore('Entity', fn)` (`entity-mode-view.js:207-219`).
- **`saveFlow.setContent('Entity', path, ...)`** + **`markDirty`** called after every mutation.
- **Save Layer button** gated on `modeShell.getCurrentMode()`; Entity mode → `saveFlow.saveActive(null)`; Scenario branch unchanged.

## New modules

- `editor/faction-complexity-discovery.js` (~50, pure async)
- `editor/entity-mode-view.js` (~180, DOM coordinator)
- `editor/entity-file-list-view.js` (~90)
- `editor/entity-component-stack-view.js` (~110)
- `editor/entity-component-card-view.js` (~280)
- `editor/entity-add-component-menu.js` (~120)
- `editor/entity-preview-view.js` (~220)
- `editor/entity-behaviour-view.js` (~280)
- `editor/entity-stations-view.js` (~260)

## Production bug surfaced + fixed

`editor/behaviour-editor.js` — `cloneTransition` did `from: [...t.from]`. When TOML transitions used scalar form `from = "pursue"` (as in `assets/entities/pirate_raider.toml`), the string was spread into characters, producing errors like `from "p" is not a valid state name`. Fixed by normalising `t.from` to an array on `load()` without mutating input.

## Tests

- `npm run test:editor` → **886/886 passed** in 51 files (+45 new).
- New suites: `faction-complexity-discovery.test.js` (8), `entity-add-component-menu.test.js` (5), `entity-component-card-view.test.js` (~14), `entity-preview-view.test.js` (8), `entity-mode.test.js` extensions (2), `slice-5-entity-mode-cycle.test.js` (5), `slice-5-add-component.test.js` (3), `slice-5-behaviour-edit.test.js` (1), `slice-5-stations-tab.test.js` (3).
- New test helper: `editor/tests/slice-5-helpers.js` (shared DOM shim + Konva stub + mountEntityMode setup).
- `cargo check` clean.

## Wire-up changes

- `editor/app.js` — Imports `mountEntityMode` and calls after `preloadEntityCache()`. Save Layer button now respects `modeShell.getCurrentMode()`.
- `editor/style.css` — Appended ~165 lines for `.entity-three-pane`, `.entity-card`, `.entity-add-component`, `.entity-preview-canvas`, `.entity-stations-tabs`, `.dirty-dot`, etc.
- No changes needed to `editor.html`, `app-v2.js`, `sidebar.js`, `save-flow.js`, `mode-shell.js`, `cross-references.js`.

## Flagged for follow-up (non-blocking)

- **Scalar→array `from` rewrite.** `pirate_raider.toml` has 3 scalar `from` entries (lines 97/103/116). Loading + saving via Entity Mode rewrites them to single-element arrays. Semantically identical and server-side TOML parsing accepts both. Future polish: emit scalar form when array has exactly one element.
- **Konva resource cleanup.** `entity-preview-view.js` creates a new `Konva.Stage` per render and never calls `stage.destroy()` before `host.innerHTML = ''`. Same pattern as the Scenario canvas; the new high-frequency entity-edit path makes it more visible. Consider adding explicit `destroy()`.
- **`_activeCount` module-level state in entity-stations-view.js**: single-editor invariant; would break if two stations editors mounted concurrently. Move to instance scope as a future cleanup.
- **Behaviour kinds / transition conditions vocab** drawn from shipped TOMLs (`patrolling/pursuing/attacking/fleeing/warping_out` etc.). `behaviour-editor.js:defaultParametersForKind` only knows `idle/patrol/attack`; unknown kinds get `{}` params and round-trip cleanly. No action needed for Slice 5.

Closes #386.
