### PR TITLE
fix(ci): update AiControllerComponent field reference and doctrine va…

### DIFF
--- a/editor/behaviour-editor.js
+++ b/editor/behaviour-editor.js
@@ -3,10 +3,10 @@
  *
  * Pure-logic module for editing the [behaviour] block of an entity TOML.
  *
- * The [behaviour] block defines the AI state machine for NPC entities:
- *  - initial_state: which state the entity starts in
- *  - state[]: array of state definitions (with kind + parameters)
- *  - transition[]: array of transition rules between states
+ * Two formats are supported:
+ *   - Doctrine-based AI (issue #572): `[[behaviour.doctrine]]` entries.
+ *     No FSM; behaviour driven by standing doctrine objectives scored each tick.
+ *   - Legacy FSM: `initial_state`, `state[]`, `transition[]`.
  *
  * No DOM manipulation is performed here; the class is fully testable in Node.
  */
@@ -40,6 +40,7 @@ export class BehaviourEditor {
     this._initialState = null;
     this._states = [];
     this._transitions = [];
+    this._doctrine = [];
   }
 
   load(behaviour = {}) {
@@ -47,6 +48,11 @@ export class BehaviourEditor {
     this._initialState = b.initial_state ?? null;
     this._states = [];
     this._transitions = [];
+    this._doctrine = [];
+
+    if (Array.isArray(b.doctrine)) {
+      this._doctrine = b.doctrine.map((d) => ({ ...d }));
+    }
 
     if (Array.isArray(b.state)) {
       for (const s of b.state) {
@@ -60,9 +66,6 @@ export class BehaviourEditor {
 
     if (Array.isArray(b.transition)) {
       for (const t of b.transition) {
-        // `from` in TOML may be either a string (single source state) or
-        // an array of strings. Normalise to an array so [...t.from] in
-        // cloneTransition doesn't spread a string into characters.
         const fromRaw = t.from;
         const fromArr = Array.isArray(fromRaw)
           ? fromRaw
@@ -81,6 +84,7 @@ export class BehaviourEditor {
       initialState: this._initialState,
       states: this._states.map(cloneState),
       transitions: this._transitions.map(cloneTransition),
+      doctrine: this._doctrine.map((d) => ({ ...d })),
     };
   }
 
@@ -165,6 +169,10 @@ export class BehaviourEditor {
     }
   }
 
+  getDoctrine() {
+    return this._doctrine.map((d) => ({ ...d }));
+  }
+
   toBehaviour() {
     const out = {};
     if (this._initialState) {
@@ -172,6 +180,9 @@ export class BehaviourEditor {
     }
     out.state = this._states.map(cloneState);
     out.transition = this._transitions.map(cloneTransition);
+    if (this._doctrine.length > 0) {
+      out.doctrine = this._doctrine.map((d) => ({ ...d }));
+    }
     return out;
   }
 
@@ -182,6 +193,27 @@ export class BehaviourEditor {
   validate() {
     const errors = [];
 
+    // Doctrine-based validation (issue #572).
+    if (this._doctrine.length > 0) {
+      for (let i = 0; i < this._doctrine.length; i++) {
+        const d = this._doctrine[i];
+        if (!d.id) {
+          errors.push(`Doctrine [${i}]: missing id`);
+        }
+        if (!d.directive_kind) {
+          errors.push(`Doctrine [${i}]: missing directive_kind`);
+        }
+        if (d.base_priority == null || typeof d.base_priority !== 'number') {
+          errors.push(`Doctrine [${i}]: base_priority must be a number`);
+        }
+        if ((d.directive_kind === 'Patrol' || d.directive_kind === 'patrol') && (!Array.isArray(d.directive_anchors) || d.directive_anchors.length === 0)) {
+          errors.push(`Doctrine [${i}]: Patrol directive needs directive_anchors`);
+        }
+      }
+      return { valid: errors.length === 0, errors };
+    }
+
+    // Legacy FSM validation.
     if (this._states.length === 0) {
       errors.push('Must have at least one state');
     }

--- a/editor/tests/entity-toml.test.js
+++ b/editor/tests/entity-toml.test.js
@@ -28,7 +28,9 @@ describe('entity-toml', () => {
       expect(result.faction).toBeTruthy();
       expect(result.hull.hull_integrity).toBe(30.0);
       expect(result.collider.shape).toBe('Capsule');
-      expect(result.behaviour.initial_state).toBe('patrol');
+      expect(Array.isArray(result.behaviour.doctrine)).toBe(true);
+      expect(result.behaviour.doctrine.length).toBeGreaterThanOrEqual(1);
+      expect(result.behaviour.doctrine[0].id).toBe('patrol-sector');
     });
 
     it('parses asteroid_common_1_large.toml', () => {

--- a/editor/tests/slice-5-behaviour-edit.test.js
+++ b/editor/tests/slice-5-behaviour-edit.test.js
@@ -2,12 +2,12 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { setupEntityMode } from './slice-5-helpers.js';
 
 /**
- * Slice 5 integration test: behaviour-view validation banner.
+ * Slice 5 integration test: behaviour-view validation banner (doctrine-based AI).
  *
- * Open pirate_raider.toml and set behaviour.initial_state to a name that
- * isn't in the state list. After re-render, the inline
+ * Open pirate_raider.toml (doctrine format) and remove the directive_kind
+ * from the first doctrine entry. After re-render, the inline
  * `.entity-behaviour-error` banner should be present and reference the
- * bad name.
+ * missing field.
  */
 
 describe('Slice 5: behaviour validation surfaces inline', () => {
@@ -17,21 +17,23 @@ describe('Slice 5: behaviour validation surfaces inline', () => {
     await ctx.view._internal.loadEntity('assets/entities/pirate_raider.toml');
   });
 
-  it('shows an inline validation banner when initial_state references a missing state', () => {
+  it('shows an inline validation banner when a doctrine entry is missing directive_kind', () => {
     // Sanity: no banner before mutation — pirate_raider.toml validates cleanly.
     const before = ctx.host.querySelectorAll('div')
       .filter((d) => d.classList.contains('entity-behaviour-error'));
     expect(before.length).toBe(0);
 
-    // Patch behaviour.initial_state to a name that's not in the state list.
+    // Patch the first doctrine entry to remove directive_kind.
     const behaviour = ctx.view.shell.getCard('behaviour').data;
-    const patched = { ...behaviour, initial_state: 'does_not_exist' };
+    const patched = {
+      ...behaviour,
+      doctrine: [{ ...behaviour.doctrine[0], directive_kind: undefined }],
+    };
     ctx.view._internal.handleCardEdit('behaviour', patched);
 
     const banner = ctx.host.querySelectorAll('div')
       .find((d) => d.classList.contains('entity-behaviour-error'));
     expect(banner).toBeDefined();
-    expect(banner.textContent).toMatch(/initial_state/i);
-    expect(banner.textContent).toContain('does_not_exist');
+    expect(banner.textContent).toMatch(/directive_kind/i);
   });
 });

--- a/editor/validation.js
+++ b/editor/validation.js
@@ -55,6 +55,27 @@ function validateBehaviourBlock(behaviour) {
   const states = behaviour.state;
   const transitions = behaviour.transition;
   const initialState = behaviour.initial_state;
+  const doctrine = behaviour.doctrine;
+
+  // Doctrine-based AI (issue #572) — validate doctrine entries.
+  if (Array.isArray(doctrine) && doctrine.length > 0) {
+    for (let i = 0; i < doctrine.length; i++) {
+      const d = doctrine[i];
+      if (!d.id) {
+        results.push({ path: `behaviour.doctrine[${i}]`, severity: 'error', message: 'Doctrine entry must have an id' });
+      }
+      if (!d.directive_kind) {
+        results.push({ path: `behaviour.doctrine[${i}]`, severity: 'error', message: 'Doctrine entry must have a directive_kind' });
+      }
+      if (d.base_priority == null || typeof d.base_priority !== 'number') {
+        results.push({ path: `behaviour.doctrine[${i}]`, severity: 'error', message: 'Doctrine entry must have a numeric base_priority' });
+      }
+      if ((d.directive_kind === 'Patrol' || d.directive_kind === 'patrol') && (!Array.isArray(d.directive_anchors) || d.directive_anchors.length === 0)) {
+        results.push({ path: `behaviour.doctrine[${i}]`, severity: 'error', message: 'Patrol doctrine must have directive_anchors' });
+      }
+    }
+    return results;
+  }
 
   const stateNames = Array.isArray(states) ? states.map((s) => s.name).filter(Boolean) : [];
   const hasStates = Array.isArray(states) && states.length > 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -218,9 +218,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -503,6 +503,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {

--- a/src/debug_overlay.rs
+++ b/src/debug_overlay.rs
@@ -202,15 +202,15 @@ fn write_entity_debug_state(
     for (i, (ai, transform, name)) in entities.iter().enumerate() {
         let label = name.map(|n| n.0.as_str()).unwrap_or("<unnamed>");
         let p = transform.translation;
-        let state = &ai.controller.current_state_name;
+        let target_str = ai.memory.target.map(|u| u.to_string()).unwrap_or_else(|| "none".to_string());
         out.push_str(&format!(
-            "{:>2}. {:<20} pos=({:>7.1},{:>7.1},{:>7.1})  state={}\n",
+            "{:>2}. {:<20} pos=({:>7.1},{:>7.1},{:>7.1})  target={}\n",
             i + 1,
             label,
             p.x,
             p.y,
             p.z,
-            state
+            target_str
         ));
     }
     crate::bridge::set_entity_debug_string(out);
@@ -377,8 +377,8 @@ fn update_entity_inspector(
         // AI state
         if let Some(ai_ctrl) = ai {
             out.push_str(&format!(
-                "    ai: {}\n",
-                ai_ctrl.controller.current_state_name
+                "    ai: target={}\n",
+                ai_ctrl.memory.target.map(|u| u.to_string()).unwrap_or_else(|| "none".to_string())
             ));
         }
     }


### PR DESCRIPTION
…lidation

- src/debug_overlay.rs: change .controller.current_state_name → .memory.target (AiControllerComponent field renamed in #572 FSM dissolution)
- editor/validation.js: add doctrine-based behaviour validation path
- editor/behaviour-editor.js: add doctrine storage/validation in BehaviourEditor
- editor/tests/entity-toml.test.js: assert doctrine format instead of initial_state
- editor/tests/slice-5-behaviour-edit.test.js: test doctrine validation instead of FSM