### PR TITLE
fix: restore 165 unit tests broken by PR #555 component migration

### DIFF
--- a/src/console/navigation/mod.rs
+++ b/src/console/navigation/mod.rs
@@ -265,6 +265,12 @@ mod tests {
             .init_resource::<LastBroadcastHull>()
             .init_resource::<LastBroadcastShields>()
             .add_systems(PostUpdate, collect);
+        // Spawn the player ship entity so handle_navigation_waypoint can query it.
+        app.world_mut().spawn((
+            crate::simulation::Ship,
+            crate::ship_plugin::ShipConfigComponent::default(),
+            crate::ship_plugin::ShipSystemControlSources::default(),
+        ));
         app
     }
 

--- a/src/console/repair/server.rs
+++ b/src/console/repair/server.rs
@@ -299,6 +299,12 @@ mod tests {
         .add_plugins(RepairPlugin)
         .add_plugins(repair_state_broadcaster())
         .add_systems(PostUpdate, collect);
+        // Spawn the player ship entity so handle_dispatch_repair_team can query it.
+        app.world_mut().spawn((
+            crate::simulation::Ship,
+            crate::ship_plugin::ShipConfigComponent::default(),
+            crate::ship_plugin::ShipSystemControlSources::default(),
+        ));
         app
     }
 

--- a/src/core/broadcast/audience.rs
+++ b/src/core/broadcast/audience.rs
@@ -14,14 +14,17 @@ pub enum Audience {
 
 impl Audience {
     /// Resolve this audience to a `Target` given current session state.
-    /// Returns `None` when `Holding` names a console with no current holder,
-    /// signalling the caller to skip this broadcast.
-    pub fn resolve(&self, sessions: &SessionManager, ship_config: &ShipConfig) -> Option<Target> {
+    /// Returns `None` when `Holding` names a console with no current holder or
+    /// when `ship_config` is `None`, signalling the caller to skip this broadcast.
+    pub fn resolve(&self, sessions: &SessionManager, ship_config: Option<&ShipConfig>) -> Option<Target> {
         match self {
             Audience::All => Some(Target::All),
-            Audience::Holding(console) => sessions
-                .console_holder(console, ship_config)
-                .map(|t| Target::Token(t.to_string())),
+            Audience::Holding(console) => {
+                let cfg = ship_config?;
+                sessions
+                    .console_holder(console, cfg)
+                    .map(|t| Target::Token(t.to_string()))
+            }
             Audience::Token(t) => Some(Target::Token(t.clone())),
             Audience::AllExcept(t) => Some(Target::AllExcept(t.clone())),
         }
@@ -94,7 +97,7 @@ mod tests {
     fn audience_all_always_resolves() {
         let sm = SessionManager::new();
         assert_eq!(
-            Audience::All.resolve(&sm, &ship_config()),
+            Audience::All.resolve(&sm, Some(&ship_config())),
             Some(Target::All)
         );
     }
@@ -103,7 +106,7 @@ mod tests {
     fn audience_holding_returns_none_when_no_holder() {
         let sm = SessionManager::new();
         assert_eq!(
-            Audience::Holding(Console::Power).resolve(&sm, &ship_config()),
+            Audience::Holding(Console::Power).resolve(&sm, Some(&ship_config())),
             None
         );
     }
@@ -112,7 +115,7 @@ mod tests {
     fn audience_holding_returns_token_when_console_held() {
         let sm = sm_with_holder("tok1", Console::Power);
         assert_eq!(
-            Audience::Holding(Console::Power).resolve(&sm, &ship_config()),
+            Audience::Holding(Console::Power).resolve(&sm, Some(&ship_config())),
             Some(Target::Token("tok1".to_string()))
         );
     }
@@ -121,7 +124,7 @@ mod tests {
     fn audience_holding_returns_none_for_different_console() {
         let sm = sm_with_holder("tok1", Console::Power);
         assert_eq!(
-            Audience::Holding(Console::Helm).resolve(&sm, &ship_config()),
+            Audience::Holding(Console::Helm).resolve(&sm, Some(&ship_config())),
             None
         );
     }
@@ -130,7 +133,7 @@ mod tests {
     fn audience_token_always_resolves() {
         let sm = SessionManager::new();
         assert_eq!(
-            Audience::Token("abc".to_string()).resolve(&sm, &ship_config()),
+            Audience::Token("abc".to_string()).resolve(&sm, Some(&ship_config())),
             Some(Target::Token("abc".to_string()))
         );
     }
@@ -139,7 +142,7 @@ mod tests {
     fn audience_all_except_always_resolves() {
         let sm = SessionManager::new();
         assert_eq!(
-            Audience::AllExcept("abc".to_string()).resolve(&sm, &ship_config()),
+            Audience::AllExcept("abc".to_string()).resolve(&sm, Some(&ship_config())),
             Some(Target::AllExcept("abc".to_string()))
         );
     }

--- a/src/core/broadcast/lobby.rs
+++ b/src/core/broadcast/lobby.rs
@@ -174,8 +174,7 @@ fn dispatch_lobby_broadcasts(world: &mut World) {
                 if !should_fire {
                     return None;
                 }
-                let ship_config = ship_config_opt.as_ref()?;
-                let target = reg.audience.resolve(&sessions.0, &ship_config.0)?;
+                let target = reg.audience.resolve(&sessions.0, ship_config_opt.as_ref().map(|c| &c.0))?;
                 Some((target, reg.producer.clone()))
             })
             .collect()

--- a/src/core/broadcast/sim.rs
+++ b/src/core/broadcast/sim.rs
@@ -175,8 +175,7 @@ fn dispatch_sim_broadcasts(world: &mut World) {
                     return None;
                 }
                 // Resolve audience → target.
-                let ship_config = ship_config_opt.as_ref()?;
-                let target = reg.audience.resolve(&sessions.0, &ship_config.0)?;
+                let target = reg.audience.resolve(&sessions.0, ship_config_opt.as_ref().map(|c| &c.0))?;
                 Some((target, reg.producer.clone()))
             })
             .collect()

--- a/src/server_app.rs
+++ b/src/server_app.rs
@@ -2154,7 +2154,7 @@ mod tests {
         .add_plugins(crate::comms_plugin::CommsConsolePlugin)
         .add_systems(
             OnEnter(GamePhase::InProgress),
-            reset_broadcast_caches_on_start,
+            (reset_broadcast_caches_on_start, spawn_test_ship).chain(),
         )
         .add_systems(
             Update,
@@ -2186,6 +2186,14 @@ mod tests {
         .add_plugins(modifier_events_broadcaster())
         .add_systems(PostUpdate, collect);
         app
+    }
+
+    fn spawn_test_ship(mut commands: Commands) {
+        commands.spawn((
+            crate::simulation::Ship,
+            crate::ship_plugin::ShipConfigComponent::default(),
+            crate::ship_plugin::ShipSystemControlSources::default(),
+        ));
     }
 
     fn push(app: &mut App, token: &str, msg: ClientMessage) {

--- a/src/ship/power.rs
+++ b/src/ship/power.rs
@@ -257,12 +257,12 @@ pub fn operate_power_ai(
     mut power: ResMut<ShipPowerSystem>,
     config: Res<PowerConfigResource>,
     ship: Res<ShipState>,
-    last_helm: Res<LastHelmInput>,
+    last_helm: Option<Res<LastHelmInput>>,
     ai_config: Res<PowerAiConfigResource>,
 ) {
     let battery_pct = power.0.battery_charge / config.0.capacity;
     let red_alert = ship.red_alert();
-    let throttle = last_helm.thrust;
+    let throttle = last_helm.map_or(0.0, |l| l.thrust);
 
     // Weapons: boost on red alert when battery allows.
     if red_alert && battery_pct >= ai_config.weapons_battery_floor {
@@ -412,6 +412,12 @@ mod tests {
             )
             .add_plugins(crate::simulation::sim_state_broadcaster())
             .add_systems(PostUpdate, collect);
+        // Spawn the player ship entity so handle_power_messages can query it.
+        app.world_mut().spawn((
+            crate::simulation::Ship,
+            crate::ship_plugin::ShipConfigComponent::default(),
+            crate::ship_plugin::ShipSystemControlSources::default(),
+        ));
         app
     }
 

--- a/src/ship/sensors.rs
+++ b/src/ship/sensors.rs
@@ -179,6 +179,11 @@ mod tests {
             .init_resource::<Outbox>()
             .add_plugins(ShipSensorsPlugin)
             .add_systems(PostUpdate, collect);
+        app.world_mut().spawn((
+            crate::simulation::Ship,
+            crate::ship_plugin::ShipConfigComponent::default(),
+            crate::ship_plugin::ShipSystemControlSources::default(),
+        ));
         app
     }
 

--- a/src/ship_plugin.rs
+++ b/src/ship_plugin.rs
@@ -824,6 +824,11 @@ mod tests {
             .insert_resource(ShipImpulse(crate::impulse::ImpulseState::new()))
             .insert_resource(ShipModifiers::new())
             .add_plugins(ShipPlugin);
+        app.world_mut().spawn((
+            Ship,
+            ShipConfigComponent::default(),
+            ShipSystemControlSources::default(),
+        ));
         app
     }
 
@@ -1195,7 +1200,12 @@ mod tests {
     fn blocks_impulse_test_app() -> App {
         let mut app = test_app();
         app.add_plugins(RegionPlugin);
-        app.world_mut().spawn((Ship, Transform::default()));
+        app.world_mut().spawn((
+            Ship,
+            Transform::default(),
+            ShipConfigComponent::default(),
+            ShipSystemControlSources::default(),
+        ));
         app
     }
 

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -3494,6 +3494,12 @@ mod tests {
                     .chain(),
             )
             .add_systems(PostUpdate, collect);
+        app.world_mut().spawn((
+            crate::simulation::Ship,
+            Transform::default(),
+            crate::ship_plugin::ShipConfigComponent::default(),
+            crate::ship_plugin::ShipSystemControlSources::default(),
+        ));
         app
     }
 
@@ -7465,7 +7471,12 @@ condition = "on_world_loaded"
             .add_observer(handle_region_exited_event);
         // Spawn the player ship (with a Transform so RegionPlugin's
         // membership query succeeds).
-        app.world_mut().spawn((Ship, Transform::default()));
+        app.world_mut().spawn((
+            Ship,
+            Transform::default(),
+            crate::ship_plugin::ShipConfigComponent::default(),
+            crate::ship_plugin::ShipSystemControlSources::default(),
+        ));
         app
     }
 


### PR DESCRIPTION
PR #555 moved ShipSystemControlSources and ShipConfigComponent from ECS Resources to per-entity Components on Ship entities. This broke tests in 10 files where:

1. operate_power_ai (ShipPowerPlugin) required Res<LastHelmInput> which is only initialized by ShipPlugin — made it Option<Res<LastHelmInput>>

2. dispatch_sim_broadcasts and dispatch_lobby_broadcasts had a blocking ? on ship_config_opt that short-circuited ALL Audience variants (including Audience::All) when no Ship entity existed — changed Audience::resolve to accept Option<&ShipConfig> and removed the early-return

3. Eight test_app() helpers never spawned a Ship entity, so systems using ship_query.single() returned early without processing — added Ship entity spawn with ShipConfigComponent + ShipSystemControlSources to test apps in: ship/power.rs, ship/sensors.rs, ship_plugin.rs, console/navigation/mod.rs, console/repair/server.rs, server_app.rs (via OnEnter(InProgress) system), world/server.rs (main test_app + comms_test_app)