### PR TITLE
Slice 6 — Definitions Mode: faction + complexity preset editors (#387)

### DIFF
--- a/editor/app-v2.js
+++ b/editor/app-v2.js
@@ -2,16 +2,36 @@ import { isSupported, pickProjectRoot, getProjectRoot, readFile, writeFile } fro
 import { ModeShell } from './mode-shell.js';
 import { stringifyWorldToml } from './world-toml.js';
 import { stringifyEntityToml } from './entity-toml.js';
+import { stringifyFactionToml } from './faction-editor.js';
+import { stringifyComplexityToml } from './complexity-editor.js';
 import { InvalidationBus } from './invalidation-bus.js';
 import { SaveFlow } from './save-flow.js';
 
 const $ = (id) => document.getElementById(id);
 
+/**
+ * Definitions Mode wraps content as { kind: 'faction'|'complexity', data }.
+ * This stringifier routes to the per-kind serializer.
+ */
+function stringifyDefinitionsPayload(payload) {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Definitions payload must be { kind, data }');
+  }
+  const { kind, data } = payload;
+  if (kind === 'faction') return stringifyFactionToml(data);
+  if (kind === 'complexity') return stringifyComplexityToml(data);
+  throw new Error(`Unknown definitions kind: ${kind}`);
+}
+
 const modeShell = new ModeShell();
 const invalidationBus = new InvalidationBus();
 const saveFlow = new SaveFlow(
   modeShell,
-  { world: stringifyWorldToml, entity: stringifyEntityToml },
+  {
+    world: stringifyWorldToml,
+    entity: stringifyEntityToml,
+    definitions: stringifyDefinitionsPayload,
+  },
   writeFile,
   invalidationBus,
 );

--- a/editor/app.js
+++ b/editor/app.js
@@ -10,6 +10,7 @@ import { renderWorldContentPanel } from './world-content-view.js';
 import { renderTriggerableWorldsPanel } from './triggerable-worlds-panel.js';
 import { mountNewWorldButton } from './new-world-dialog.js';
 import { mountEntityMode } from './entity-mode-view.js';
+import { mountDefinitionsMode } from './definitions-mode-view.js';
 import { readFile, writeFile, listDirectory } from './project-root.js';
 
 const layerManager = new LayerManager();
@@ -50,6 +51,20 @@ async function init() {
       modeShell: v2Boot.modeShell,
       saveFlow: v2Boot.saveFlow,
       registerRestore: v2Boot.registerRestore,
+      invalidationBus: v2Boot.invalidationBus,
+    });
+  }
+
+  // Slice 6: mount Definitions Mode two-section shell.
+  const definitionsHost = document.getElementById('definitions-mode-root');
+  if (definitionsHost && v2Boot && v2Boot.modeShell && v2Boot.saveFlow) {
+    mountDefinitionsMode({
+      host: definitionsHost,
+      modeShell: v2Boot.modeShell,
+      saveFlow: v2Boot.saveFlow,
+      registerRestore: v2Boot.registerRestore,
+      invalidationBus: v2Boot.invalidationBus,
+      io: { readFile, listDirectory },
     });
   }
 

--- a/editor/complexity-form-view.js
+++ b/editor/complexity-form-view.js
@@ -1,0 +1,276 @@
+/**
+ * complexity-form-view.js
+ *
+ * Centre pane of the Definitions Mode → Complexity section. Renders, for
+ * one open complexity TOML, all of its presets and the per-preset blocks:
+ *
+ *   Preset tabs  — click switches `activePresetIndex`.
+ *   hidden_elements multi-select — options = knownUiElements ∪ authored
+ *                                   hidden_elements (dedup) so unknown
+ *                                   authored values stay visible.
+ *   delegated    — table of rows { consoleKey: dropdown, controlsCsv }.
+ *   ai           — one collapsible block per behaviorKey with typed inputs
+ *                  derived from `typeof value`.
+ *
+ * Callbacks (all optional; missing ones are no-ops):
+ *   callbacks.onSwitchPreset(presetIndex)
+ *   callbacks.onSetHiddenElements(presetIndex, string[])
+ *   callbacks.onSetDelegated(presetIndex, consoleKey, controls: string[])
+ *   callbacks.onRemoveDelegated(presetIndex, consoleKey)
+ *   callbacks.onSetAiParam(presetIndex, behaviorKey, paramKey, value)
+ *   callbacks.onRemoveAiBlock(presetIndex, behaviorKey)
+ *   callbacks.onAddDelegated(presetIndex)
+ *   callbacks.onAddAiBlock(presetIndex)
+ */
+
+export const KNOWN_CONSOLE_KEYS = [
+  'Tactical',
+  'Helm',
+  'Repair',
+  'Power',
+  'Sensors',
+  'Shields',
+  'Navigation',
+  'Comms',
+  'CaptainChair',
+];
+
+export function renderComplexityFormView(host, opts) {
+  if (!host) return;
+  host.innerHTML = '';
+
+  const {
+    presets,
+    knownUiElements = [],
+    activePresetIndex = 0,
+    callbacks = {},
+  } = opts || {};
+
+  if (!Array.isArray(presets) || presets.length === 0) {
+    const p = document.createElement('p');
+    p.className = 'placeholder';
+    p.textContent = 'Select a complexity file from the list.';
+    host.appendChild(p);
+    return;
+  }
+
+  const idx = Math.max(0, Math.min(activePresetIndex, presets.length - 1));
+  const active = presets[idx];
+
+  // ── Preset tabs ───────────────────────────────────────────────────────
+  const tabs = document.createElement('div');
+  tabs.className = 'def-preset-tabs';
+  host.appendChild(tabs);
+  presets.forEach((preset, i) => {
+    const btn = document.createElement('button');
+    btn.className = 'def-preset-tab';
+    if (i === idx) btn.classList.add('def-preset-tab-active');
+    btn.dataset.presetIndex = String(i);
+    btn.textContent = preset.name || `(preset ${i})`;
+    btn.addEventListener('click', () => {
+      if (callbacks.onSwitchPreset) callbacks.onSwitchPreset(i);
+    });
+    tabs.appendChild(btn);
+  });
+
+  // ── hidden_elements multi-select ──────────────────────────────────────
+  const hiddenSection = document.createElement('section');
+  hiddenSection.className = 'def-form-section def-hidden-section';
+  host.appendChild(hiddenSection);
+
+  const hiddenLabel = document.createElement('label');
+  hiddenLabel.textContent = 'hidden_elements';
+  hiddenSection.appendChild(hiddenLabel);
+
+  const hiddenSelect = document.createElement('select');
+  hiddenSelect.multiple = true;
+  hiddenSelect.className = 'def-multi-select def-hidden-elements-select';
+
+  // Dedup: known UI elements ∪ authored values. Order: known first, then
+  // any extras the file has but our vocab doesn't.
+  const knownSet = new Set(knownUiElements);
+  const authored = Array.isArray(active.hidden_elements) ? active.hidden_elements : [];
+  const merged = [...knownUiElements];
+  for (const v of authored) {
+    if (!knownSet.has(v)) merged.push(v);
+  }
+  const authoredSet = new Set(authored);
+  for (const elName of merged) {
+    const opt = document.createElement('option');
+    opt.value = elName;
+    opt.textContent = elName;
+    opt.selected = authoredSet.has(elName);
+    hiddenSelect.appendChild(opt);
+  }
+  hiddenSelect.addEventListener('change', () => {
+    const values = [];
+    for (const child of hiddenSelect.children) {
+      if (child && child.selected) values.push(child.value);
+    }
+    if (callbacks.onSetHiddenElements) callbacks.onSetHiddenElements(idx, values);
+  });
+  hiddenSection.appendChild(hiddenSelect);
+
+  // ── Delegated table ───────────────────────────────────────────────────
+  const delegatedSection = document.createElement('section');
+  delegatedSection.className = 'def-form-section def-delegated-section';
+  host.appendChild(delegatedSection);
+
+  const delegatedHeader = document.createElement('div');
+  delegatedHeader.className = 'def-form-section-header';
+  delegatedHeader.textContent = 'delegated';
+  delegatedSection.appendChild(delegatedHeader);
+
+  const table = document.createElement('div');
+  table.className = 'def-delegated-table';
+  delegatedSection.appendChild(table);
+
+  const delegatedEntries = active.delegated && typeof active.delegated === 'object'
+    ? Object.entries(active.delegated)
+    : [];
+  for (const [consoleKey, val] of delegatedEntries) {
+    const row = document.createElement('div');
+    row.className = 'def-delegated-row';
+    row.dataset.consoleKey = consoleKey;
+    table.appendChild(row);
+
+    // Console-key dropdown (with free-text fallback if value is unknown).
+    const keySelect = document.createElement('select');
+    keySelect.className = 'def-delegated-console';
+    const keyOptions = KNOWN_CONSOLE_KEYS.includes(consoleKey)
+      ? KNOWN_CONSOLE_KEYS
+      : [...KNOWN_CONSOLE_KEYS, consoleKey];
+    for (const k of keyOptions) {
+      const opt = document.createElement('option');
+      opt.value = k;
+      opt.textContent = k;
+      opt.selected = k === consoleKey;
+      keySelect.appendChild(opt);
+    }
+    keySelect.addEventListener('change', (e) => {
+      const newKey = e.target.value;
+      if (newKey === consoleKey) return;
+      // Rename: remove the old key, add the new one with the same controls.
+      const controls = (val && Array.isArray(val.controls)) ? [...val.controls] : [];
+      if (callbacks.onRemoveDelegated) callbacks.onRemoveDelegated(idx, consoleKey);
+      if (callbacks.onSetDelegated) callbacks.onSetDelegated(idx, newKey, controls);
+    });
+    row.appendChild(keySelect);
+
+    // Controls — CSV input
+    const controlsInput = document.createElement('input');
+    controlsInput.type = 'text';
+    controlsInput.className = 'def-delegated-controls';
+    controlsInput.value = Array.isArray(val?.controls) ? val.controls.join(', ') : '';
+    controlsInput.placeholder = 'comma-separated control names';
+    controlsInput.addEventListener('input', (e) => {
+      const csv = e.target.value;
+      const list = csv.split(',').map((s) => s.trim()).filter(Boolean);
+      if (callbacks.onSetDelegated) callbacks.onSetDelegated(idx, consoleKey, list);
+    });
+    row.appendChild(controlsInput);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'def-delegated-remove';
+    removeBtn.textContent = 'Remove';
+    removeBtn.addEventListener('click', () => {
+      if (callbacks.onRemoveDelegated) callbacks.onRemoveDelegated(idx, consoleKey);
+    });
+    row.appendChild(removeBtn);
+  }
+
+  const addDelegated = document.createElement('button');
+  addDelegated.className = 'def-delegated-add';
+  addDelegated.textContent = '+ Add delegated';
+  addDelegated.addEventListener('click', () => {
+    if (callbacks.onAddDelegated) callbacks.onAddDelegated(idx);
+  });
+  delegatedSection.appendChild(addDelegated);
+
+  // ── AI tuning blocks ──────────────────────────────────────────────────
+  const aiSection = document.createElement('section');
+  aiSection.className = 'def-form-section def-ai-section';
+  host.appendChild(aiSection);
+
+  const aiHeader = document.createElement('div');
+  aiHeader.className = 'def-form-section-header';
+  aiHeader.textContent = 'ai';
+  aiSection.appendChild(aiHeader);
+
+  const aiEntries = active.ai && typeof active.ai === 'object'
+    ? Object.entries(active.ai)
+    : [];
+  for (const [behaviorKey, params] of aiEntries) {
+    const block = document.createElement('div');
+    block.className = 'def-ai-block';
+    block.dataset.behaviorKey = behaviorKey;
+    aiSection.appendChild(block);
+
+    const blockHeader = document.createElement('div');
+    blockHeader.className = 'def-ai-block-header';
+    blockHeader.textContent = behaviorKey;
+    block.appendChild(blockHeader);
+
+    const paramEntries = params && typeof params === 'object'
+      ? Object.entries(params)
+      : [];
+    for (const [paramKey, value] of paramEntries) {
+      const paramRow = document.createElement('div');
+      paramRow.className = 'def-ai-param-row';
+      paramRow.dataset.paramKey = paramKey;
+      block.appendChild(paramRow);
+
+      const paramLabel = document.createElement('label');
+      paramLabel.textContent = paramKey;
+      paramRow.appendChild(paramLabel);
+
+      const input = document.createElement('input');
+      const t = typeof value;
+      if (t === 'number') {
+        input.type = 'number';
+        input.step = '0.1';
+        input.value = String(value);
+        input.addEventListener('input', (e) => {
+          const n = Number(e.target.value);
+          if (callbacks.onSetAiParam) {
+            callbacks.onSetAiParam(idx, behaviorKey, paramKey, Number.isFinite(n) ? n : 0);
+          }
+        });
+      } else if (t === 'boolean') {
+        input.type = 'checkbox';
+        input.checked = !!value;
+        input.addEventListener('change', (e) => {
+          if (callbacks.onSetAiParam) {
+            callbacks.onSetAiParam(idx, behaviorKey, paramKey, !!e.target.checked);
+          }
+        });
+      } else {
+        input.type = 'text';
+        input.value = value == null ? '' : String(value);
+        input.addEventListener('input', (e) => {
+          if (callbacks.onSetAiParam) {
+            callbacks.onSetAiParam(idx, behaviorKey, paramKey, e.target.value);
+          }
+        });
+      }
+      input.className = 'def-ai-param-input';
+      paramRow.appendChild(input);
+    }
+
+    const removeBlock = document.createElement('button');
+    removeBlock.className = 'def-ai-remove';
+    removeBlock.textContent = 'Remove block';
+    removeBlock.addEventListener('click', () => {
+      if (callbacks.onRemoveAiBlock) callbacks.onRemoveAiBlock(idx, behaviorKey);
+    });
+    block.appendChild(removeBlock);
+  }
+
+  const addAi = document.createElement('button');
+  addAi.className = 'def-ai-add';
+  addAi.textContent = '+ Add AI block';
+  addAi.addEventListener('click', () => {
+    if (callbacks.onAddAiBlock) callbacks.onAddAiBlock(idx);
+  });
+  aiSection.appendChild(addAi);
+}

--- a/editor/definitions-file-list-view.js
+++ b/editor/definitions-file-list-view.js
@@ -1,0 +1,52 @@
+/**
+ * definitions-file-list-view.js
+ *
+ * Shared left-pane file list used by both Definitions Mode sections
+ * (factions + complexity presets). One row per path, with a dirty-dot
+ * indicator from `modeShell.isDirty(mode, path)` and click → `onSelect(path)`.
+ *
+ * `mode` is always `'Definitions'` — the section label distinction
+ * (faction vs complexity) is encoded in the path prefix.
+ */
+
+export function renderDefinitionsFileListView(host, { paths, activePath, modeShell, mode = 'Definitions', onSelect }) {
+  if (!host) return;
+  host.innerHTML = '';
+
+  const root = host.ownerDocument
+    ? host.ownerDocument.createElement('div')
+    : document.createElement('div');
+  root.className = 'definitions-file-list';
+  host.appendChild(root);
+
+  if (!paths || paths.length === 0) {
+    const p = document.createElement('p');
+    p.className = 'placeholder';
+    p.textContent = 'No files.';
+    root.appendChild(p);
+    return;
+  }
+
+  for (const path of paths) {
+    const row = document.createElement('div');
+    row.className = 'definitions-file-list-row';
+    row.dataset.path = path;
+    if (path === activePath) row.classList.add('definitions-file-list-row-active');
+
+    if (modeShell && modeShell.isDirty(mode, path)) {
+      const dot = document.createElement('span');
+      dot.className = 'dirty-dot';
+      dot.textContent = '\u25CF';
+      row.appendChild(dot);
+    }
+
+    const label = document.createElement('span');
+    label.className = 'definitions-file-list-label';
+    // Strip the assets/factions/ or assets/complexity/ prefix for display.
+    label.textContent = path.replace(/^assets\/(factions|complexity)\//, '');
+    row.appendChild(label);
+
+    row.addEventListener('click', () => onSelect && onSelect(path));
+    root.appendChild(row);
+  }
+}

--- a/editor/definitions-mode-view.js
+++ b/editor/definitions-mode-view.js
@@ -1,0 +1,474 @@
+/**
+ * definitions-mode-view.js
+ *
+ * Top-level coordinator for the Definitions Mode two-section shell.
+ *
+ *   Top section    — Factions: left file list (assets/factions/*.toml)
+ *                              + centre form (faction-form-view).
+ *   Bottom section — Complexity presets: left file list
+ *                              (assets/complexity/*.toml) + centre form
+ *                              (complexity-form-view).
+ *
+ * Both sections share one `'Definitions'` ModeShell key; the kind
+ * distinction is encoded in the path prefix (`assets/factions/` vs
+ * `assets/complexity/`) and round-trips through the SaveFlow content
+ * cache as `{ kind: 'faction' | 'complexity', data }`.
+ *
+ * Wires:
+ *   - file-list click → io.readFile → editor.openFile → re-render section
+ *   - form edit → snapshot-before-mutate → editor mutator →
+ *       saveFlow.setContent('Definitions', path, {kind, data}) →
+ *       modeShell.markDirty → re-render section
+ *   - registerRestore('Definitions', …) for Ctrl+Z restore
+ *   - InvalidationBus.fireFactionSaved fires from save-flow itself when
+ *     a faction file saves; Entity Mode subscribes to refresh its dropdown.
+ */
+
+import { FactionEditor } from './faction-editor.js';
+import { ComplexityEditor } from './complexity-editor.js';
+import { renderDefinitionsFileListView } from './definitions-file-list-view.js';
+import { renderFactionFormView } from './faction-form-view.js';
+import { renderComplexityFormView } from './complexity-form-view.js';
+import { readFile, listDirectory, getProjectRoot } from './project-root.js';
+
+const FACTIONS_DIR = 'assets/factions';
+const COMPLEXITY_DIR = 'assets/complexity';
+
+export function mountDefinitionsMode({ host, modeShell, saveFlow, registerRestore, invalidationBus, io } = {}) {
+  if (!host) return null;
+
+  const ioDeps = {
+    readFile: io?.readFile || readFile,
+    listDirectory: io?.listDirectory || listDirectory,
+    getProjectRoot: io?.getProjectRoot || getProjectRoot,
+  };
+
+  const factionEditor = new FactionEditor();
+  const complexityEditor = new ComplexityEditor();
+
+  // Complexity centre state (active preset index per file). Faction
+  // editor is single-screen so no equivalent index needed.
+  let activePresetIndex = 0;
+
+  // Cache the raw text for each file so re-opening after edits stays
+  // consistent with what the editor parsed.
+  const factionRawCache = new Map();
+  const complexityRawCache = new Map();
+
+  // ── Skeleton ──────────────────────────────────────────────────────────
+  host.innerHTML = '';
+  const wrap = document.createElement('div');
+  wrap.className = 'definitions-two-section';
+  host.appendChild(wrap);
+
+  // Faction section
+  const factionSection = document.createElement('section');
+  factionSection.className = 'definitions-section definitions-section-faction';
+  wrap.appendChild(factionSection);
+
+  const factionHeader = document.createElement('div');
+  factionHeader.className = 'definitions-section-header';
+  factionHeader.textContent = 'Factions';
+  factionSection.appendChild(factionHeader);
+
+  const factionBody = document.createElement('div');
+  factionBody.className = 'definitions-section-body';
+  factionSection.appendChild(factionBody);
+
+  const factionLeft = document.createElement('div');
+  factionLeft.className = 'def-pane def-pane-left';
+  factionBody.appendChild(factionLeft);
+
+  const factionCenter = document.createElement('div');
+  factionCenter.className = 'def-pane def-pane-center';
+  factionBody.appendChild(factionCenter);
+
+  // Complexity section
+  const complexitySection = document.createElement('section');
+  complexitySection.className = 'definitions-section definitions-section-complexity';
+  wrap.appendChild(complexitySection);
+
+  const complexityHeader = document.createElement('div');
+  complexityHeader.className = 'definitions-section-header';
+  complexityHeader.textContent = 'Complexity Presets';
+  complexitySection.appendChild(complexityHeader);
+
+  const complexityBody = document.createElement('div');
+  complexityBody.className = 'definitions-section-body';
+  complexitySection.appendChild(complexityBody);
+
+  const complexityLeft = document.createElement('div');
+  complexityLeft.className = 'def-pane def-pane-left';
+  complexityBody.appendChild(complexityLeft);
+
+  const complexityCenter = document.createElement('div');
+  complexityCenter.className = 'def-pane def-pane-center';
+  complexityBody.appendChild(complexityCenter);
+
+  // ── Render helpers ────────────────────────────────────────────────────
+
+  function renderFactionLeft() {
+    renderDefinitionsFileListView(factionLeft, {
+      paths: factionEditor.getFileList(),
+      activePath: factionEditor.getActiveFile(),
+      modeShell,
+      mode: 'Definitions',
+      onSelect: (p) => loadFactionFile(p),
+    });
+  }
+
+  function renderFactionCenter() {
+    const formState = factionEditor.getFormState();
+    renderFactionFormView(factionCenter, {
+      formState,
+      enemyOptions: factionEditor.getEnemyOptions(),
+      onNameChange: (name) => handleFactionNameChange(name),
+      onEnemiesChange: (uuids) => handleFactionEnemiesChange(uuids),
+    });
+  }
+
+  function renderComplexityLeft() {
+    renderDefinitionsFileListView(complexityLeft, {
+      paths: complexityEditor.getFileList(),
+      activePath: complexityEditor.getActiveFile(),
+      modeShell,
+      mode: 'Definitions',
+      onSelect: (p) => loadComplexityFile(p),
+    });
+  }
+
+  function renderComplexityCenter() {
+    const presets = complexityEditor.getPresets();
+    renderComplexityFormView(complexityCenter, {
+      presets: presets || [],
+      knownUiElements: complexityEditor.getKnownUiElements(),
+      activePresetIndex,
+      callbacks: {
+        onSwitchPreset: (i) => {
+          activePresetIndex = i;
+          renderComplexityCenter();
+        },
+        onSetHiddenElements: (i, list) => handleComplexityMutation(() => {
+          complexityEditor.setHiddenElements(i, list);
+        }),
+        onSetDelegated: (i, key, controls) => handleComplexityMutation(() => {
+          complexityEditor.setDelegated(i, key, controls);
+        }),
+        onRemoveDelegated: (i, key) => handleComplexityMutation(() => {
+          complexityEditor.removeDelegated(i, key);
+        }),
+        onSetAiParam: (i, b, k, v) => handleComplexityMutation(() => {
+          complexityEditor.setAiParam(i, b, k, v);
+        }),
+        onRemoveAiBlock: (i, b) => handleComplexityMutation(() => {
+          complexityEditor.removeAiBlock(i, b);
+        }),
+        onAddDelegated: (i) => handleComplexityMutation(() => {
+          // Pick the first known console not yet present in the table.
+          const existing = new Set(Object.keys(complexityEditor.getPreset(i)?.delegated || {}));
+          const fallback = ['Tactical', 'Helm', 'Repair', 'Power', 'Sensors',
+            'Shields', 'Navigation', 'Comms', 'CaptainChair']
+            .find((k) => !existing.has(k)) || 'Tactical';
+          complexityEditor.setDelegated(i, fallback, []);
+        }),
+        onAddAiBlock: (i) => handleComplexityMutation(() => {
+          // Generate a stable placeholder behavior key.
+          let n = 1;
+          const existing = new Set(Object.keys(complexityEditor.getPreset(i)?.ai || {}));
+          while (existing.has(`new_behavior_${n}`)) n += 1;
+          complexityEditor.setAiBlock(i, `new_behavior_${n}`, {});
+        }),
+      },
+    });
+  }
+
+  function renderAll() {
+    renderFactionLeft();
+    renderFactionCenter();
+    renderComplexityLeft();
+    renderComplexityCenter();
+  }
+
+  // ── Mutation helpers ──────────────────────────────────────────────────
+
+  function snapshotFaction(path) {
+    const formState = factionEditor.getFormState();
+    if (!formState) return;
+    modeShell.pushUndoEntry('Definitions', path, structuredClone({
+      kind: 'faction',
+      data: formState,
+    }));
+  }
+
+  function commitFaction(path) {
+    const data = factionEditor.getFormState();
+    saveFlow.setContent('Definitions', path, { kind: 'faction', data });
+    modeShell.markDirty('Definitions', path, true);
+    // Re-render both panes (left for dirty-dot, centre for current values).
+    renderFactionLeft();
+    renderFactionCenter();
+  }
+
+  function handleFactionNameChange(name) {
+    const path = factionEditor.getActiveFile();
+    if (!path) return;
+    snapshotFaction(path);
+    factionEditor.setName(name);
+    commitFaction(path);
+  }
+
+  function handleFactionEnemiesChange(uuids) {
+    const path = factionEditor.getActiveFile();
+    if (!path) return;
+    snapshotFaction(path);
+    factionEditor.setEnemies(uuids);
+    commitFaction(path);
+  }
+
+  function snapshotComplexity(path) {
+    const presets = complexityEditor.getPresets();
+    if (!presets) return;
+    modeShell.pushUndoEntry('Definitions', path, structuredClone({
+      kind: 'complexity',
+      data: presets,
+    }));
+  }
+
+  function handleComplexityMutation(mutator) {
+    const path = complexityEditor.getActiveFile();
+    if (!path) return;
+    snapshotComplexity(path);
+    mutator();
+    const data = complexityEditor.getPresets();
+    saveFlow.setContent('Definitions', path, { kind: 'complexity', data });
+    modeShell.markDirty('Definitions', path, true);
+    renderComplexityLeft();
+    renderComplexityCenter();
+  }
+
+  // ── File load ────────────────────────────────────────────────────────
+
+  async function loadFactionFile(path) {
+    let text = factionRawCache.get(path);
+    if (text === undefined) {
+      try {
+        text = await ioDeps.readFile(path);
+        factionRawCache.set(path, text);
+      } catch {
+        return;
+      }
+    }
+    if (!factionEditor.openFile(path)) {
+      // Editor's loadAll may not include this path yet (e.g. new file).
+      // Append a single-file load on the fly.
+      factionEditor.loadAll([
+        ...factionEditor.getFileList().map((p) => ({
+          path: p,
+          content: factionRawCache.get(p),
+        })),
+        { path, content: text },
+      ]);
+      factionEditor.openFile(path);
+    }
+    modeShell.setActiveFile('Definitions', path);
+    const formState = factionEditor.getFormState();
+    if (formState) {
+      saveFlow.setContent('Definitions', path, { kind: 'faction', data: formState });
+    }
+    renderFactionLeft();
+    renderFactionCenter();
+  }
+
+  async function loadComplexityFile(path) {
+    let text = complexityRawCache.get(path);
+    if (text === undefined) {
+      try {
+        text = await ioDeps.readFile(path);
+        complexityRawCache.set(path, text);
+      } catch {
+        return;
+      }
+    }
+    if (!complexityEditor.openFile(path)) {
+      complexityEditor.loadAll([
+        ...complexityEditor.getFileList().map((p) => ({
+          path: p,
+          content: complexityRawCache.get(p),
+        })),
+        { path, content: text },
+      ]);
+      complexityEditor.openFile(path);
+    }
+    activePresetIndex = 0;
+    modeShell.setActiveFile('Definitions', path);
+    const presets = complexityEditor.getPresets();
+    if (presets) {
+      saveFlow.setContent('Definitions', path, { kind: 'complexity', data: presets });
+    }
+    renderComplexityLeft();
+    renderComplexityCenter();
+  }
+
+  // ── File-list bootstrap ──────────────────────────────────────────────
+
+  async function refreshFactionList() {
+    let entries = [];
+    try {
+      entries = await ioDeps.listDirectory(FACTIONS_DIR);
+    } catch {
+      entries = [];
+    }
+    const paths = (entries || [])
+      .filter((e) => e && e.kind === 'file' && typeof e.name === 'string' && e.name.endsWith('.toml'))
+      .map((e) => `${FACTIONS_DIR}/${e.name}`)
+      .sort();
+
+    const loaded = [];
+    for (const p of paths) {
+      try {
+        const content = await ioDeps.readFile(p);
+        factionRawCache.set(p, content);
+        loaded.push({ path: p, content });
+      } catch {
+        // Skip files that fail to read.
+      }
+    }
+    factionEditor.loadAll(loaded);
+
+    // Reflect into ModeShell's open-files registry so SaveAll picks these up.
+    const currentOpen = modeShell.getOpenFiles('Definitions') || [];
+    const filtered = currentOpen.filter((p) => !p.startsWith(`${FACTIONS_DIR}/`));
+    modeShell.setOpenFiles('Definitions', [...filtered, ...paths]);
+    renderFactionLeft();
+  }
+
+  async function refreshComplexityList() {
+    let entries = [];
+    try {
+      entries = await ioDeps.listDirectory(COMPLEXITY_DIR);
+    } catch {
+      entries = [];
+    }
+    const paths = (entries || [])
+      .filter((e) => e && e.kind === 'file' && typeof e.name === 'string' && e.name.endsWith('.toml'))
+      .map((e) => `${COMPLEXITY_DIR}/${e.name}`)
+      .sort();
+
+    const loaded = [];
+    for (const p of paths) {
+      try {
+        const content = await ioDeps.readFile(p);
+        complexityRawCache.set(p, content);
+        loaded.push({ path: p, content });
+      } catch {
+        // Skip
+      }
+    }
+    complexityEditor.loadAll(loaded);
+
+    const currentOpen = modeShell.getOpenFiles('Definitions') || [];
+    const filtered = currentOpen.filter((p) => !p.startsWith(`${COMPLEXITY_DIR}/`));
+    modeShell.setOpenFiles('Definitions', [...filtered, ...paths]);
+    renderComplexityLeft();
+  }
+
+  // ── Undo restore registration ────────────────────────────────────────
+
+  if (typeof registerRestore === 'function') {
+    registerRestore('Definitions', (ms, path, direction) => {
+      // Determine which editor owns the path.
+      const isFaction = typeof path === 'string' && path.startsWith(`${FACTIONS_DIR}/`);
+      const isComplexity = typeof path === 'string' && path.startsWith(`${COMPLEXITY_DIR}/`);
+      if (!isFaction && !isComplexity) return;
+
+      // Capture current state in the wrapped { kind, data } shape so the
+      // opposite stack can replay it later.
+      let current;
+      if (isFaction) {
+        const fs = factionEditor.getFormState();
+        if (!fs) return;
+        current = structuredClone({ kind: 'faction', data: fs });
+      } else {
+        const ps = complexityEditor.getPresets();
+        if (!ps) return;
+        current = structuredClone({ kind: 'complexity', data: ps });
+      }
+
+      const snap = direction === 'undo'
+        ? ms.swapUndoActive('Definitions', path, current)
+        : ms.swapRedoActive('Definitions', path, current);
+      if (!snap) return;
+
+      if (isFaction && snap.kind === 'faction') {
+        factionEditor.setName(snap.data.name);
+        factionEditor.setEnemies(snap.data.enemies || []);
+        saveFlow.setContent('Definitions', path, { kind: 'faction', data: snap.data });
+        renderFactionLeft();
+        renderFactionCenter();
+      } else if (isComplexity && snap.kind === 'complexity') {
+        // Replay every preset block. ComplexityEditor doesn't expose a
+        // wholesale setter, so reach in via the per-preset mutators.
+        const presets = snap.data || [];
+        for (let i = 0; i < presets.length; i += 1) {
+          complexityEditor.setHiddenElements(i, presets[i].hidden_elements || []);
+          // Reset the delegated map: remove all existing keys first, then
+          // re-apply the snapshot's.
+          const existing = Object.keys(complexityEditor.getPreset(i)?.delegated || {});
+          for (const k of existing) complexityEditor.removeDelegated(i, k);
+          for (const [k, v] of Object.entries(presets[i].delegated || {})) {
+            complexityEditor.setDelegated(i, k, v.controls || []);
+          }
+          const aiExisting = Object.keys(complexityEditor.getPreset(i)?.ai || {});
+          for (const k of aiExisting) complexityEditor.removeAiBlock(i, k);
+          for (const [k, v] of Object.entries(presets[i].ai || {})) {
+            complexityEditor.setAiBlock(i, k, v);
+          }
+        }
+        saveFlow.setContent('Definitions', path, { kind: 'complexity', data: presets });
+        renderComplexityLeft();
+        renderComplexityCenter();
+      }
+    });
+  }
+
+  // ── Bootstrap ────────────────────────────────────────────────────────
+
+  let bootstrapPromise = null;
+  function bootstrap() {
+    if (bootstrapPromise) return bootstrapPromise;
+    bootstrapPromise = (async () => {
+      try {
+        const root = await ioDeps.getProjectRoot();
+        if (!root) {
+          factionLeft.innerHTML = '<p class="placeholder">Pick a project root to load definition files.</p>';
+          complexityLeft.innerHTML = '<p class="placeholder">Pick a project root to load definition files.</p>';
+          return;
+        }
+      } catch {
+        // best-effort; carry on
+      }
+      await refreshFactionList();
+      await refreshComplexityList();
+    })();
+    return bootstrapPromise;
+  }
+
+  // Fire-and-forget. Tests await `_internal.bootstrap` directly to dedupe.
+  bootstrap();
+
+  return {
+    factionEditor,
+    complexityEditor,
+    render: renderAll,
+    _internal: {
+      bootstrap,
+      loadFactionFile,
+      loadComplexityFile,
+      refreshFactionList,
+      refreshComplexityList,
+      handleFactionNameChange,
+      handleFactionEnemiesChange,
+      handleComplexityMutation,
+    },
+  };
+}

--- a/editor/entity-mode-view.js
+++ b/editor/entity-mode-view.js
@@ -34,11 +34,15 @@ import { readFile, listDirectory, getProjectRoot } from './project-root.js';
  * @param {import('./mode-shell.js').ModeShell} opts.modeShell
  * @param {import('./save-flow.js').SaveFlow} opts.saveFlow
  * @param {(mode:string, fn:(modeShell, path, direction)=>void)=>void} opts.registerRestore
+ * @param {object} [opts.invalidationBus]
+ *   Optional InvalidationBus. When supplied, Entity Mode subscribes to
+ *   `onFactionSaved` so the faction dropdown picks up Definitions Mode
+ *   edits (Slice 6 cross-mode coupling).
  * @param {object} [opts.io]  Override I/O for tests: { readFile, listDirectory,
  *                            preload, onCacheInvalidate, getProjectRoot, discover }.
  * @returns {{ shell: EntityModeShell, render: () => void }}
  */
-export function mountEntityMode({ host, modeShell, saveFlow, registerRestore, io }) {
+export function mountEntityMode({ host, modeShell, saveFlow, registerRestore, invalidationBus, io }) {
   if (!host) return null;
 
   const shell = new EntityModeShell();
@@ -230,6 +234,30 @@ export function mountEntityMode({ host, modeShell, saveFlow, registerRestore, io
     });
   }
 
+  // ── Faction invalidation (Slice 6 cross-mode coupling) ────────────────
+  // When Definitions Mode saves a faction file, re-run discovery so the
+  // faction dropdown in component cards reflects the renamed/removed
+  // faction immediately.
+  async function refreshFactionMap() {
+    try {
+      const { factionMap } = await ioDeps.discover({
+        listDirectory: ioDeps.listDirectory,
+        readFile: ioDeps.readFile,
+      });
+      shell.setFactionMap(factionMap);
+      renderCenter();
+    } catch (err) {
+      console.warn('[entity-mode-view] faction refresh failed:', err?.message || err);
+    }
+  }
+
+  let factionSavedSub = null;
+  if (invalidationBus && typeof invalidationBus.onFactionSaved === 'function') {
+    factionSavedSub = invalidationBus.onFactionSaved(() => {
+      refreshFactionMap();
+    });
+  }
+
   // ── Bootstrap ─────────────────────────────────────────────────────────
   (async () => {
     // Initial discovery (factions + complexity).
@@ -273,6 +301,7 @@ export function mountEntityMode({ host, modeShell, saveFlow, registerRestore, io
       refreshFileList,
       handleCardEdit,
       handleAddChoice,
+      refreshFactionMap,
     },
   };
 }

--- a/editor/faction-form-view.js
+++ b/editor/faction-form-view.js
@@ -1,0 +1,99 @@
+/**
+ * faction-form-view.js
+ *
+ * Centre pane of the Definitions Mode → Faction section. Renders a small
+ * form for the currently open faction:
+ *
+ *   uuid     — read-only label (never edited; identity is path-bound).
+ *   name     — single-line text input.
+ *   enemies  — <select multiple> over other factions, displayed by NAME
+ *              with `option.value = uuid` (AC3).
+ *
+ * Callbacks emit canonical values:
+ *   onNameChange(newName: string)
+ *   onEnemiesChange(uuidList: string[])
+ */
+
+export function renderFactionFormView(host, { formState, enemyOptions, onNameChange, onEnemiesChange }) {
+  if (!host) return;
+  host.innerHTML = '';
+
+  if (!formState) {
+    const p = document.createElement('p');
+    p.className = 'placeholder';
+    p.textContent = 'Select a faction file from the list.';
+    host.appendChild(p);
+    return;
+  }
+
+  const form = document.createElement('div');
+  form.className = 'faction-form';
+  host.appendChild(form);
+
+  // ── UUID (read-only) ──────────────────────────────────────────────────
+  const uuidRow = document.createElement('div');
+  uuidRow.className = 'def-form-row';
+  form.appendChild(uuidRow);
+
+  const uuidLabel = document.createElement('label');
+  uuidLabel.textContent = 'UUID';
+  uuidRow.appendChild(uuidLabel);
+
+  const uuidValue = document.createElement('span');
+  uuidValue.className = 'def-uuid-readonly';
+  uuidValue.textContent = formState.uuid;
+  uuidRow.appendChild(uuidValue);
+
+  // ── Name (text) ───────────────────────────────────────────────────────
+  const nameRow = document.createElement('div');
+  nameRow.className = 'def-form-row';
+  form.appendChild(nameRow);
+
+  const nameLabel = document.createElement('label');
+  nameLabel.textContent = 'Name';
+  nameRow.appendChild(nameLabel);
+
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.className = 'def-name-input';
+  nameInput.value = formState.name;
+  nameInput.addEventListener('input', (e) => {
+    if (onNameChange) onNameChange(e.target.value);
+  });
+  nameRow.appendChild(nameInput);
+
+  // ── Enemies (multi-select, displays NAMES) ────────────────────────────
+  const enemiesRow = document.createElement('div');
+  enemiesRow.className = 'def-form-row';
+  form.appendChild(enemiesRow);
+
+  const enemiesLabel = document.createElement('label');
+  enemiesLabel.textContent = 'Enemies';
+  enemiesRow.appendChild(enemiesLabel);
+
+  const select = document.createElement('select');
+  select.multiple = true;
+  select.className = 'def-multi-select';
+  const selectedUuids = new Set(formState.enemies || []);
+  const opts = Array.isArray(enemyOptions) ? enemyOptions : [];
+  for (const opt of opts) {
+    const optionEl = document.createElement('option');
+    optionEl.value = opt.uuid;
+    optionEl.textContent = opt.name;
+    optionEl.selected = selectedUuids.has(opt.uuid);
+    select.appendChild(optionEl);
+  }
+
+  select.addEventListener('change', () => {
+    // Collect every option currently flagged `selected`. The FakeElement
+    // shim has no native HTMLSelectElement.selectedOptions, so iterate
+    // children explicitly.
+    const uuids = [];
+    for (const child of select.children) {
+      if (child && child.selected) uuids.push(child.value);
+    }
+    if (onEnemiesChange) onEnemiesChange(uuids);
+  });
+
+  enemiesRow.appendChild(select);
+}

--- a/editor/invalidation-bus.js
+++ b/editor/invalidation-bus.js
@@ -2,6 +2,7 @@ export class InvalidationBus {
   constructor() {
     this._entitySavedListeners = [];
     this._worldSavedListeners = [];
+    this._factionSavedListeners = [];
   }
 
   fireEntitySaved(entityPath) {
@@ -13,6 +14,12 @@ export class InvalidationBus {
   fireWorldSaved(worldPath) {
     for (const cb of this._worldSavedListeners) {
       cb(worldPath);
+    }
+  }
+
+  fireFactionSaved(factionPath) {
+    for (const cb of this._factionSavedListeners) {
+      cb(factionPath);
     }
   }
 
@@ -32,6 +39,17 @@ export class InvalidationBus {
     return {
       unsubscribe: () => {
         this._worldSavedListeners = this._worldSavedListeners.filter(
+          (cb) => cb !== callback
+        );
+      },
+    };
+  }
+
+  onFactionSaved(callback) {
+    this._factionSavedListeners.push(callback);
+    return {
+      unsubscribe: () => {
+        this._factionSavedListeners = this._factionSavedListeners.filter(
           (cb) => cb !== callback
         );
       },

--- a/editor/save-flow.js
+++ b/editor/save-flow.js
@@ -48,6 +48,12 @@ export class SaveFlow {
     if (mode === 'Scenario') {
       return this._stringifyFunctions.world;
     }
+    if (mode === 'Definitions') {
+      // Backward-compat: tests / older callers that don't supply a
+      // `definitions` stringifier fall through to `entity`. This keeps
+      // pre-Slice-6 fixtures working unchanged.
+      return this._stringifyFunctions.definitions || this._stringifyFunctions.entity;
+    }
     return this._stringifyFunctions.entity;
   }
 
@@ -113,6 +119,13 @@ export class SaveFlow {
         this._invalidationBus.fireEntitySaved(path);
       } else if (mode === 'Scenario' && typeof this._invalidationBus.fireWorldSaved === 'function') {
         this._invalidationBus.fireWorldSaved(path);
+      } else if (
+        mode === 'Definitions' &&
+        typeof path === 'string' &&
+        path.startsWith('assets/factions/') &&
+        typeof this._invalidationBus.fireFactionSaved === 'function'
+      ) {
+        this._invalidationBus.fireFactionSaved(path);
       }
     }
 

--- a/editor/style.css
+++ b/editor/style.css
@@ -1448,3 +1448,119 @@ form {
 .entity-preview-error {
   padding: 12px; color: #d66; font-size: 12px; font-family: monospace;
 }
+
+/* -- Definitions Mode (Slice 6) ----------------------------------------- */
+
+.definitions-two-section {
+  display: flex; flex-direction: column; gap: 8px;
+  height: 100%; min-height: 0;
+}
+.definitions-section {
+  display: flex; flex-direction: column;
+  flex: 1 1 50%; min-height: 0; max-height: 50%;
+  background: #1a1c20; border: 1px solid #2f323a; border-radius: 4px;
+  overflow: hidden;
+}
+.definitions-section-header {
+  padding: 6px 10px; background: #23262c;
+  border-bottom: 1px solid #2f323a;
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px;
+  color: #aaa; flex-shrink: 0;
+}
+.definitions-section-body {
+  display: grid; grid-template-columns: 220px 1fr; gap: 8px;
+  flex: 1 1 auto; min-height: 0; padding: 8px;
+}
+.def-pane {
+  background: #1e2126; border: 1px solid #2f323a; border-radius: 4px;
+  overflow: auto; min-height: 0; padding: 6px;
+}
+.def-pane-left  { /* file list lives here */ }
+.def-pane-center { padding: 10px; }
+
+.definitions-file-list { display: flex; flex-direction: column; gap: 1px; }
+.definitions-file-list-row {
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 8px; border-radius: 3px;
+  color: #ccc; font-size: 12px; cursor: pointer;
+}
+.definitions-file-list-row:hover { background: #2a2d34; }
+.definitions-file-list-row-active { background: #3a4a66; color: #fff; }
+.definitions-file-list-row .dirty-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: #d6a64a; flex-shrink: 0;
+}
+.definitions-file-list-label {
+  flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+/* Form rows shared between faction + complexity panes */
+.def-form-row {
+  display: flex; align-items: center; gap: 8px; margin-bottom: 8px;
+}
+.def-form-row > label { width: 110px; color: #aaa; font-size: 11px; }
+.def-uuid-readonly {
+  font-family: monospace; font-size: 11px; color: #888;
+  background: #15171a; padding: 3px 6px; border-radius: 3px;
+}
+.def-name-input,
+.def-multi-select,
+.def-delegated-controls,
+.def-ai-param-input {
+  background: #15171a; border: 1px solid #2f323a; color: #ddd;
+  padding: 3px 6px; border-radius: 3px; font-size: 12px;
+}
+.def-multi-select { min-height: 100px; min-width: 200px; flex: 1; }
+
+/* Complexity preset tabs */
+.def-preset-tabs {
+  display: flex; gap: 2px; border-bottom: 1px solid #333740; margin-bottom: 10px;
+}
+.def-preset-tab {
+  background: #2a2d34; border: 1px solid #333740; border-bottom: none;
+  color: #aaa; padding: 4px 12px; cursor: pointer; font-size: 11px;
+  border-radius: 3px 3px 0 0;
+}
+.def-preset-tab-active { background: #1e2126; color: #fff; }
+
+.def-form-section { margin-bottom: 12px; }
+.def-form-section-header {
+  font-size: 11px; text-transform: uppercase; color: #aaa;
+  letter-spacing: 0.5px; margin-bottom: 6px;
+}
+
+/* Delegated table */
+.def-delegated-table { display: flex; flex-direction: column; gap: 4px; }
+.def-delegated-row {
+  display: flex; gap: 6px; align-items: center;
+  background: #1a1c20; padding: 4px; border-radius: 3px;
+}
+.def-delegated-console { min-width: 110px; }
+.def-delegated-controls { flex: 1; font-family: monospace; }
+.def-delegated-remove,
+.def-delegated-add,
+.def-ai-remove,
+.def-ai-add {
+  background: #2c2f36; border: 1px solid #3a3d44; color: #ccc;
+  padding: 2px 8px; border-radius: 3px; cursor: pointer; font-size: 11px;
+}
+.def-delegated-remove:hover,
+.def-ai-remove:hover { background: #5a2d2d; color: #fff; }
+.def-delegated-add:hover,
+.def-ai-add:hover { background: #3a3d44; }
+
+/* AI tuning blocks */
+.def-ai-block {
+  background: #1a1c20; border: 1px solid #2f323a; border-radius: 3px;
+  padding: 6px 8px; margin-bottom: 6px;
+}
+.def-ai-block-header {
+  font-size: 11px; color: #ddd; font-weight: 600; margin-bottom: 4px;
+}
+.def-ai-param-row {
+  display: flex; align-items: center; gap: 6px; margin-bottom: 3px;
+}
+.def-ai-param-row > label {
+  width: 140px; color: #aaa; font-size: 11px;
+}
+.def-ai-param-input { flex: 1; }

--- a/editor/tests/complexity-form-view.test.js
+++ b/editor/tests/complexity-form-view.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { installDom, FakeElement, fireInput, fireChange, fireClick } from './slice-5-helpers.js';
+import { renderComplexityFormView, KNOWN_CONSOLE_KEYS } from '../complexity-form-view.js';
+
+function mount(opts) {
+  installDom();
+  const host = new FakeElement('div');
+  renderComplexityFormView(host, opts);
+  return host;
+}
+
+const SAMPLE_PRESETS = [
+  {
+    name: 'Low',
+    hidden_elements: ['phaser_mode_selector', 'unknown_custom_element'],
+    delegated: {
+      Tactical: { controls: ['auto_fire_torpedoes', 'auto_frequency_match'] },
+    },
+    ai: {
+      torpedo_auto_fire: { lead_prediction: true, min_accuracy: 0.7 },
+    },
+  },
+  {
+    name: 'Std',
+    hidden_elements: [],
+    delegated: {},
+    ai: {},
+  },
+];
+
+describe('renderComplexityFormView', () => {
+  it('renders one preset tab per preset and marks the active one', () => {
+    const host = mount({
+      presets: SAMPLE_PRESETS,
+      knownUiElements: [],
+      activePresetIndex: 0,
+      callbacks: {},
+    });
+    const tabs = host.querySelectorAll('.def-preset-tab');
+    expect(tabs.length).toBe(2);
+    expect(tabs[0].textContent).toBe('Low');
+    expect(tabs[1].textContent).toBe('Std');
+    expect(tabs[0].classList.contains('def-preset-tab-active')).toBe(true);
+    expect(tabs[1].classList.contains('def-preset-tab-active')).toBe(false);
+  });
+
+  it('clicking a preset tab fires onSwitchPreset with the index', () => {
+    let switched = null;
+    const host = mount({
+      presets: SAMPLE_PRESETS,
+      knownUiElements: [],
+      activePresetIndex: 0,
+      callbacks: {
+        onSwitchPreset: (i) => { switched = i; },
+      },
+    });
+    const tabs = host.querySelectorAll('.def-preset-tab');
+    fireClick(tabs[1]);
+    expect(switched).toBe(1);
+  });
+
+  it('hidden_elements dedupes known + authored values', () => {
+    const host = mount({
+      presets: SAMPLE_PRESETS,
+      knownUiElements: ['phaser_mode_selector', 'torpedo_tube_selector'],
+      activePresetIndex: 0,
+      callbacks: {},
+    });
+    const select = host.querySelector('.def-hidden-elements-select');
+    const options = select.querySelectorAll('OPTION');
+    const values = options.map((o) => o.value);
+    // Two knowns + one extra authored = 3 distinct entries.
+    expect(values).toEqual([
+      'phaser_mode_selector',
+      'torpedo_tube_selector',
+      'unknown_custom_element',
+    ]);
+    // The two authored values are marked selected; the other known is not.
+    const selectedValues = options.filter((o) => o.selected).map((o) => o.value).sort();
+    expect(selectedValues).toEqual(['phaser_mode_selector', 'unknown_custom_element']);
+  });
+
+  it('hidden_elements change fires onSetHiddenElements with selected values + preset index', () => {
+    let called = null;
+    const host = mount({
+      presets: SAMPLE_PRESETS,
+      knownUiElements: ['phaser_mode_selector', 'torpedo_tube_selector'],
+      activePresetIndex: 0,
+      callbacks: {
+        onSetHiddenElements: (i, list) => { called = { i, list }; },
+      },
+    });
+    const select = host.querySelector('.def-hidden-elements-select');
+    const options = select.querySelectorAll('OPTION');
+    options[0].selected = false;
+    options[1].selected = true;
+    options[2].selected = true;
+    select.dispatchEvent({ type: 'change', target: select });
+    expect(called).toEqual({
+      i: 0,
+      list: ['torpedo_tube_selector', 'unknown_custom_element'],
+    });
+  });
+
+  it('renders one delegated row per console key, with controls CSV; editing CSV fires onSetDelegated', () => {
+    let called = null;
+    const host = mount({
+      presets: SAMPLE_PRESETS,
+      knownUiElements: [],
+      activePresetIndex: 0,
+      callbacks: {
+        onSetDelegated: (i, key, controls) => { called = { i, key, controls }; },
+      },
+    });
+    const rows = host.querySelectorAll('.def-delegated-row');
+    expect(rows.length).toBe(1);
+    expect(rows[0].dataset.consoleKey).toBe('Tactical');
+
+    const csv = rows[0].querySelector('.def-delegated-controls');
+    expect(csv.value).toBe('auto_fire_torpedoes, auto_frequency_match');
+    fireInput(csv, 'a, b , c');
+    expect(called).toEqual({
+      i: 0,
+      key: 'Tactical',
+      controls: ['a', 'b', 'c'],
+    });
+
+    // The console-key dropdown lists every known console.
+    const select = rows[0].querySelector('.def-delegated-console');
+    const consoleOpts = select.querySelectorAll('OPTION');
+    const consoleVals = consoleOpts.map((o) => o.value);
+    for (const k of KNOWN_CONSOLE_KEYS) expect(consoleVals).toContain(k);
+  });
+
+  it('renders one AI block per behavior with typed inputs (number / boolean / string)', () => {
+    const presets = [{
+      name: 'Low',
+      hidden_elements: [],
+      delegated: {},
+      ai: {
+        block_a: { min_accuracy: 0.7, enabled: true, label: 'hello' },
+      },
+    }];
+    let lastSet = null;
+    const host = mount({
+      presets,
+      knownUiElements: [],
+      activePresetIndex: 0,
+      callbacks: {
+        onSetAiParam: (i, b, k, v) => { lastSet = { i, b, k, v }; },
+      },
+    });
+
+    const blocks = host.querySelectorAll('.def-ai-block');
+    expect(blocks.length).toBe(1);
+    expect(blocks[0].dataset.behaviorKey).toBe('block_a');
+
+    const rows = blocks[0].querySelectorAll('.def-ai-param-row');
+    expect(rows.length).toBe(3);
+
+    // number row
+    const numRow = rows.find((r) => r.dataset.paramKey === 'min_accuracy');
+    const numInput = numRow.querySelector('.def-ai-param-input');
+    expect(numInput.type).toBe('number');
+    expect(numInput.step).toBe('0.1');
+    expect(numInput.value).toBe('0.7');
+    fireInput(numInput, '0.9');
+    expect(lastSet).toEqual({ i: 0, b: 'block_a', k: 'min_accuracy', v: 0.9 });
+
+    // boolean row
+    const boolRow = rows.find((r) => r.dataset.paramKey === 'enabled');
+    const boolInput = boolRow.querySelector('.def-ai-param-input');
+    expect(boolInput.type).toBe('checkbox');
+    expect(boolInput.checked).toBe(true);
+    boolInput.checked = false;
+    boolInput.dispatchEvent({ type: 'change', target: boolInput });
+    expect(lastSet).toEqual({ i: 0, b: 'block_a', k: 'enabled', v: false });
+
+    // string row
+    const strRow = rows.find((r) => r.dataset.paramKey === 'label');
+    const strInput = strRow.querySelector('.def-ai-param-input');
+    expect(strInput.type).toBe('text');
+    expect(strInput.value).toBe('hello');
+    fireInput(strInput, 'world');
+    expect(lastSet).toEqual({ i: 0, b: 'block_a', k: 'label', v: 'world' });
+  });
+});

--- a/editor/tests/definitions-file-list-view.test.js
+++ b/editor/tests/definitions-file-list-view.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { installDom, FakeElement, fireClick } from './slice-5-helpers.js';
+import { renderDefinitionsFileListView } from '../definitions-file-list-view.js';
+import { ModeShell } from '../mode-shell.js';
+
+describe('renderDefinitionsFileListView', () => {
+  it('renders one row per path with display labels stripped of asset prefix', () => {
+    installDom();
+    const host = new FakeElement('div');
+    const modeShell = new ModeShell();
+    renderDefinitionsFileListView(host, {
+      paths: ['assets/factions/federation.toml', 'assets/factions/pirate.toml'],
+      activePath: null,
+      modeShell,
+      onSelect: () => {},
+    });
+    const rows = host.querySelectorAll('.definitions-file-list-row');
+    expect(rows.length).toBe(2);
+    expect(rows[0].dataset.path).toBe('assets/factions/federation.toml');
+    const label = rows[0].querySelector('.definitions-file-list-label');
+    expect(label.textContent).toBe('federation.toml');
+  });
+
+  it('marks the active row with the active class', () => {
+    installDom();
+    const host = new FakeElement('div');
+    const modeShell = new ModeShell();
+    renderDefinitionsFileListView(host, {
+      paths: ['assets/complexity/tactical.toml', 'assets/complexity/power.toml'],
+      activePath: 'assets/complexity/power.toml',
+      modeShell,
+      onSelect: () => {},
+    });
+    const rows = host.querySelectorAll('.definitions-file-list-row');
+    expect(rows[0].classList.contains('definitions-file-list-row-active')).toBe(false);
+    expect(rows[1].classList.contains('definitions-file-list-row-active')).toBe(true);
+  });
+
+  it('renders a dirty-dot for dirty files and fires onSelect on click', () => {
+    installDom();
+    const host = new FakeElement('div');
+    const modeShell = new ModeShell();
+    modeShell.markDirty('Definitions', 'assets/factions/federation.toml', true);
+
+    const selected = [];
+    renderDefinitionsFileListView(host, {
+      paths: ['assets/factions/federation.toml', 'assets/factions/pirate.toml'],
+      activePath: null,
+      modeShell,
+      onSelect: (p) => selected.push(p),
+    });
+    const rows = host.querySelectorAll('.definitions-file-list-row');
+    const dot0 = rows[0].querySelector('.dirty-dot');
+    const dot1 = rows[1].querySelector('.dirty-dot');
+    expect(dot0).toBeTruthy();
+    expect(dot1).toBeFalsy();
+
+    fireClick(rows[1]);
+    expect(selected).toEqual(['assets/factions/pirate.toml']);
+  });
+});

--- a/editor/tests/faction-form-view.test.js
+++ b/editor/tests/faction-form-view.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { installDom, FakeElement, fireInput } from './slice-5-helpers.js';
+import { renderFactionFormView } from '../faction-form-view.js';
+
+function mount(opts) {
+  installDom();
+  const host = new FakeElement('div');
+  renderFactionFormView(host, opts);
+  return host;
+}
+
+describe('renderFactionFormView', () => {
+  it('renders UUID as a read-only label (not an input)', () => {
+    const host = mount({
+      formState: {
+        uuid: 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa',
+        name: 'Federation',
+        enemies: [],
+      },
+      enemyOptions: [],
+      onNameChange: () => {},
+      onEnemiesChange: () => {},
+    });
+
+    const ro = host.querySelector('.def-uuid-readonly');
+    expect(ro).toBeTruthy();
+    expect(ro.tagName).toBe('SPAN');
+    expect(ro.textContent).toBe('aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa');
+
+    // There must be no INPUT whose value equals the uuid (would be editable).
+    const inputs = host.querySelectorAll('INPUT');
+    for (const inp of inputs) {
+      expect(inp.value).not.toBe('aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa');
+    }
+  });
+
+  it('renders name as an editable text input wired to onNameChange', () => {
+    let lastName = null;
+    const host = mount({
+      formState: { uuid: 'x', name: 'Federation', enemies: [] },
+      enemyOptions: [],
+      onNameChange: (n) => { lastName = n; },
+      onEnemiesChange: () => {},
+    });
+
+    const input = host.querySelector('.def-name-input');
+    expect(input).toBeTruthy();
+    expect(input.type).toBe('text');
+    expect(input.value).toBe('Federation');
+
+    fireInput(input, 'United Federation');
+    expect(lastName).toBe('United Federation');
+  });
+
+  it('enemy multi-select shows NAMES as option text and UUIDs as values (AC3)', () => {
+    const host = mount({
+      formState: { uuid: 'me', name: 'Me', enemies: [] },
+      enemyOptions: [
+        { uuid: 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa', name: 'Federation', path: 'a.toml' },
+        { uuid: 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb', name: 'Pirate', path: 'b.toml' },
+      ],
+      onNameChange: () => {},
+      onEnemiesChange: () => {},
+    });
+
+    const select = host.querySelector('.def-multi-select');
+    expect(select).toBeTruthy();
+    expect(select.multiple).toBe(true);
+    const options = select.querySelectorAll('OPTION');
+    expect(options.length).toBe(2);
+
+    // textContent must be the NAME (the human-readable label).
+    const texts = options.map((o) => o.textContent).sort();
+    expect(texts).toEqual(['Federation', 'Pirate']);
+
+    // value must be the UUID (the canonical wire identity).
+    const values = options.map((o) => o.value).sort();
+    expect(values).toEqual([
+      'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa',
+      'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb',
+    ]);
+  });
+
+  it('change event reports selected UUIDs (not names) via onEnemiesChange', () => {
+    let lastEnemies = null;
+    const host = mount({
+      formState: { uuid: 'me', name: 'Me', enemies: [] },
+      enemyOptions: [
+        { uuid: 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa', name: 'Federation', path: 'a.toml' },
+        { uuid: 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb', name: 'Pirate', path: 'b.toml' },
+      ],
+      onNameChange: () => {},
+      onEnemiesChange: (uuids) => { lastEnemies = uuids; },
+    });
+
+    const select = host.querySelector('.def-multi-select');
+    const options = select.querySelectorAll('OPTION');
+    // Toggle selection on the second option, then fire change.
+    options[1].selected = true;
+    select.dispatchEvent({ type: 'change', target: select });
+    expect(lastEnemies).toEqual(['bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb']);
+
+    // Pre-selected enemies render `option.selected = true`.
+    const host2 = mount({
+      formState: { uuid: 'me', name: 'Me', enemies: ['aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa'] },
+      enemyOptions: [
+        { uuid: 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa', name: 'Federation', path: 'a.toml' },
+        { uuid: 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb', name: 'Pirate', path: 'b.toml' },
+      ],
+      onNameChange: () => {},
+      onEnemiesChange: () => {},
+    });
+    const opts2 = host2.querySelectorAll('OPTION');
+    expect(opts2[0].selected).toBe(true);
+    expect(opts2[1].selected).toBe(false);
+  });
+
+  it('renders a placeholder when no faction is open', () => {
+    const host = mount({
+      formState: null,
+      enemyOptions: [],
+      onNameChange: () => {},
+      onEnemiesChange: () => {},
+    });
+    const placeholder = host.querySelector('.placeholder');
+    expect(placeholder).toBeTruthy();
+  });
+});

--- a/editor/tests/invalidation-bus.test.js
+++ b/editor/tests/invalidation-bus.test.js
@@ -79,4 +79,24 @@ describe('InvalidationBus', () => {
       expect(() => bus.fireWorldSaved('anything.toml')).not.toThrow();
     });
   });
+
+  describe('fireFactionSaved', () => {
+    it('triggers registered callbacks with correct path', () => {
+      const bus = new InvalidationBus();
+      const calls = [];
+      bus.onFactionSaved((path) => calls.push(path));
+      bus.fireFactionSaved('assets/factions/federation.toml');
+      expect(calls).toEqual(['assets/factions/federation.toml']);
+    });
+
+    it('onFactionSaved returns unsubscribe handle that stops events', () => {
+      const bus = new InvalidationBus();
+      const calls = [];
+      const { unsubscribe } = bus.onFactionSaved((p) => calls.push(p));
+      bus.fireFactionSaved('a.toml');
+      unsubscribe();
+      bus.fireFactionSaved('b.toml');
+      expect(calls).toEqual(['a.toml']);
+    });
+  });
 });

--- a/editor/tests/save-flow.test.js
+++ b/editor/tests/save-flow.test.js
@@ -341,4 +341,106 @@ describe('SaveFlow', () => {
       expect(fired).toEqual(['assets/entities/a.toml']);
     });
   });
+
+  describe('Definitions mode', () => {
+    it('dispatches to the `definitions` stringifier when provided', async () => {
+      const modeShell = new ModeShell();
+      modeShell.switchMode('Definitions');
+      modeShell.setOpenFiles('Definitions', ['assets/factions/federation.toml']);
+      modeShell.setActiveFile('Definitions', 'assets/factions/federation.toml');
+      modeShell.markDirty('Definitions', 'assets/factions/federation.toml', true);
+
+      const writeFile = vi.fn(async () => {});
+      const defStringify = vi.fn(() => 'DEFINITIONS_CONTENT');
+      const stringifyFns = {
+        world: () => 'W',
+        entity: () => 'E',
+        definitions: defStringify,
+      };
+
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, writeFile, noopBus);
+      saveFlow.setContent('Definitions', 'assets/factions/federation.toml', {
+        kind: 'faction',
+        data: { uuid: 'x', name: 'X', enemies: [] },
+      });
+
+      const result = await saveFlow.saveActive(null);
+      expect(result.ok).toBe(true);
+      expect(defStringify).toHaveBeenCalledTimes(1);
+      expect(defStringify.mock.calls[0][0]).toEqual({
+        kind: 'faction',
+        data: { uuid: 'x', name: 'X', enemies: [] },
+      });
+      expect(writeFile).toHaveBeenCalledWith('assets/factions/federation.toml', 'DEFINITIONS_CONTENT');
+    });
+
+    it('fires fireFactionSaved when saving a faction path in Definitions mode', async () => {
+      const modeShell = new ModeShell();
+      modeShell.switchMode('Definitions');
+      modeShell.setOpenFiles('Definitions', ['assets/factions/pirate.toml']);
+      modeShell.setActiveFile('Definitions', 'assets/factions/pirate.toml');
+      modeShell.markDirty('Definitions', 'assets/factions/pirate.toml', true);
+
+      const bus = new InvalidationBus();
+      const fired = [];
+      bus.onFactionSaved((p) => fired.push(p));
+
+      const stringifyFns = {
+        world: () => '',
+        entity: () => '',
+        definitions: () => 'X',
+      };
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, bus);
+      saveFlow.setContent('Definitions', 'assets/factions/pirate.toml', {
+        kind: 'faction',
+        data: {},
+      });
+
+      await saveFlow.saveActive(null);
+      expect(fired).toEqual(['assets/factions/pirate.toml']);
+    });
+
+    it('does NOT fire fireFactionSaved for complexity paths in Definitions mode', async () => {
+      const modeShell = new ModeShell();
+      modeShell.switchMode('Definitions');
+      modeShell.setOpenFiles('Definitions', ['assets/complexity/tactical.toml']);
+      modeShell.setActiveFile('Definitions', 'assets/complexity/tactical.toml');
+      modeShell.markDirty('Definitions', 'assets/complexity/tactical.toml', true);
+
+      const bus = new InvalidationBus();
+      const fired = [];
+      bus.onFactionSaved((p) => fired.push(p));
+
+      const stringifyFns = {
+        world: () => '',
+        entity: () => '',
+        definitions: () => 'X',
+      };
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, bus);
+      saveFlow.setContent('Definitions', 'assets/complexity/tactical.toml', {
+        kind: 'complexity',
+        data: [],
+      });
+
+      await saveFlow.saveActive(null);
+      expect(fired).toEqual([]);
+    });
+
+    it('backward-compat: falls back to `entity` stringifier when `definitions` is missing', async () => {
+      const modeShell = new ModeShell();
+      modeShell.switchMode('Definitions');
+      modeShell.setOpenFiles('Definitions', ['assets/factions/federation.toml']);
+      modeShell.setActiveFile('Definitions', 'assets/factions/federation.toml');
+      modeShell.markDirty('Definitions', 'assets/factions/federation.toml', true);
+
+      const entityStringify = vi.fn(() => 'FALLBACK');
+      const stringifyFns = { world: () => '', entity: entityStringify };
+      const saveFlow = new SaveFlow(modeShell, stringifyFns, noopWriter, noopBus);
+      saveFlow.setContent('Definitions', 'assets/factions/federation.toml', { foo: 'bar' });
+
+      const result = await saveFlow.saveActive(null);
+      expect(result.ok).toBe(true);
+      expect(entityStringify).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/editor/tests/slice-6-definitions-mode.test.js
+++ b/editor/tests/slice-6-definitions-mode.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setupDefinitionsMode } from './slice-6-helpers.js';
+
+/**
+ * Slice-6 integration tests for Definitions Mode.
+ *
+ *   AC1: Click Definitions tab → two-section layout.
+ *   AC2: Open faction file → UUID readonly + name input + enemy multi-select.
+ *   AC3: Enemy multi-select shows faction NAMES (not UUIDs).
+ *   AC4: Open complexity file → presets + hidden_elements + delegated + AI.
+ *   AC5: Save / undo round-trip.
+ */
+
+describe('Slice 6: Definitions Mode', () => {
+  let ctx;
+  beforeEach(async () => {
+    ctx = await setupDefinitionsMode();
+  });
+
+  it('mounts a two-section layout with both file lists populated (AC1)', () => {
+    const sections = ctx.host.querySelectorAll('.definitions-section');
+    expect(sections.length).toBe(2);
+    expect(sections[0].classList.contains('definitions-section-faction')).toBe(true);
+    expect(sections[1].classList.contains('definitions-section-complexity')).toBe(true);
+
+    const factionRows = sections[0].querySelectorAll('.definitions-file-list-row');
+    const complexityRows = sections[1].querySelectorAll('.definitions-file-list-row');
+    expect(factionRows.length).toBe(4);
+    expect(complexityRows.length).toBe(6);
+  });
+
+  it('clicking a faction file populates the form with UUID + name + enemies (AC2)', async () => {
+    await ctx.view._internal.loadFactionFile('assets/factions/federation.toml');
+
+    const formRoot = ctx.host.querySelector('.faction-form');
+    expect(formRoot).toBeTruthy();
+
+    const uuid = ctx.host.querySelector('.def-uuid-readonly');
+    expect(uuid.textContent).toBe('aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa');
+
+    const nameInput = ctx.host.querySelector('.def-name-input');
+    expect(nameInput.value).toBe('Federation');
+
+    const select = ctx.host.querySelector('.def-multi-select');
+    expect(select).toBeTruthy();
+  });
+
+  it('enemy multi-select option labels are faction NAMES, not UUIDs (AC3)', async () => {
+    await ctx.view._internal.loadFactionFile('assets/factions/federation.toml');
+
+    const select = ctx.host.querySelector('.def-multi-select');
+    const options = select.querySelectorAll('OPTION');
+    const texts = options.map((o) => o.textContent).sort();
+
+    // The other three factions (Federation is excluded as the active file).
+    expect(texts).toEqual(['Harrow', 'Pirate', 'Requiem']);
+
+    // The UUID lives in `.value`, never in the visible text.
+    for (const opt of options) {
+      expect(opt.value).toMatch(/^[a-f0-9]{8}-/);
+      expect(opt.textContent).not.toBe(opt.value);
+    }
+  });
+
+  it('clicking a complexity file renders presets + hidden_elements + delegated + ai (AC4)', async () => {
+    await ctx.view._internal.loadComplexityFile('assets/complexity/tactical.toml');
+
+    const tabs = ctx.host.querySelectorAll('.def-preset-tab');
+    expect(tabs.length).toBeGreaterThanOrEqual(2);
+
+    const hiddenSelect = ctx.host.querySelector('.def-hidden-elements-select');
+    expect(hiddenSelect).toBeTruthy();
+    const hiddenOpts = hiddenSelect.querySelectorAll('OPTION');
+    // tactical.toml has 3 authored hidden_elements + the rest from KNOWN_UI_ELEMENTS.tactical.
+    expect(hiddenOpts.length).toBeGreaterThanOrEqual(3);
+
+    const delegatedRows = ctx.host.querySelectorAll('.def-delegated-row');
+    expect(delegatedRows.length).toBe(1);
+    expect(delegatedRows[0].dataset.consoleKey).toBe('Tactical');
+
+    const aiBlocks = ctx.host.querySelectorAll('.def-ai-block');
+    expect(aiBlocks.length).toBe(2);
+  });
+
+  it('mutating a faction name stages content + marks dirty + saves via TOML stringifier; fireFactionSaved fires (AC5)', async () => {
+    await ctx.view._internal.loadFactionFile('assets/factions/federation.toml');
+
+    const factionFired = [];
+    ctx.invalidationBus.onFactionSaved((p) => factionFired.push(p));
+
+    ctx.view._internal.handleFactionNameChange('United Federation');
+
+    const path = 'assets/factions/federation.toml';
+    expect(ctx.modeShell.isDirty('Definitions', path)).toBe(true);
+    const stash = ctx.saveFlow._contentCache.Definitions[path];
+    expect(stash.kind).toBe('faction');
+    expect(stash.data.name).toBe('United Federation');
+
+    const undoEntries = ctx.modeShell.getUndoHistory('Definitions', path);
+    expect(undoEntries.length).toBe(1);
+    expect(undoEntries[0].data.name).toBe('Federation');
+
+    ctx.modeShell.setActiveFile('Definitions', path);
+    const result = await ctx.saveFlow.saveActive(null);
+    expect(result.ok).toBe(true);
+    expect(ctx.writeFileCalls.length).toBe(1);
+    expect(ctx.writeFileCalls[0].path).toBe(path);
+    expect(ctx.writeFileCalls[0].content).toContain('United Federation');
+    expect(ctx.modeShell.isDirty('Definitions', path)).toBe(false);
+    expect(factionFired).toEqual([path]);
+  });
+
+  it('undo restores prior faction name', async () => {
+    await ctx.view._internal.loadFactionFile('assets/factions/federation.toml');
+    ctx.view._internal.handleFactionNameChange('United Federation');
+
+    const restore = ctx.getRestoreCb();
+    expect(restore).toBeDefined();
+    restore(ctx.modeShell, 'assets/factions/federation.toml', 'undo');
+
+    expect(ctx.view.factionEditor.getFormState().name).toBe('Federation');
+  });
+});

--- a/editor/tests/slice-6-faction-invalidation.test.js
+++ b/editor/tests/slice-6-faction-invalidation.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { installDom, FakeElement, fixture, KonvaStub } from './slice-5-helpers.js';
+
+/**
+ * Slice 6 cross-mode coupling regression:
+ *
+ * When Definitions Mode saves a faction file, Entity Mode re-runs faction
+ * discovery so its component-card faction dropdown reflects the rename.
+ */
+describe('Slice 6: faction-save invalidation refreshes Entity Mode', () => {
+  it('Definitions save → invalidationBus.fireFactionSaved → Entity Mode reruns discover + setFactionMap', async () => {
+    installDom();
+    globalThis.window = { Konva: KonvaStub };
+
+    const { mountEntityMode } = await import('../entity-mode-view.js');
+    const { ModeShell } = await import('../mode-shell.js');
+    const { SaveFlow } = await import('../save-flow.js');
+    const { InvalidationBus } = await import('../invalidation-bus.js');
+    const { stringifyEntityToml } = await import('../entity-toml.js');
+    const { stringifyFactionToml } = await import('../faction-editor.js');
+    const { stringifyComplexityToml } = await import('../complexity-editor.js');
+
+    const modeShell = new ModeShell();
+    const invalidationBus = new InvalidationBus();
+
+    function stringifyDefinitionsPayload(p) {
+      if (p.kind === 'faction') return stringifyFactionToml(p.data);
+      if (p.kind === 'complexity') return stringifyComplexityToml(p.data);
+      throw new Error('bad kind');
+    }
+
+    const saveFlow = new SaveFlow(
+      modeShell,
+      {
+        world: () => '',
+        entity: stringifyEntityToml,
+        definitions: stringifyDefinitionsPayload,
+      },
+      async () => {},
+      invalidationBus,
+    );
+
+    // Entity Mode discover() returns a controllable factionMap so we can
+    // assert it gets re-called after a faction save.
+    let discoverCallCount = 0;
+    const factionMapV1 = new Map([['uuid-1', 'Federation']]);
+    const factionMapV2 = new Map([['uuid-1', 'United Federation']]);
+    const io = {
+      readFile: async (path) => fixture(path),
+      listDirectory: async (rel) => {
+        if (rel === 'assets/entities') {
+          return [{ name: 'pirate_raider.toml', kind: 'file' }];
+        }
+        return [];
+      },
+      preload: async () => {},
+      onCacheInvalidate: () => {},
+      getProjectRoot: async () => ({ stub: true }),
+      discover: async () => {
+        discoverCallCount += 1;
+        return {
+          factionMap: discoverCallCount === 1 ? factionMapV1 : factionMapV2,
+          complexityPaths: [],
+        };
+      },
+      Konva: KonvaStub,
+    };
+
+    const host = new FakeElement('div');
+    const view = mountEntityMode({
+      host,
+      modeShell,
+      saveFlow,
+      registerRestore: () => {},
+      invalidationBus,
+      io,
+    });
+    for (let i = 0; i < 10; i += 1) await Promise.resolve();
+    await view._internal.refreshFileList();
+
+    expect(discoverCallCount).toBe(1);
+    // Sanity: initial setFactionMap landed.
+    const initial = view.shell.getFactionDropdownOptions();
+    expect(initial.some((o) => o.name === 'Federation')).toBe(true);
+
+    // Stage a fake faction save through SaveFlow → fires fireFactionSaved
+    // → Entity Mode's subscriber re-runs discover().
+    modeShell.switchMode('Definitions');
+    modeShell.setOpenFiles('Definitions', ['assets/factions/federation.toml']);
+    modeShell.setActiveFile('Definitions', 'assets/factions/federation.toml');
+    modeShell.markDirty('Definitions', 'assets/factions/federation.toml', true);
+    saveFlow.setContent('Definitions', 'assets/factions/federation.toml', {
+      kind: 'faction',
+      data: { uuid: 'uuid-1', name: 'United Federation', enemies: [] },
+    });
+
+    await saveFlow.saveActive(null);
+
+    // Subscriber's discover() is async; flush microtasks.
+    for (let i = 0; i < 10; i += 1) await Promise.resolve();
+
+    expect(discoverCallCount).toBe(2);
+    const after = view.shell.getFactionDropdownOptions();
+    expect(after.some((o) => o.name === 'United Federation')).toBe(true);
+    expect(after.some((o) => o.name === 'Federation')).toBe(false);
+  });
+});

--- a/editor/tests/slice-6-helpers.js
+++ b/editor/tests/slice-6-helpers.js
@@ -1,0 +1,90 @@
+/**
+ * Slice-6 helpers — DOM shim + Definitions Mode mount with real fixtures.
+ */
+import { installDom, FakeElement, fixture } from './slice-5-helpers.js';
+
+const FACTION_FILES = ['federation.toml', 'pirate.toml', 'harrow.toml', 'requiem.toml'];
+const COMPLEXITY_FILES = ['tactical.toml', 'power.toml', 'science.toml', 'sensors.toml', 'shields.toml', 'navigation.toml'];
+
+export async function setupDefinitionsMode(opts = {}) {
+  installDom();
+  globalThis.window = globalThis.window || {};
+  const host = new FakeElement('div');
+
+  const { mountDefinitionsMode } = await import('../definitions-mode-view.js');
+  const { ModeShell } = await import('../mode-shell.js');
+  const { SaveFlow } = await import('../save-flow.js');
+  const { InvalidationBus } = await import('../invalidation-bus.js');
+  const { stringifyFactionToml } = await import('../faction-editor.js');
+  const { stringifyComplexityToml } = await import('../complexity-editor.js');
+
+  function stringifyDefinitionsPayload(payload) {
+    if (!payload || typeof payload !== 'object') throw new Error('bad payload');
+    if (payload.kind === 'faction') return stringifyFactionToml(payload.data);
+    if (payload.kind === 'complexity') return stringifyComplexityToml(payload.data);
+    throw new Error(`unknown kind: ${payload.kind}`);
+  }
+
+  const writeFileCalls = [];
+  const writeFileFn = async (path, content) => {
+    writeFileCalls.push({ path, content });
+  };
+
+  const modeShell = new ModeShell();
+  modeShell.switchMode('Definitions');
+  const invalidationBus = new InvalidationBus();
+  const saveFlow = new SaveFlow(
+    modeShell,
+    {
+      world: () => '',
+      entity: () => '',
+      definitions: stringifyDefinitionsPayload,
+    },
+    writeFileFn,
+    invalidationBus,
+  );
+
+  let restoreCb = null;
+  const registerRestore = (mode, fn) => {
+    if (mode === 'Definitions') restoreCb = fn;
+  };
+
+  const factionFiles = opts.factionFiles ?? FACTION_FILES;
+  const complexityFiles = opts.complexityFiles ?? COMPLEXITY_FILES;
+
+  const io = {
+    readFile: async (path) => fixture(path),
+    listDirectory: async (rel) => {
+      if (rel === 'assets/factions') {
+        return factionFiles.map((name) => ({ name, kind: 'file' }));
+      }
+      if (rel === 'assets/complexity') {
+        return complexityFiles.map((name) => ({ name, kind: 'file' }));
+      }
+      return [];
+    },
+    getProjectRoot: async () => ({ stub: true }),
+  };
+
+  const view = mountDefinitionsMode({
+    host,
+    modeShell,
+    saveFlow,
+    registerRestore,
+    invalidationBus,
+    io,
+  });
+
+  // Wait for the fire-and-forget bootstrap to finish.
+  await view._internal.bootstrap();
+
+  return {
+    view,
+    host,
+    modeShell,
+    saveFlow,
+    invalidationBus,
+    writeFileCalls,
+    getRestoreCb: () => restoreCb,
+  };
+}


### PR DESCRIPTION
# Slice 6 — Definitions Mode: faction + complexity preset editors (#387)

Closes #387. Definitions Mode authors faction TOMLs (`assets/factions/*.toml`) and complexity preset TOMLs (`assets/complexity/*.toml`). Deep editors (`faction-editor.js`, `complexity-editor.js`) already existed and were tested — this slice wires them into the live editor with a two-section layout.

Stacked on #394 (Slice 5).

## ACs delivered

- **AC1** — Definitions tab → two-section layout (faction top, complexity bottom). `definitions-mode-view.js:60-88`; mounted by `app.js:54-65`.
- **AC2** — Faction file form: UUID is `<span class="def-uuid-readonly">` (NOT input), name is editable `<input>`, enemies is `<select multiple>`. `faction-form-view.js:42-76`.
- **AC3** — Enemy multi-select shows NAMES not UUIDs: `option.value = uuid; option.textContent = name`. `faction-form-view.js:81-82`.
- **AC4** — Complexity file form: preset tabs, hidden_elements multi-select (deduped union of known + authored), delegated table with console-key dropdown over 9 enum values, AI tuning blocks with type-detected inputs (number/checkbox/text). `complexity-form-view.js:60-275`.
- **AC5** — All 886 prior tests still pass.

## Architectural decisions

- **Single `'Definitions'` mode key** (matches existing `DEFAULT_MODES` in `mode-shell.js`). Faction vs complexity distinguished by file-path prefix (`assets/factions/` vs `assets/complexity/`).
- **`saveFlow.setContent('Definitions', path, {kind, data})`** wraps payloads with a `kind` discriminator. `SaveFlow` gains a third stringifier slot (`definitions`) with fallback to `entity` for backward compat.
- **Cross-mode UUID resolution**: new `invalidationBus.fireFactionSaved/onFactionSaved`. Save-flow fires it when a faction path is saved. Entity Mode subscribes and re-runs `discoverFactionsAndComplexity`, then `shell.setFactionMap(...)` — faction dropdowns refresh live.

## Contract guarantees

- Snapshot-before-mutate via `snapshotFaction`/`snapshotComplexity` helpers (`definitions-mode-view.js:197-235`).
- `registerRestore('Definitions', fn)` (`:377-432`). Faction restore is wholesale; complexity restore is surgical (per-preset mutator replay) because `ComplexityEditor` has no wholesale setter.
- Save dispatch via `{kind}` (`app-v2.js:13-23`); backward-compat fallback (`save-flow.js:51-55`).

## New modules

- `editor/definitions-mode-view.js` (~474, DOM coordinator)
- `editor/definitions-file-list-view.js` (~52)
- `editor/faction-form-view.js` (~99)
- `editor/complexity-form-view.js` (~276)

## Extended modules

- `editor/save-flow.js` — third stringifier slot + faction-save invalidation fire
- `editor/app-v2.js` — passes `definitions` stringifier
- `editor/invalidation-bus.js` — `fireFactionSaved` / `onFactionSaved`
- `editor/entity-mode-view.js` — `refreshFactionMap` subscriber for live faction-dropdown refresh
- `editor/app.js` — mount Definitions Mode
- `editor/style.css` — `.definitions-two-section`, `.def-pane-left`, `.def-preset-tabs`, `.def-delegated-table`, `.def-ai-block`, etc.

## Tests

- `npm run test:editor` → **913/913 passed** in 56 files (+27 new).
- New: `definitions-file-list-view.test.js` (3), `faction-form-view.test.js` (5), `complexity-form-view.test.js` (6), `slice-6-definitions-mode.test.js` (6), `slice-6-faction-invalidation.test.js` (1), plus extensions to `invalidation-bus.test.js` (+2) and `save-flow.test.js` (+4).
- `cargo check` clean.

## Flagged for follow-up (non-blocking)

- **Surgical complexity restore** relies on per-preset mutators (`setHiddenElements/setDelegated/removeDelegated/setAiBlock/removeAiBlock`). If new top-level preset fields are added to the schema, the restore path will silently drop them. Future: expose `ComplexityEditor.setPresets(presets)` for wholesale restore.
- **`loadAll` after open** re-loads all cached files when adding one new file. Quadratic in file count; fine at current scale (4 factions, 6 complexity files).
- **Delegated rename** does `onRemoveDelegated` then `onSetDelegated` — two snapshot/mutation cycles, so undo requires two presses to revert one rename. Cosmetic.
- **Test fragility**: `slice-6-definitions-mode.test.js` hardcodes 4 factions / 6 complexity files (the current shipped asset count). Will need updates when authors add new factions or complexity presets.
- **`KNOWN_UI_ELEMENTS`** is a hand-curated vocab in `complexity-editor.js`. Authored-but-unknown elements still display (deduped union), so this is forward-compatible.

Closes #387.
