### PR TITLE
feat(server): expose combat_test scenario on the landing page (#475)

### DIFF
--- a/server.html
+++ b/server.html
@@ -556,7 +556,7 @@
     <div id="world-list">
       <div id="world-list-label">Select a world</div>
       <button class="world-btn" data-path="assets/worlds/default.toml">Starbase Alpha</button>
-      <button class="world-btn" data-path="assets/worlds/patrol.toml">Patrol</button>
+      <button class="world-btn" data-path="assets/worlds/combat_test.toml">Combat Test</button>
       <button class="world-btn" data-path="assets/worlds/before_the_fire.toml">Before the Fire</button>
     </div>
   </div>


### PR DESCRIPTION
Replaces the "Patrol" entry with "Combat Test" in the world-select panel on server.html. The patrol.toml scenario remains in assets/worlds/ and is still loadable via ?scenario=, used by the patrol.spec.ts and ship-mesh-load.spec.ts smoke tests, and exercised by load_world unit tests in src/world/server.rs — only its landing-page button is gone.