### PR TITLE
@

### DIFF
--- a/client.html
+++ b/client.html
@@ -1297,6 +1297,29 @@
       } catch (_) {}
     }
 
+    // -- Generic console state push (ship-agnostic) --------------------------
+    // Every station id (including the aggregate cruiser/destroyer consoles like
+    // `engineering` = power+repair and `science` = sensors+shields) is handled
+    // generically by window.buildConsoleState(name, state), which nests the
+    // sub-panel payloads. The per-console push*ConsoleState helpers below only
+    // cover the legacy standalone iframes, so aggregate consoles (engineering,
+    // science, …) would otherwise never receive state. Route by the console
+    // registry so whatever iframe the current ship actually mounted is fed.
+    function pushConsoleStateFor(name) {
+      if (!name) return;
+      const registry = window.CONSOLE_REGISTRY || {};
+      const entry = registry[name];
+      const iframeId = entry ? entry.iframeId : (name + '-iframe');
+      const json = (typeof window.buildConsoleState === 'function')
+        ? window.buildConsoleState(name, state)
+        : '{}';
+      _pushIframe($(iframeId), name, json);
+    }
+
+    function pushActiveConsoleState() {
+      pushConsoleStateFor(activeConsole);
+    }
+
     // -- Weapons console iframe bridge (issue #422) --------------------------
     // Builds a WeaponsConsoleState JSON from client state and pushes it to the
     // gui/weapons-console.html iframe via its window.__updateConsole function.
@@ -1321,50 +1344,20 @@
     function _attachIframeLoadListener(iframeEl, consoleName) {
       if (!iframeEl) return;
       iframeEl.addEventListener('load', () => {
-        switch (consoleName) {
-          case 'tactical':   pushWeaponsConsoleState();    break;
-          case 'captain':    pushCaptainConsoleState();    break;
-          case 'helm':       pushHelmConsoleState();       break;
-          case 'repair':     pushRepairConsoleState();     break;
-          case 'power':      pushPowerConsoleState();      break;
-          case 'shields':    pushShieldsConsoleState();    break;
-          case 'sensors':    pushSensorsConsoleState();    break;
-          case 'science':    pushScienceConsoleState();    break;
-          case 'comms':      pushCommsConsoleState();      break;
-          case 'navigation': pushNavigationConsoleState(); break;
-        }
+        // Push the freshly-loaded iframe its current snapshot. Generic so it
+        // covers every station id the ship mounts (including engineering /
+        // science aggregates the old per-name switch never handled).
+        pushConsoleStateFor(consoleName);
         injectSwipeRelay(iframeEl);
       });
     }
 
     function renderGame(s) {
-      if (activeConsole === 'captain') {
-        pushCaptainConsoleState();
-      }
-      if (activeConsole === 'helm') {
-        pushHelmConsoleState();
-      }
-      if (activeConsole === 'repair') {
-        pushRepairConsoleState();
-      }
-      if (activeConsole === 'power') {
-        pushPowerConsoleState();
-      }
-      if (activeConsole === 'shields') {
-        pushShieldsConsoleState();
-      }
-      if (activeConsole === 'sensors') {
-        pushSensorsConsoleState();
-      }
-      if (activeConsole === 'science') {
-        pushScienceConsoleState();
-      }
-      if (activeConsole === 'comms') {
-        pushCommsConsoleState();
-      }
-      if (activeConsole === 'navigation') {
-        pushNavigationConsoleState();
-      }
+      // Refresh whichever console is currently visible. This is ship-agnostic:
+      // it covers the aggregate cruiser/destroyer consoles (engineering,
+      // science, …) that the per-name push helpers below do not, and the
+      // standalone consoles resolve to the same iframe via the registry.
+      pushActiveConsoleState();
     }
 
     // -- Captain console iframe bridge (issue #428) ---------------------------

--- a/gui/components/ph-helm-joystick.js
+++ b/gui/components/ph-helm-joystick.js
@@ -5,6 +5,9 @@ export class PhHelmJoystick extends HTMLElement {
   #pointerId = null;
   #rafId = null;
   #hbId = null;
+  #keys = {};
+  #inputRaf = null;
+  #lastKbSend = 0;
 
   constructor() {
     super();
@@ -86,6 +89,31 @@ export class PhHelmJoystick extends HTMLElement {
       }
     }
     this.#bindEvents();
+    // Keyboard (WASD / arrows) + gamepad drive the same set_helm output as the
+    // on-screen thumbstick. Ported from the legacy helm-console.html so the new
+    // per-ship helm consoles keep desktop/controller control (issue: new GUI).
+    if (typeof document !== 'undefined') {
+      document.addEventListener('keydown', this.#onKeyDown);
+      document.addEventListener('keyup', this.#onKeyUp);
+    }
+    if (typeof window !== 'undefined') {
+      window.addEventListener('blur', this.#onBlur);
+      window.addEventListener('gamepadconnected', this.#onGamepadConnected);
+    }
+  }
+
+  disconnectedCallback() {
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('keydown', this.#onKeyDown);
+      document.removeEventListener('keyup', this.#onKeyUp);
+    }
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('blur', this.#onBlur);
+      window.removeEventListener('gamepadconnected', this.#onGamepadConnected);
+    }
+    if (this.#inputRaf) { cancelAnimationFrame(this.#inputRaf); this.#inputRaf = null; }
+    if (this.#hbId) { clearInterval(this.#hbId); this.#hbId = null; }
+    if (this.#rafId) { cancelAnimationFrame(this.#rafId); this.#rafId = null; }
   }
 
   set state(val) {
@@ -189,6 +217,105 @@ export class PhHelmJoystick extends HTMLElement {
     root.getElementById('thrust-readout').textContent = fmt(-this.#py);
     root.getElementById('yaw-readout').textContent = fmt(this.#px);
   }
+
+  // ── Keyboard + gamepad input ──────────────────────────────────────────
+  #onKeyDown = (e) => {
+    const tag = e.target && e.target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+    const relevant = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'KeyA', 'KeyD', 'KeyW', 'KeyS'];
+    if (relevant.indexOf(e.code) === -1) return;
+    e.preventDefault();
+    this.#keys[e.code] = true;
+    this.#startInputLoop();
+  };
+
+  #onKeyUp = (e) => {
+    delete this.#keys[e.code];
+    this.#startInputLoop();
+  };
+
+  #onBlur = () => {
+    this.#keys = {};
+    this.#startInputLoop();
+  };
+
+  #onGamepadConnected = () => {
+    this.#startInputLoop();
+  };
+
+  #getGamepadInput() {
+    if (typeof navigator === 'undefined' || !navigator.getGamepads) return { x: 0, y: 0 };
+    const pads = navigator.getGamepads();
+    for (let i = 0; i < pads.length; i++) {
+      const gp = pads[i];
+      if (!gp || gp.axes.length < 2) continue;
+      const dead = 0.1;
+      return {
+        x: Math.abs(gp.axes[0]) > dead ? gp.axes[0] : 0,
+        y: Math.abs(gp.axes[1]) > dead ? gp.axes[1] : 0,
+      };
+    }
+    return { x: 0, y: 0 };
+  }
+
+  #hasGamepad() {
+    if (typeof navigator === 'undefined' || !navigator.getGamepads) return false;
+    const pads = navigator.getGamepads();
+    for (let i = 0; i < pads.length; i++) if (pads[i]) return true;
+    return false;
+  }
+
+  #startInputLoop() {
+    if (this.#inputRaf) return;
+    this.#inputRaf = requestAnimationFrame(this.#inputLoop);
+  }
+
+  #inputLoop = () => {
+    this.#inputRaf = null;
+    const auto = this.#state ? !!this.#state.auto : false;
+    const keepPolling = Object.keys(this.#keys).length > 0 || this.#hasGamepad();
+
+    // The on-screen thumbstick (pointer drag) and AUTO both take priority.
+    if (auto || this.#pointerId !== null) {
+      if (!auto && keepPolling) this.#inputRaf = requestAnimationFrame(this.#inputLoop);
+      return;
+    }
+
+    let kx = 0, ky = 0;
+    if (this.#keys['ArrowLeft'] || this.#keys['KeyA']) kx -= 1;
+    if (this.#keys['ArrowRight'] || this.#keys['KeyD']) kx += 1;
+    if (this.#keys['ArrowUp'] || this.#keys['KeyW']) ky -= 1; // forward thrust
+    if (this.#keys['ArrowDown'] || this.#keys['KeyS']) ky += 1;
+
+    const gp = this.#getGamepadInput();
+    let nx = kx !== 0 ? kx : gp.x;
+    let ny = ky !== 0 ? ky : gp.y;
+    const d = Math.hypot(nx, ny);
+    if (d > 1) { nx /= d; ny /= d; }
+
+    const hasInput = nx !== 0 || ny !== 0;
+    if (hasInput) {
+      this.#px = nx;
+      this.#py = ny;
+      this.#applyNubPosition();
+      this.#updateReadout();
+      const now = Date.now();
+      if (now - this.#lastKbSend >= 100) { this.#sendAction(); this.#lastKbSend = now; }
+      this.#inputRaf = requestAnimationFrame(this.#inputLoop);
+    } else {
+      // Input released this frame — snap back to centre and send a stop once.
+      if (this.#px !== 0 || this.#py !== 0) {
+        this.#px = 0;
+        this.#py = 0;
+        this.#applyNubPosition();
+        this.#updateReadout();
+        this.#sendAction();
+      }
+      // Keep polling while a gamepad is present (its stick can re-engage
+      // without a keydown to restart the loop).
+      if (keepPolling) this.#inputRaf = requestAnimationFrame(this.#inputLoop);
+    }
+  };
 
   #sendAction() {
     if (this.sendAction) {

--- a/gui/components/ph-navigation-map.js
+++ b/gui/components/ph-navigation-map.js
@@ -204,18 +204,23 @@ export class PhNavigationMap extends HTMLElement {
     octx.fillStyle = '#07080c';
     octx.fillRect(0, 0, W, H);
 
-    this.#drawGrid(octx, cx, cy, scale, shipPos.x, shipPos.z, headingRad, W, H, rangeClamped);
+    // World-anchored, north-up chart: the camera is fixed on the world origin
+    // (0,0) rather than the ship, so the ship icon is plotted at its true
+    // sector position and visibly moves as it flies — instead of being pinned
+    // to the centre of the screen. Matches the legacy navigation console.
+    this.#drawGrid(octx, cx, cy, scale, 0, 0, 0, W, H, rangeClamped);
 
     if (waypoint && Number.isFinite(waypoint.x) && Number.isFinite(waypoint.z)) {
-      this.#drawWaypoint(octx, waypoint, cx, cy, scale, shipPos, headingRad);
+      this.#drawWaypoint(octx, waypoint, cx, cy, scale);
     }
 
-    this.#drawShipMarker(octx, cx, cy, R);
+    const [shipSx, shipSy] = this.#worldToScreen(shipPos.x, shipPos.z, 0, 0, 0, scale, cx, cy);
+    this.#drawShipMarker(octx, shipSx, shipSy, R, headingRad);
 
     this.#projectedBlips = [];
     const blipR = Math.max(3, R * 0.015);
     for (const b of blips) {
-      const [sx, sy] = this.#worldToScreen(b.world_x, b.world_z, shipPos.x, shipPos.z, headingRad, scale, cx, cy);
+      const [sx, sy] = this.#worldToScreen(b.world_x, b.world_z, 0, 0, 0, scale, cx, cy);
       if (sx < -50 || sx > W + 50 || sy < -50 || sy > H + 50) continue;
       const color = this.#blipColor(b.stance);
       this.#drawBlipShape(octx, b.kind, sx, sy, blipR, color);
@@ -285,28 +290,31 @@ export class PhNavigationMap extends HTMLElement {
     }
   }
 
-  #drawShipMarker(octx, cx, cy, R) {
+  #drawShipMarker(octx, sx, sy, R, headingRad) {
     const r = Math.max(6, R * 0.025);
     octx.save();
+    octx.translate(sx, sy);
     octx.strokeStyle = 'rgba(108,182,208,0.2)';
     octx.lineWidth = 1;
-    octx.beginPath(); octx.arc(cx, cy, r * 2.2, 0, Math.PI * 2); octx.stroke();
+    octx.beginPath(); octx.arc(0, 0, r * 2.2, 0, Math.PI * 2); octx.stroke();
+    // Orient the ship glyph to its heading (north-up chart, 0 rad = north/up).
+    octx.rotate(headingRad || 0);
     octx.shadowColor = '#6cb6d0';
     octx.shadowBlur = 14;
     octx.fillStyle = '#6cb6d0';
     octx.beginPath();
-    octx.moveTo(cx, cy - r);
-    octx.lineTo(cx + r * 0.65, cy + r * 0.45);
-    octx.lineTo(cx, cy + r * 0.05);
-    octx.lineTo(cx - r * 0.65, cy + r * 0.45);
+    octx.moveTo(0, -r);
+    octx.lineTo(r * 0.65, r * 0.45);
+    octx.lineTo(0, r * 0.05);
+    octx.lineTo(-r * 0.65, r * 0.45);
     octx.closePath();
     octx.fill();
     octx.shadowBlur = 0;
     octx.restore();
   }
 
-  #drawWaypoint(octx, wp, cx, cy, scale, shipPos, headingRad) {
-    const [px, py] = this.#worldToScreen(wp.x, wp.z, shipPos.x, shipPos.z, headingRad, scale, cx, cy);
+  #drawWaypoint(octx, wp, cx, cy, scale) {
+    const [px, py] = this.#worldToScreen(wp.x, wp.z, 0, 0, 0, scale, cx, cy);
     const d = 8;
     octx.save();
     octx.fillStyle = 'rgba(212,168,32,0.18)';
@@ -405,17 +413,16 @@ export class PhNavigationMap extends HTMLElement {
   #handleTap(bufX, bufY) {
     const hit = this.#getBlipAt(bufX, bufY);
     const state = this.#state || {};
-    const shipPos = state.ship_pos || { x: 0, z: 0 };
     const range = state.range || 50000;
     const rangeClamped = range > 0 ? range : 50000;
-    const shipHeading = state.ship_heading || 0;
-    const headingRad = shipHeading * Math.PI / 180;
     const R = Math.min(this.#canvas.width, this.#canvas.height) / 2;
     const scale = R / rangeClamped;
     const cx = this.#canvas.width / 2;
     const cy = this.#canvas.height / 2;
 
-    const [wx, wz] = this.#screenToWorld(bufX, bufY, shipPos.x, shipPos.z, headingRad, scale, cx, cy);
+    // World-anchored chart: map the tapped screen point to its absolute world
+    // coordinate (camera fixed on the origin, north-up), matching #render.
+    const [wx, wz] = this.#screenToWorld(bufX, bufY, 0, 0, 0, scale, cx, cy);
 
     if (hit && this.sendAction) {
       this.#selectedBlip = hit.blip;

--- a/gui/console-core.js
+++ b/gui/console-core.js
@@ -121,6 +121,38 @@ export function initConsole({ name, render }) {
     }
   }
 
+  // ── Expose sendAction to web-component controls ────────────────────────
+  // The `gui/components/ph-*.js` custom elements dispatch user actions by
+  // calling `this.sendAction(...)`, falling back to `window.sendAction` in
+  // their `connectedCallback`. Because the console HTML imports the component
+  // modules *before* calling initConsole, each element's connectedCallback has
+  // already run (and captured an undefined `window.sendAction`) by the time we
+  // get here. So we must both (a) publish `window.sendAction` for any element
+  // that reads it lazily or upgrades later, and (b) assign `.sendAction`
+  // directly onto every custom element already in the DOM so their captured
+  // reference is repaired. Without this every control in the new per-ship
+  // consoles is inert (see the missing wiring vs. the old *-console.html files
+  // which captured `initConsole(...).sendAction` and assigned it by hand).
+  _root.sendAction = sendAction;
+  function _wireComponents() {
+    if (typeof document === 'undefined') return;
+    var all = document.querySelectorAll('*');
+    for (var i = 0; i < all.length; i++) {
+      var el = all[i];
+      // Custom elements always contain a hyphen in their tag name.
+      if (el.tagName && el.tagName.indexOf('-') !== -1) {
+        el.sendAction = sendAction;
+      }
+    }
+  }
+  if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', _wireComponents);
+    } else {
+      _wireComponents();
+    }
+  }
+
   // ── Help system (issue #462) ───────────────────────────────────────────
   // Mount the shared "?" help button + click-to-dismiss modal for this
   // console. `name` is the lowercase station id (post issue #618), which

--- a/gui/console-state.js
+++ b/gui/console-state.js
@@ -511,6 +511,7 @@ export function buildCaptainConsoleState(state) {
       viewscreen_auto:       bb.viewscreen_auto        ?? false,
       view_direction:        bb.view_direction         ?? '',
       view_mode:             'Camera',
+      camera_views:          bb.camera_views           ?? [],
       objectives:            bb.objectives             ?? [],
       hull_integrity_pct:    bb.hull_integrity_pct     ?? 100,
       game_status:           bb.game_status            ?? '',
@@ -531,6 +532,7 @@ export function buildCaptainConsoleState(state) {
     viewscreen_auto:       viewscreenAuto,
     view_direction:        viewDirection,
     view_mode:             'Camera',
+    camera_views:          state.cameraViews || [],
     objectives:            state.objectives  || [],
     hull_integrity_pct:    state.hullPct     || 100,
     game_status:           state.redAlert

--- a/gui/tab-bar.js
+++ b/gui/tab-bar.js
@@ -25,6 +25,7 @@ export const CONSOLE_LABEL = Object.freeze({
   navigation: 'Navigation',
   power: 'Power',
   comms: 'Comms',
+  engineering: 'Engineering',
 });
 
 export const CONSOLE_INITIAL = Object.freeze({
@@ -38,6 +39,7 @@ export const CONSOLE_INITIAL = Object.freeze({
   navigation: 'N',
   power: 'P',
   comms: 'C',
+  engineering: 'E',
 });
 
 // Threshold at which the portrait bar collapses to initials. Matches the

--- a/tests/client/ph-navigation-map.test.js
+++ b/tests/client/ph-navigation-map.test.js
@@ -168,6 +168,36 @@ describe('PhNavigationMap', () => {
     expect(h.fakeCtx._calls.arc.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('draws the ship marker at its true world position, not the screen centre', () => {
+    const h = setup();
+    // Canvas 600x600 → cx=cy=300, R=300, range=5000 → scale=0.06.
+    // World-anchored (camera on origin): ship at (2000,0) projects to
+    // sx = 300 + 2000*0.06 = 420, sy = 300 (unchanged on z=0).
+    h.el.state = {
+      blips: [],
+      range: 5000,
+      ship_pos: { x: 2000, z: 0 },
+      ship_heading: 0,
+    };
+    h.tickRaf();
+    // #drawShipMarker is the only code path that calls translate().
+    const translateCalls = h.fakeCtx.translate.mock.calls;
+    expect(translateCalls.length).toBeGreaterThan(0);
+    const [sx, sy] = translateCalls[translateCalls.length - 1];
+    expect(sx).toBeCloseTo(420, 1);
+    expect(sy).toBeCloseTo(300, 1);
+  });
+
+  it('ship marker sits at centre only when the ship is at the world origin', () => {
+    const h = setup();
+    h.el.state = { blips: [], range: 5000, ship_pos: { x: 0, z: 0 }, ship_heading: 0 };
+    h.tickRaf();
+    const c = h.fakeCtx.translate.mock.calls;
+    const [sx, sy] = c[c.length - 1];
+    expect(sx).toBeCloseTo(300, 1);
+    expect(sy).toBeCloseTo(300, 1);
+  });
+
   it('waypoint marker renders diamond shape when waypoint is set', () => {
     const h = setup();
     const state = {
@@ -210,11 +240,11 @@ describe('PhNavigationMap', () => {
 
     // Click at CSS (150, 75) → buffer (300, 150)
     // cx=300, cy=300, scale=0.06 (R=300, range=5000)
-    // With zoom=1, pan=(0,0):
+    // World-anchored (camera on origin, north-up), zoom=1, pan=(0,0):
     // nx = (300-300)/(0.06*1) = 0, ny = (150-300)/(0.06*1) = -2500
-    // heading=0, cos=1, sin=0: wx = 0 + 0 + 500 = 500, wz = 0 - (-2500) + 300 = 2800
+    // wx = 0, wz = -(-2500) = 2500 (independent of ship_pos)
     click(h.canvas, 150, 75);
-    expect(sendAction).toHaveBeenCalledWith('set_navigation_waypoint', { x: 500, z: 2800 });
+    expect(sendAction).toHaveBeenCalledWith('set_navigation_waypoint', { x: 0, z: 2500 });
   });
 
   it('tap on blip dispatches set_navigation_waypoint with source_uuid', () => {
@@ -439,15 +469,15 @@ describe('PhNavigationMap', () => {
       h.tickRaf();
 
       // Tap at center CSS (150,150) → buf (300,300)
-      // With zoom=1.13, panX=100, panY=0:
+      // World-anchored (camera on origin), zoom=1.13, panX=100, panY=0:
       //   nx = (300-300-100)/(0.06*1.13) = -100/0.0678 = -1474.93
       //   ny = (300-300-0)/(0.06*1.13) = 0
-      //   heading=0: wx = -1474.93 + 100 = -1374.93, wz = -0 + 100 = 100
+      //   wx = -1474.93, wz = 0 (independent of ship_pos)
       click(h.canvas, 150, 150);
       expect(sendAction).toHaveBeenCalledTimes(1);
       const call = sendAction.mock.calls[0][1];
-      expect(call.x).toBeCloseTo(-1374.93, 1);
-      expect(call.z).toBe(100);
+      expect(call.x).toBeCloseTo(-1474.93, 1);
+      expect(call.z).toBe(0);
     });
 
     it('mousemove without prior mousedown does not affect pan', () => {

--- a/tests/client/tab-bar.test.js
+++ b/tests/client/tab-bar.test.js
@@ -65,10 +65,10 @@ function fakeRoot() {
 }
 
 describe('CONSOLE_LABEL / CONSOLE_INITIAL', () => {
-  it('keys all ten consoles by lowercase station id', () => {
+  it('keys all consoles by lowercase station id', () => {
     const expected = [
       'captain', 'helm', 'tactical', 'repair', 'sensors',
-      'shields', 'navigation', 'power', 'comms', 'science',
+      'shields', 'navigation', 'power', 'comms', 'science', 'engineering',
     ];
     expect(Object.keys(CONSOLE_LABEL).sort()).toEqual(expected.slice().sort());
     expect(Object.keys(CONSOLE_INITIAL).sort()).toEqual(expected.slice().sort());


### PR DESCRIPTION
fix: wire up new per-ship consoles (controls + data + nav map)

The new cruiser/destroyer consoles and ph-* web components were added without porting the wiring the old *-console.html files did by hand.

- console-core: publish window.sendAction and assign .sendAction onto mounted components so every control (joystick, torpedo, red alert, impulse, power, shield focus, repair, targeting, comms, camera) fires
- client.html: push console state generically by station id via the registry, so aggregate consoles (engineering=power+repair, science=sensors+shields) actually receive live state
- console-state: emit camera_views in buildCaptainConsoleState so the camera buttons render
- ph-navigation-map: world-anchor the chart (camera on origin, north-up) so the ship is drawn at its true position instead of pinned to centre
- ph-helm-joystick: port WASD/arrow-key + gamepad input from the legacy helm console
- tab-bar: add the missing engineering label/initial

Full JS suite green (2187); added nav-map ship-position assertions.


@