### PR TITLE
fix(ci): resolve all CI failures — sensors null guard, Rust compile error, preload GLB block

### DIFF
--- a/src/server/asset_preload.rs
+++ b/src/server/asset_preload.rs
@@ -98,9 +98,13 @@ fn discover_entity_config_assets(config: &EntityConfig, manifest: &mut AssetMani
     // GLB model + sidecar
     if let Some(ref mesh) = config.mesh {
         if let Some(ref model_path) = mesh.model {
-            let rel = model_path.strip_prefix("assets/").unwrap_or(model_path);
-            if !manifest.glb_models.contains(&rel.to_string()) {
-                manifest.glb_models.push(rel.to_string());
+            // Only preload the GLB if it will actually be rendered; no_render
+            // entities only need the sidecar (for ModelMarkers).
+            if !mesh.no_render {
+                let rel = model_path.strip_prefix("assets/").unwrap_or(model_path);
+                if !manifest.glb_models.contains(&rel.to_string()) {
+                    manifest.glb_models.push(rel.to_string());
+                }
             }
             let sc = sidecar_path(model_path, mesh.variant.as_deref());
             if !manifest.sidecars.contains(&sc) {
@@ -821,6 +825,33 @@ mod tests {
             .iter()
             .any(|s| s.contains("test_ship.model.toml")));
         assert_eq!(manifest.radar_icons, vec!["radar_icons/Icon-TestShip.png"]);
+    }
+
+    #[test]
+    fn discover_entity_config_no_render_skips_glb_keeps_sidecar() {
+        let mut config = EntityConfig::default();
+        config.mesh = Some(MeshConfig {
+            model: Some("assets/models/alliance_cruiser.glb".into()),
+            variant: None,
+            shape: MeshShape::Sphere,
+            colour: vec![],
+            radius: 1.0,
+            size: None,
+            minor_radius: 0.0,
+            emissive: None,
+            scale: 1.0,
+            rotation: [0.0, 0.0, 0.0],
+            no_render: true,
+        });
+        let mut manifest = AssetManifest::default();
+        discover_entity_config_assets(&config, &mut manifest);
+        // GLB must NOT be added when no_render = true (saves blocking preload on 7.8 MB file).
+        assert!(manifest.glb_models.is_empty());
+        // Sidecar must still be added for ModelMarkers.
+        assert!(manifest
+            .sidecars
+            .iter()
+            .any(|s| s.contains("alliance_cruiser.model.toml")));
     }
 
     #[test]

--- a/src/server/asset_preload.rs
+++ b/src/server/asset_preload.rs
@@ -803,6 +803,7 @@ mod tests {
             emissive: None,
             scale: 1.0,
             rotation: [0.0, 0.0, 0.0],
+            no_render: false,
         });
         config.radar_appearance = Some(RadarAppearanceConfig {
             icon: Some("testShip".into()),


### PR DESCRIPTION
## Summary

- **sensors null guard** (`f8adcbf`): `gui/sensors-console.html` — both `getElementById('cpx-badge')` calls now check for null before writing, fixing the `TypeError` in Playwright smoke tests after the element was removed in `8113f3a`.
- **Rust compile error** (`dd68d8f`): `src/server/asset_preload.rs` test — added missing `no_render: false` field to `MeshConfig` struct literal, fixing `E0063` compile failure introduced when `4060686` added the `no_render` field.
- **GLB preload block** (`a532ea2`): `discover_entity_config_assets` now skips adding the GLB to `manifest.glb_models` when `mesh.no_render = true`. The 7.8 MB `alliance_cruiser.glb` was blocking game start for `combat-test-scenario` and `tactical-fire-flow` smoke tests, which timed out under CI's ~1/15 wall-clock throttle. The sidecar TOML is still fetched (required for `ModelMarkers`). Adds a unit test to guard against regression.

## Test plan

- [ ] `test` job: `cargo test` passes (Rust compile error fixed, new unit test passes)
- [ ] `build` job: Trunk WASM build succeeds
- [ ] `smoke` job: all Playwright tests pass — sensors console, combat scenario, tactical fire-flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mvhLq1CUzs83f3df3h3Tu

---
_Generated by [Claude Code](https://claude.ai/code/session_016mvhLq1CUzs83f3df3h3Tu)_