### PR TITLE
fix(config): lowercase mesh shape in player_ship.toml

### DIFF
--- a/assets/entities/player_ship.toml
+++ b/assets/entities/player_ship.toml
@@ -4,7 +4,7 @@ faction = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"
 
 [mesh]
 model = "assets/models/alliance_cruiser.glb"
-shape = "Sphere"
+shape = "sphere"
 colour = []
 no_render = true
 


### PR DESCRIPTION
MeshShape is deserialized with `#[serde(rename_all = "lowercase")]`, so the TOML value must be `"sphere"` not `"Sphere"`. This caused 32 unit tests that parse `player_ship.toml` to fail with `unknown variant 'Sphere', expected one of 'sphere', 'cuboid', 'torus'`.

The bad value was introduced by commit `4060686` which added the `[mesh]` block to `player_ship.toml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016mvhLq1CUzs83f3df3h3Tu)_