### PR TITLE
feat(radar): extend circle to screen edge, overflowing the bezel frame

### DIFF
--- a/client.html
+++ b/client.html
@@ -218,14 +218,16 @@
 
     /* Iframe content sits inside the bezel safe zone.
        No top padding — the container's padding-top + the tab bar already
-       clear the top bezel edge. Side + bottom still needed. */
-    #weapons-ui.active,
-    #captain-ui.active,
+       clear the top bezel edge. Side + bottom still needed for most consoles.
+       Radar consoles (helm/weapons/sensors) get no padding so the iframe
+       fills to the screen edge, letting the radar circle meet the bezel. */
     #helm-ui.active,
+    #weapons-ui.active,
+    #sensors-ui.active { padding: 0; }
+    #captain-ui.active,
     #power-ui.active,
     #repair-ui.active,
     #shields-ui.active,
-    #sensors-ui.active,
     #comms-ui.active { padding: 0 var(--bezel-inset) var(--bezel-inset); }
 
     /* ── Console tab bar (issue #441) ──────────────────────────────────

--- a/gui/helm-console.html
+++ b/gui/helm-console.html
@@ -28,8 +28,8 @@
     .hero { gap: 12px; padding: 4px 0; }
 
     .radar-col .radar-wrap { flex: 1; min-height: 0; display: flex; align-items: center; justify-content: center; }
-    /* Radar fills the full available height in landscape (no fixed cap). */
-    .radar-col .radar-surround-frame { aspect-ratio: 1/1; width: auto; height: 100%; max-height: none; max-width: 100%; display: flex; align-items: center; justify-content: center; }
+    /* Radar circle fills full screen height in landscape (surround-frame at 125dvh so 80% = 100dvh). */
+    .radar-col .radar-surround-frame { aspect-ratio: 1/1; width: auto; height: calc(100dvh * 1.25); max-height: none; max-width: none; display: flex; align-items: center; justify-content: center; }
     .radar-col .radar-surround-frame .radar { width: 80%; height: 80%; max-height: none; max-width: none; }
 
     .ctrl-col .stick-area { flex: 1; min-height: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; }
@@ -318,7 +318,7 @@
     .readout .v { font-size: 24px; }
     .radar-col > .readout { padding: 6px 14px; }
     .radar-col > .readout .v { font-size: 18px; }
-    .radar-col .radar-surround-frame { max-height: none; max-width: 100%; }
+    .radar-col .radar-surround-frame { max-height: none; max-width: none; }
     .helm-readout-overlay { font-size: 10px; }
     .helm-readout-overlay .v { font-size: 11px; }
     .readout-hdg { top: 8px; left: 12%; }
@@ -362,8 +362,8 @@
     .side-rail { display: none; }
 
     .radar-col .radar-wrap { min-height: 35vh; }
-    /* Portrait: radar fills the full available width. */
-    .radar-col .radar-surround-frame { width: 100%; height: auto; max-height: none; max-width: none; }
+    /* Portrait: radar circle fills full screen width (surround-frame at 125vw so 80% = 100vw). */
+    .radar-col .radar-surround-frame { width: calc(100vw * 1.25); height: auto; max-height: none; max-width: none; }
     .radar-col > .readout { padding: 0.4rem 0.6rem; }
     .radar-col > .readout .v { font-size: 1.25rem; }
 

--- a/gui/sensors-console.html
+++ b/gui/sensors-console.html
@@ -41,10 +41,10 @@
       flex: 1; min-height: 0;
       display: flex; align-items: center; justify-content: center;
     }
-    /* Radar fills the full available height in landscape (no fixed cap). */
+    /* Radar circle fills full screen height in landscape (surround-frame at 125dvh so 80% = 100dvh). */
     .radar-col .radar-surround-frame {
-      aspect-ratio: 1/1; height: 100%; width: auto;
-      max-height: none; max-width: 100%;
+      aspect-ratio: 1/1; height: calc(100dvh * 1.25); width: auto;
+      max-height: none; max-width: none;
       display: flex; align-items: center; justify-content: center;
     }
     .radar-col .radar-surround-frame .radar { width: 80%; height: 80%; max-height: none; max-width: none; }
@@ -227,7 +227,8 @@
       .side-rail { display: none; }
 
       .radar-col .radar-wrap { min-height: 0; }
-      .radar-col .radar-surround-frame { width: 100%; height: auto; max-height: none; max-width: none; }
+      /* Portrait: radar circle fills full screen width (surround-frame at 125vw so 80% = 100vw). */
+      .radar-col .radar-surround-frame { width: calc(100vw * 1.25); height: auto; max-height: none; max-width: none; }
 
       .radar-col > .readout    { padding: .4rem .55rem; }
       .radar-col > .readout .v { font-size: 1.2rem; }

--- a/gui/weapons-console.html
+++ b/gui/weapons-console.html
@@ -32,9 +32,9 @@
     .hero .bar { width: 6px; }
     .hero { gap: 12px; }
 
-    /* Radar — fills the full available height in landscape (no fixed cap) */
+    /* Radar circle fills full screen height in landscape (surround-frame at 125dvh so 80% = 100dvh). */
     .radar-col .radar-wrap { flex: 1; min-height: 0; display: flex; align-items: center; justify-content: center; }
-    .radar-col .radar-surround-frame { aspect-ratio: 1/1; width: auto; height: 100%; max-height: none; max-width: 100%; display: flex; align-items: center; justify-content: center; }
+    .radar-col .radar-surround-frame { aspect-ratio: 1/1; width: auto; height: calc(100dvh * 1.25); max-height: none; max-width: none; display: flex; align-items: center; justify-content: center; }
     .radar-col .radar-surround-frame .radar { width: 80%; height: 80%; max-height: none; max-width: none; }
 
     /* Compress inset bodies */
@@ -183,7 +183,7 @@
       .hero { gap: 10px; }
       .hero .sub { font-size: 11px; }
       .hero .complexity { display: none; }
-      .radar-col .radar-surround-frame { max-height: none; max-width: 100%; }
+      .radar-col .radar-surround-frame { max-height: none; max-width: none; }
       .side-rail { font-size: 9px; }
       .side-rail.top { top: 10px; }
       .side-rail.bottom { bottom: 10px; }
@@ -250,8 +250,9 @@
         display: none;
       }
       .radar-col .radar-surround-frame {
-        max-height: calc(100dvh - 54px);
-        max-width: calc(100dvh - 54px);
+        height: calc(100dvh * 1.25);
+        max-height: none;
+        max-width: none;
       }
       .radar-col > .readout {
         padding: 4px 9px;
@@ -452,8 +453,8 @@
       .side-rail { display: none; }
 
       .radar-col .radar-wrap { min-height: 30vh; }
-      /* Portrait: radar fills the full available width. */
-      .radar-col .radar-surround-frame { width: 100%; height: auto; max-height: none; max-width: none; }
+      /* Portrait: radar circle fills full screen width (surround-frame at 125vw so 80% = 100vw). */
+      .radar-col .radar-surround-frame { width: calc(100vw * 1.25); height: auto; max-height: none; max-width: none; }
       .radar-col .radar { max-height: none; max-width: none; }
       .radar-col > .readout { padding: 0.4rem 0.6rem; }
       .radar-col > .readout .v { font-size: 1.25rem; }


### PR DESCRIPTION
The radar iframes for helm, weapons and sensors now fill to the left, right and bottom screen edges (no bezel padding on those sections). Inside each iframe the radar-surround-frame is sized to 125dvh×125dvh (landscape) or 125vw×125vw (portrait) so that the inner .radar circle at 80% equals 100dvh / 100vw — touching the actual screen boundary. The phone-bezel overlay (z-index 15) decorates on top as before. Other consoles (captain, power, repair, shields, comms) are unaffected.


Claude-Session: https://claude.ai/code/session_01XKhrum5QNjtG8moqD9kQLQ