### PR TITLE
Decompose trigger-action dispatch into a pure, testable table (#707-#719)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ docs/           — Draft design notes (numbered).
 7. **Helm runs on fixed ticks, not frames.** Simulation reads helm inputs at 30Hz (`HelmInputTimer`); AI helm decisions run on the shared sim tick (`[global] ai_helm_tick_hz` in the world TOML, default 30Hz) — never once per rendered frame.
 8. **Deterministic asteroids.** Per-cell density is seeded from `(field_idx, gx, gz) + Perlin noise`. Destroyed asteroids respawn fresh when the player leaves the cell and returns.
 9. **WebGL2 rendering; PeerJS cloud broker** (not self-hosted, deferred post-PoC).
-10. **Pure modules are Bevy-free.** `lobby/handler`, `radar`, `ship/{damage,physics,rating,control_source,coordination}`, `modifiers/repair_teams`, and friends have no Bevy imports — fully unit-testable on native.
+10. **Pure modules are Bevy-free.** `lobby/handler`, `radar`, `ship/{damage,physics,rating,control_source,coordination}`, `modifiers/repair_teams`, `world/{content,flags,dispatch}`, and friends have no Bevy imports — fully unit-testable on native.
 11. **No hardcoded gameplay values.** All gameplay data (stats, icons, colours, sizes, behaviours) comes from TOML config, loaded into entities/components and sent over the network where the client needs it. The only acceptable hardcoded values are: (a) defaults applied while parsing a TOML file (`unwrap_or(...)`-style fallbacks), and (b) client-side placeholders shown while waiting for authoritative data from the server. If a value could plausibly be tuned by a designer, it belongs in TOML — never inline it "for now", and never add a hardcoded branch that can override what the config says.
 
 ---

--- a/pasm/spec/architecture/objectives.yaml
+++ b/pasm/spec/architecture/objectives.yaml
@@ -112,7 +112,7 @@ entities:
     implementation:
       status: declared
       paths: [src/world/config.rs, src/world/server.rs, src/console/comms/server.rs]
-      symbols: [TriggerAction, handle_ai_events]
+      symbols: [TriggerAction, tick_trigger_pipeline]
       tests: [cargo test]
 
   - component: objective-manager

--- a/pasm/spec/architecture/trigger-pipeline.yaml
+++ b/pasm/spec/architecture/trigger-pipeline.yaml
@@ -1,0 +1,214 @@
+# Trigger pipeline (issues #707-#719): how authored world events become
+# dispatched trigger actions on the host, each tick.
+#
+# Event flow (one host tick, systems chained in this order):
+#   external world events (AI combat / waypoint bridge messages, queued
+#   world-load / region / delayed-action events)
+#     -> world-event-collector            (collect_world_events)
+#     -> world-event-buffer-state         (WorldEventBuffer, per-tick)
+#     -> world-comms-template-injector    (inject_comms_templates)
+#     -> world-trigger-chaining-loop      (tick_trigger_pipeline:
+#          evaluate conditions -> dispatch_action table -> ActionCmds
+#          -> apply_dispatch_result, looped for same-tick chaining)
+#   world-delayed-action-scheduler        (tick_delayed_actions) runs after
+#   the loop and feeds the NEXT tick's buffer.
+#
+# Per-caller routing of dispatch-produced events: the chaining loop feeds
+# them to the next pass of the SAME tick; only the delayed-action scheduler
+# queues them for the NEXT tick. (The comms-response dispatch site also
+# pushes onto pending_world_events, but it runs in SimSet::Input, before
+# Physics, so the pipeline fires those events later the SAME tick.)
+#
+# This slice complements world-files.yaml, which owns the evaluator
+# (world-trigger-evaluator) and the action catalogue
+# (world-trigger-action-dispatcher); the entities here describe the pipeline
+# that drives them and the contracts that keep it extendable.
+entities:
+  - component: world-event-collector
+    core:
+      status: implemented
+      confidence: confirmed
+      title: World Event Collector
+      summary: Collects each tick's externally-sourced world events into the per-tick event buffer from three sources, in order - bridged AI combat and waypoint messages, events queued by world loads, region observers, and the previous tick's delayed actions, and one synthesised timer event once a world is loaded.
+      goals:
+        - every consumer of world events reads one buffer filled by one producer
+        - stale events cannot leak between ticks because the buffer is rebuilt every run
+      rationale:
+        - a single collection point keeps the trigger pipeline's inputs inspectable and keeps event-free ticks from marking runtime state changed
+      references:
+        - world-trigger-chaining-loop
+    architecture:
+      kind: event-bridge
+      authority: authoritative
+      owns: [world-event-buffer-state]
+      produces: [world-event-buffer-state]
+      runs_in: [host-browser-runtime]
+    implementation:
+      status: declared
+      paths: [src/world/server.rs]
+      symbols: [collect_world_events, AiEventReaders]
+      tests: [cargo test]
+    evidence:
+      - kind: test
+        reference: world_event_buffer_holds_only_current_tick_events
+        summary: The buffer holds exactly the current tick's events; stale events do not leak.
+      - kind: test
+        reference: tick_trigger_pipeline_is_a_noop_on_an_empty_world
+        summary: An event-free tick leaves the runtime and the buffer unmarked by change detection.
+
+  - state: world-event-buffer-state
+    core:
+      status: implemented
+      confidence: confirmed
+      title: World Event Buffer
+      summary: This tick's externally-sourced world events, valid for exactly one tick. Only external events enter it - the chaining loop's internally-produced flag and destruction events stay local to the loop, which is what restricts comms templates to firing from external events only.
+    architecture:
+      classification: authoritative
+      owner: world-event-collector
+      writers: [world-event-collector]
+    implementation:
+      status: declared
+      paths: [src/world/server.rs]
+      symbols: [WorldEventBuffer]
+      tests: [cargo test]
+
+  - component: world-comms-template-injector
+    core:
+      status: implemented
+      confidence: confirmed
+      title: World Comms Template Injector
+      summary: Auto-fires comms templates that match this tick's external events and injects the resulting messages onto the immediate comms channel. Ordered after event collection and before trigger dispatch, so it reads the same entity name bindings the trigger pipeline's tick-level snapshot sees.
+      rationale:
+        - running before dispatch means no spawn action has mutated the name map yet this tick, keeping template sender resolution deterministic
+    architecture:
+      kind: event-router
+      authority: authoritative
+      reads: [world-event-buffer-state, world-configuration-state, world-name-binding-state]
+      coordinates: [world-comms-runtime]
+      runs_in: [host-browser-runtime]
+    implementation:
+      status: declared
+      paths: [src/world/server.rs]
+      symbols: [inject_comms_templates]
+      tests: [cargo test]
+
+  - component: world-trigger-chaining-loop
+    core:
+      status: implemented
+      confidence: confirmed
+      title: World Trigger Chaining Loop
+      summary: Within one host tick, alternates trigger evaluation and action dispatch until a pass produces no new events, so chained triggers (a flag mutation firing a flag-watching trigger) resolve with zero frame latency. Bounded by a fixed pass cap of sixteen that breaks pathological trigger cycles with a warning instead of hanging the frame.
+      goals:
+        - chained scenario logic resolves in the same frame that caused it
+        - a mis-authored trigger cycle degrades to a logged cutoff, never a hang
+      rationale:
+        - "determinism contract: each pass is two-phase - every trigger condition is evaluated against the live flag stores before any fired action dispatches, so all triggers in a pass see the same values and their mutations become visible only to the next pass"
+        - "live-store freshness: action dispatch re-projects the live flag stores per action, never a pre-pass snapshot, so duplicate mutations preview correct before/after transitions and each boolean flip emits exactly one event"
+        - "the dispatch name map is rebuilt at the top of every pass, so an action can resolve an entity name that a spawn registered in an earlier pass of the same tick"
+        - "event routing is per-caller: this loop feeds produced events into its own next pass (same tick); the delayed-action scheduler queues them for the next tick; the comms-response site pushes onto pending_world_events from SimSet::Input, which the pipeline drains later the same tick"
+    architecture:
+      kind: evaluation-loop
+      authority: authoritative
+      reads: [world-event-buffer-state, world-flag-state, world-layer-runtime-state, world-name-binding-state]
+      coordinates: [world-trigger-evaluator, world-trigger-action-dispatcher]
+      runs_in: [host-browser-runtime]
+    implementation:
+      status: declared
+      paths: [src/world/server.rs, src/world/content.rs]
+      symbols: [tick_trigger_pipeline, MAX_CHAIN_PASSES, evaluate_single_trigger, apply_dispatch_result]
+      tests: [cargo test]
+    evidence:
+      - kind: test
+        reference: trigger_chain_exceeding_max_passes_stops_at_the_cap
+        summary: A chain longer than the cap performs exactly the capped number of passes, then breaks.
+      - kind: test
+        reference: set_flag_action_fires_on_flag_set_trigger_within_same_tick
+        summary: Chained triggers fire in the same Bevy frame as the mutation that caused them.
+      - kind: test
+        reference: flag_stores_handed_to_dispatch_are_live_within_a_pass
+        summary: Dispatch previews transitions against live stores, never a per-pass snapshot.
+      - kind: test
+        reference: single_trigger_dispatches_every_action_variant_in_list_order
+        summary: One trigger carrying every action variant dispatches them in authored list order.
+      - kind: test
+        reference: trigger_from_layer_missing_in_layer_map_reads_base_flags
+        summary: A trigger whose origin layer is missing from the layer map evaluates against the base flag store.
+
+  - component: trigger-dispatch-purity-contract
+    core:
+      status: implemented
+      confidence: confirmed
+      title: Trigger Dispatch Purity Contract
+      summary: The action-dispatch table is a pure, Bevy-free decision layer. It reads a read-only context and returns commands keyed by entity UUID strings, warnings as plain data, and destination-agnostic events; one impure applier turns those into ECS mutations for both world-trigger callers (immediate and delayed).
+      goals:
+        - every dispatch arm, including every failure path, is testable as a plain function call over plain data
+        - one dispatch table serves both world-trigger dispatch sites (immediate and delayed), so those two paths cannot drift apart; the comms-response site (handle_respond_to_message) remains an intentionally parallel inline dispatch, kept symmetric by exhaustive matching plus the comms parity test suite
+      rationale:
+        - "purity boundaries: entity targets are UUID strings (never ECS entity handles), logging is returned as warning strings, flag mutation is previewed rather than performed, and produced events are returned unrouted for the caller to place"
+        - "per-group layout: one exhaustive match routes each variant to its group function - mission state (dispatch_state_action), per-entity modifiers (dispatch_entity_modifier_action), world flags (dispatch_world_flag_action), destruction (dispatch_destroy_entity), spawning (dispatch_spawn_entity). The routing match and the applier are wildcard-free (compile-time exhaustive); each group function ends in an unreachable! guard, so routing a new variant into a group without adding its inner arm is a runtime panic caught by the group's should_panic test, not a compile error"
+        - "non-determinism is injected: the spawn UUID source and the entity template loader are seams on the context, so tests stub them and the module never touches the filesystem or the config cache"
+    architecture:
+      kind: purity-contract
+      authority: authoritative
+      coordinates: [world-trigger-action-dispatcher]
+      runs_in: [host-browser-runtime]
+    implementation:
+      status: declared
+      paths: [src/world/dispatch.rs, src/world/server.rs, src/entities/loader.rs]
+      symbols: [dispatch_action, dispatch_state_action, dispatch_entity_modifier_action, dispatch_world_flag_action, dispatch_destroy_entity, dispatch_spawn_entity, DispatchContext, DispatchResult, ActionCmd, TemplateLoader]
+      tests: [cargo test]
+    evidence:
+      - kind: test
+        reference: spawn_failed_template_load_does_not_consume_a_uuid_directly
+        summary: Failure paths are gated inside the pure layer, so the applier applies results unconditionally.
+
+  - component: trigger-action-extension-contract
+    core:
+      status: implemented
+      confidence: confirmed
+      title: Trigger Action Extension Contract
+      summary: The authored procedure for adding a new trigger action variant. Exhaustive matches in the dispatch table's routing match, the applier, the comms-response inline dispatch, and the parity enumeration mean the compiler walks the author to every site that must change; the one runtime-only gap is the group functions' unreachable! guards (covered by should_panic tests).
+      goals:
+        - declare the new variant on the TriggerAction enum and parse it from world TOML (src/world/config.rs)
+        - add a dispatch arm in the pure table (src/world/dispatch.rs), routed into the matching per-group function or a new group function for a new action family
+        - when the action needs a new ECS effect, add an ActionCmd variant and an applier arm (apply_dispatch_result in src/world/server.rs); actions that resolve to existing commands need no applier change
+        - add the variant's arm to the comms-response inline dispatch (handle_respond_to_message in src/console/comms/server.rs, an intentionally parallel match — the compiler forces this because that match is also exhaustive) and extend its parity enumeration tests so comms responses stay symmetric with world triggers
+        - add pure unit tests beside the dispatch table and pipeline tests beside the Bevy systems
+      rationale:
+        - keeping every match exhaustive turns "did I wire the new variant everywhere" into a compile error rather than a runtime gap
+      references:
+        - trigger-dispatch-purity-contract
+    architecture:
+      kind: authoring-contract
+      authority: authoritative
+      coordinates: [world-trigger-action-dispatcher]
+      runs_in: [host-browser-runtime]
+    implementation:
+      status: declared
+      paths: [src/world/config.rs, src/world/dispatch.rs, src/world/server.rs]
+      symbols: [TriggerAction, ActionCmd]
+      tests: [cargo test]
+
+  - component: world-delayed-action-scheduler
+    core:
+      status: implemented
+      confidence: confirmed
+      title: World Delayed Action Scheduler
+      summary: Holds trigger actions whose authored per-action delay has not yet elapsed and dispatches due ones through the same pure dispatch table as immediate actions. Its produced events queue for the next tick's buffer, because it runs after the chaining loop has already drained this tick's.
+      rationale:
+        - sharing the dispatch table with the immediate path means delayed actions gain every dispatch behaviour (including AI target revalidation) instead of drifting on a duplicated table
+    architecture:
+      kind: scheduler
+      authority: authoritative
+      reads: [world-flag-state, world-layer-runtime-state]
+      coordinates: [world-trigger-action-dispatcher, world-event-collector]
+      runs_in: [host-browser-runtime]
+    implementation:
+      status: declared
+      paths: [src/world/server.rs]
+      symbols: [tick_delayed_actions, DelayedAction]
+      tests: [cargo test]
+    evidence:
+      - kind: test
+        reference: delayed_action_dispatches_and_queues_event_for_next_tick
+        summary: A delayed action's produced events queue for the next tick, not the current pass.

--- a/src/ai/server.rs
+++ b/src/ai/server.rs
@@ -272,7 +272,7 @@ pub struct AiEntityDestroyed {
 /// Emitted by `advance_objective_cursors` when a ship reaches the waypoint its
 /// cursor is currently pointing at, immediately before the cursor advances.
 ///
-/// The world plugin reads this in `handle_ai_events` and turns it into a
+/// The world plugin reads this in `tick_trigger_pipeline` and turns it into a
 /// `WorldEvent::WaypointReached`, which drives `on_waypoint_reached` scenario
 /// triggers — the same event-bridge shape `AiEntityAttacked` /
 /// `AiEntityDestroyed` already use, so the AI module stays free of any

--- a/src/console/comms/server.rs
+++ b/src/console/comms/server.rs
@@ -149,7 +149,7 @@ pub(crate) fn handle_hail(
 
         // Route the Hailed event into the trigger system so that
         // on_hailed triggers (e.g. complete_objective, load_world)
-        // can fire. handle_ai_events drains pending_world_events
+        // can fire. tick_trigger_pipeline drains pending_world_events
         // in SimSet::Physics, which runs after SimSet::Input.
         runtime.pending_world_events.push(WorldEvent::Hailed {
             target_uuid: target_uuid.clone(),
@@ -294,19 +294,19 @@ pub(crate) fn handle_respond_to_message(
         // Fire response actions.
         //
         // PRD #397 fix 2: this dispatch is intentionally parallel to the
-        // per-action match in `handle_ai_events` below. Every `TriggerAction`
+        // per-action match in `tick_trigger_pipeline` below. Every `TriggerAction`
         // variant a trigger can fire must produce the same observable
         // effect when listed under a comms response. Comms responses do not
         // currently carry an originating sub-world layer (the `CommsTemplate`
         // type has no `origin_layer` field, unlike `TriggerState`), so all
         // layer-scoped operations resolve against the base world (`None`).
         // Flag-mutation transitions are pushed onto
-        // `runtime.pending_world_events` so `handle_ai_events` (later in the
+        // `runtime.pending_world_events` so `tick_trigger_pipeline` (later in the
         // same Update tick via `SimSet::Physics`) picks them up and fires
         // any chained `on_flag_set` / `on_flag_cleared` triggers.
         //
         // When adding a new `TriggerAction` variant, add an arm here AND in
-        // `handle_ai_events`. The `comms_response_dispatches_every_trigger_action_variant`
+        // `tick_trigger_pipeline`. The `comms_response_dispatches_every_trigger_action_variant`
         // parity test guards against drift.
         let origin_layer: Option<String> = None;
         let name_to_uuid_snapshot = runtime.name_to_uuid.clone();
@@ -776,7 +776,7 @@ pub(crate) fn handle_respond_to_message(
                     }
                     // Defer AiEntityDestroyed via Commands::queue so
                     // external consumers (and chained on_destroyed triggers
-                    // in handle_ai_events later this tick) observe the event.
+                    // in tick_trigger_pipeline later this tick) observe the event.
                     runtime
                         .pending_world_events
                         .push(WorldEvent::Destroyed { uuid: uuid.clone() });
@@ -820,7 +820,7 @@ pub(crate) fn handle_respond_to_message(
                         }
                     };
                     // Idempotent. No target re-validation needed for the
-                    // add path — see handle_ai_events for the rationale.
+                    // add path — see tick_trigger_pipeline for the rationale.
                     registry.0.add_enemy(faction_uuid, enemy_uuid);
                 }
                 TriggerAction::RemoveFactionEnemy { faction, enemy } => {
@@ -1180,7 +1180,7 @@ mod tests {
     // -- PRD #397 fix 2: comms-response action dispatch parity ----------------
     //
     // These tests assert that `handle_respond_to_message` dispatches every
-    // `TriggerAction` variant that `handle_ai_events` dispatches. The
+    // `TriggerAction` variant that `tick_trigger_pipeline` dispatches. The
     // "enumeration" test at the end matches on every variant of `TriggerAction`
     // so adding a new variant is a compile error until the new variant is
     // wired into both dispatch sites and a per-variant assertion is added.
@@ -1191,7 +1191,7 @@ mod tests {
     /// `apply_world_layer_changes` system is intentionally NOT wired in: we
     /// only assert that LoadWorld/UnloadWorld push commands into
     /// `PendingWorldLayerChanges`, matching the per-variant assertions used
-    /// by the `handle_ai_events` tests above.
+    /// by the `tick_trigger_pipeline` tests above.
     fn comms_parity_test_app() -> App {
         let mut app = comms_test_app();
         app.init_resource::<WorldLayerMap>()
@@ -1361,7 +1361,7 @@ mod tests {
                 e, WorldEvent::FlagSet { name, .. } if name == "comms_set"
             )),
             "SetWorldFlag from comms response must enqueue a FlagSet event \
-             for handle_ai_events to chain on"
+             for tick_trigger_pipeline to chain on"
         );
     }
 

--- a/src/console/comms/server.rs
+++ b/src/console/comms/server.rs
@@ -1477,10 +1477,10 @@ mod tests {
     }
 
     /// `RemoveFactionEnemy` re-validates every AI controller's target after a
-    /// successful removal (issue #710 gave the delayed path this too; the
-    /// audit for issue #722 found comms independently replicated it
-    /// correctly already). This test proves unifying comms onto the shared
-    /// `dispatch_action` table doesn't silently drop that behaviour: a comms
+    /// successful removal (issue #710 gave the delayed path this too; an
+    /// audit found comms independently replicated it correctly already).
+    /// This test proves unifying comms onto the shared `dispatch_action`
+    /// table doesn't silently drop that behaviour: a comms
     /// response that tears down a hostility must clear an in-progress AI
     /// engagement on the now-friendly target, exactly like
     /// `tick_trigger_pipeline`'s
@@ -1488,10 +1488,11 @@ mod tests {
     /// proves for the trigger path.
     #[test]
     fn comms_response_remove_faction_enemy_revalidates_ai_targets() {
-        use crate::ai_plugin::{AiPlugin, ShipAiMemory};
+        use crate::ai_plugin::AiPlugin;
         use crate::entities::spawner::FactionComponent;
         use crate::entity_config::BehaviourConfig;
         use crate::entity_spawner::BehaviourSection;
+        use crate::weapons_plugin::WeaponsTarget;
 
         // Bundled TOML faction UUIDs (see `world::server::tests::{fed,harrow}_faction_uuid`).
         let federation_uuid =
@@ -1551,7 +1552,9 @@ mod tests {
             FactionComponent(federation_uuid),
         ));
 
-        // Harrow-factioned NPC with an AI behaviour.
+        // Harrow-factioned NPC with an AI behaviour and its authoritative
+        // Tactical lock (post-#702, WeaponsTarget — not a ShipAiMemory
+        // mirror — is what revalidate_ai_targets_after_faction_change clears).
         let npc_uuid_str = "22222222-2222-2222-2222-222222222222";
         let npc_entity = app
             .world_mut()
@@ -1560,19 +1563,20 @@ mod tests {
                 EntityUuid(npc_uuid_str.to_string()),
                 BehaviourSection(BehaviourConfig::default()),
                 FactionComponent(harrow_uuid),
+                WeaponsTarget::default(),
             ))
             .id();
 
-        // Let `AiPlugin` attach `AiControllerComponent` + `ShipAiMemory`.
+        // Let `AiPlugin` attach the `AiControllerComponent` marker.
         app.update();
 
-        // Seed the engagement: NPC's ShipAiMemory.target = player.
+        // Seed the engagement: NPC's WeaponsTarget locks the player.
         {
-            let mut mem = app
+            let mut lock = app
                 .world_mut()
-                .get_mut::<ShipAiMemory>(npc_entity)
-                .expect("ShipAiMemory must be attached");
-            mem.0.target = Some(uuid::Uuid::parse_str(player_uuid_str).unwrap());
+                .get_mut::<WeaponsTarget>(npc_entity)
+                .expect("WeaponsTarget must be attached");
+            lock.0 = Some(player_uuid_str.to_string());
         }
 
         // Install the comms template: one response carries all three
@@ -1661,12 +1665,12 @@ mod tests {
         );
         let _ = tick(&mut app);
 
-        // The NPC's ShipAiMemory.target must be cleared: Harrow no longer
+        // The NPC's WeaponsTarget lock must be cleared: Harrow no longer
         // considers Federation hostile after the response's third action.
-        let mem = app.world().get::<ShipAiMemory>(npc_entity).unwrap();
+        let lock = app.world().get::<WeaponsTarget>(npc_entity).unwrap();
         assert_eq!(
-            mem.0.target, None,
-            "comms RemoveFactionEnemy must clear memory.target when the target is no longer hostile"
+            lock.0, None,
+            "comms RemoveFactionEnemy must clear WeaponsTarget when the target is no longer hostile"
         );
     }
 

--- a/src/console/comms/server.rs
+++ b/src/console/comms/server.rs
@@ -15,10 +15,10 @@ use crate::world::server::{CommsInboxRes, WorldContentRuntime};
 use crate::entity_spawner::EntityUuid;
 use crate::messages::{CommsMessage, GamePhase};
 use crate::world::content::{
-    evaluate_comms_templates, ActiveDialogue, PendingFollowUp, TriggerAction, WorldEvent,
+    evaluate_comms_templates, ActiveDialogue, PendingFollowUp, WorldEvent,
 };
 use crate::world::server::{
-    CommsChannel2Event, OnScreenMessage, ShipModifiersParams, WorldLayerChange, WorldLayerParams,
+    CommsChannel2Event, OnScreenMessage, ShipModifiersParams, WorldLayerParams,
 };
 
 pub struct CommsConsolePlugin;
@@ -293,582 +293,96 @@ pub(crate) fn handle_respond_to_message(
 
         // Fire response actions.
         //
-        // PRD #397 fix 2: this dispatch is intentionally parallel to the
-        // per-action match in `tick_trigger_pipeline` below. Every `TriggerAction`
-        // variant a trigger can fire must produce the same observable
-        // effect when listed under a comms response. Comms responses do not
-        // currently carry an originating sub-world layer (the `CommsTemplate`
-        // type has no `origin_layer` field, unlike `TriggerState`), so all
-        // layer-scoped operations resolve against the base world (`None`).
-        // Flag-mutation transitions are pushed onto
-        // `runtime.pending_world_events` so `tick_trigger_pipeline` (later in the
-        // same Update tick via `SimSet::Physics`) picks them up and fires
-        // any chained `on_flag_set` / `on_flag_cleared` triggers.
-        //
-        // When adding a new `TriggerAction` variant, add an arm here AND in
-        // `tick_trigger_pipeline`. The `comms_response_dispatches_every_trigger_action_variant`
-        // parity test guards against drift.
+        // Issue #722: dispatched through the shared `world::dispatch` table
+        // (issue #708/#710), the same table `tick_trigger_pipeline` and
+        // `tick_delayed_actions` use. Comms responses do not carry an
+        // originating sub-world layer (the `CommsTemplate` type has no
+        // `origin_layer` field, unlike `TriggerState`), so `origin_layer` is
+        // always `None` here — every layer-scoped action resolves against
+        // the base world. This is a single-shot dispatch per response
+        // action, not a chaining pass: `new_events` are routed onto
+        // `runtime.pending_world_events` so `tick_trigger_pipeline` (later in
+        // the same Update tick via `SimSet::Physics`, since this handler
+        // runs in `SimSet::Input`) picks them up and fires any chained
+        // `on_flag_set` / `on_flag_cleared` / `on_destroyed` triggers —
+        // reproducing the previous same-tick-in-practice timing exactly.
         let origin_layer: Option<String> = None;
         let name_to_uuid_snapshot = runtime.name_to_uuid.clone();
-        // Build reverse map (UUID → entity name) so we can associate objectives
-        // added by comms responses with the sender entity.
+        // Build reverse map (UUID → entity name) so `AddObjective`'s
+        // empty-`targets` fallback can resolve to the comms sender's name.
+        // Comms has no `TriggerState.entity_name` to fall back to instead —
+        // this pre-resolved name is what gets passed as
+        // `DispatchContext::entity_name` below.
         let uuid_to_name: std::collections::HashMap<&str, &str> = name_to_uuid_snapshot
             .iter()
             .map(|(name, uuid)| (uuid.as_str(), name.as_str()))
             .collect();
-        // Build UUID → ECS Entity map once per response so the six
-        // per-entity modifier/flag arms below can resolve their `entity`
+        // Build UUID → ECS Entity map once per response so the applier's
+        // per-entity modifier/flag commands can resolve their `entity`
         // target in O(1) instead of scanning `entity_uuid_query` each time.
-        // Used by `ApplyModifier` / `RemoveModifier` / `ApplyFlag` /
-        // `RemoveFlag` / `ApplyIntModifier` / `RemoveIntModifier` to write
-        // to the target entity's per-entity `ShipModifiers` Component.
         let uuid_to_entity: std::collections::HashMap<String, Entity> = entity_uuid_query
             .iter()
             .map(|(ent, uuid_comp)| (uuid_comp.0.clone(), ent))
             .collect();
         let sender_uuid = inbox.0.sender_uuid_for(message_id);
+        let sender_entity_name: Option<String> = sender_uuid
+            .as_deref()
+            .and_then(|suid| uuid_to_name.get(suid).copied())
+            .map(String::from);
+
+        let empty_anchors: std::collections::HashMap<String, [f32; 3]> =
+            std::collections::HashMap::new();
+        // Same template source `tick_trigger_pipeline` / `tick_delayed_actions`
+        // use (issue #715): built once per system run, config cache first,
+        // filesystem fallback on native. Collapses comms's old three-message
+        // cfg-split loader (cache / native-fs / wasm) into this one path.
+        let template_loader = crate::entity_loader::WasmTemplateLoader;
+
         for action in &response.actions {
-            match action {
-                TriggerAction::AddObjective {
-                    id,
-                    text,
-                    mandatory,
-                    targets,
-                    directive,
-                    utility,
-                    source,
-                } => {
-                    // Explicit targets win; otherwise fall back to the comms
-                    // sender so legacy single-entity objectives still mark up.
-                    let resolved = if targets.is_empty() {
-                        sender_uuid
-                            .clone()
-                            .and_then(|suid| uuid_to_name.get(suid.as_str()).copied())
-                            .map(String::from)
-                            .into_iter()
-                            .collect()
-                    } else {
-                        targets.clone()
-                    };
-                    objectives.0.add_full(
-                        id,
-                        text,
-                        *mandatory,
-                        resolved,
-                        directive.clone(),
-                        utility.clone(),
-                        source.clone(),
-                    );
-                }
-                TriggerAction::CompleteObjective { id } => {
-                    objectives.0.complete(id);
-                }
-                TriggerAction::FailObjective { id } => {
-                    objectives.0.fail(id);
-                }
-                TriggerAction::SetAiState {
-                    entity,
-                    state,
-                    target: _,
-                } => {
-                    // No-op in doctrine-based AI (issue #572). FSM state slots are
-                    // gone; NPC behaviour is now driven by the scored doctrine pool.
-                    bevy::log::warn!(
-                        "handle_respond_to_message: SetAiState('{entity}' → '{state}') ignored — doctrine-based AI"
-                    );
-                }
-                TriggerAction::ApplyModifier {
-                    entity,
-                    tag,
-                    slot,
-                    bonus,
-                } => {
-                    let Some(uuid) = name_to_uuid_snapshot.get(entity) else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: ApplyModifier: unknown entity name '{entity}'"
-                        );
-                        continue;
-                    };
-                    let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: ApplyModifier: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                        );
-                        continue;
-                    };
-                    let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: ApplyModifier: entity '{entity}' has no ShipModifiers component"
-                        );
-                        continue;
-                    };
-                    mods.add_or_update(crate::modifiers::Modifier {
-                        source: crate::messages::ModifierSource::World {
-                            id: "world".to_string(),
-                            tag: tag.clone(),
-                        },
-                        slot: slot.clone(),
-                        bonus: *bonus,
-                    });
-                }
-                TriggerAction::RemoveModifier { entity, tag, slot } => {
-                    let Some(uuid) = name_to_uuid_snapshot.get(entity) else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: RemoveModifier: unknown entity name '{entity}'"
-                        );
-                        continue;
-                    };
-                    let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: RemoveModifier: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                        );
-                        continue;
-                    };
-                    let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: RemoveModifier: entity '{entity}' has no ShipModifiers component"
-                        );
-                        continue;
-                    };
-                    mods.remove(
-                        &crate::messages::ModifierSource::World {
-                            id: "world".to_string(),
-                            tag: tag.clone(),
-                        },
-                        slot,
-                    );
-                }
-                TriggerAction::ApplyFlag { entity, tag, kind } => {
-                    let Some(uuid) = name_to_uuid_snapshot.get(entity) else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: ApplyFlag: unknown entity name '{entity}'"
-                        );
-                        continue;
-                    };
-                    let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: ApplyFlag: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                        );
-                        continue;
-                    };
-                    let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: ApplyFlag: entity '{entity}' has no ShipModifiers component"
-                        );
-                        continue;
-                    };
-                    mods.add_flag(
-                        crate::messages::ModifierSource::World {
-                            id: "world".to_string(),
-                            tag: tag.clone(),
-                        },
-                        kind.clone(),
-                    );
-                }
-                TriggerAction::RemoveFlag { entity, tag, kind } => {
-                    let Some(uuid) = name_to_uuid_snapshot.get(entity) else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: RemoveFlag: unknown entity name '{entity}'"
-                        );
-                        continue;
-                    };
-                    let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: RemoveFlag: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                        );
-                        continue;
-                    };
-                    let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: RemoveFlag: entity '{entity}' has no ShipModifiers component"
-                        );
-                        continue;
-                    };
-                    mods.remove_flag(
-                        crate::messages::ModifierSource::World {
-                            id: "world".to_string(),
-                            tag: tag.clone(),
-                        },
-                        kind.clone(),
-                    );
-                }
-                TriggerAction::ApplyIntModifier {
-                    entity,
-                    tag,
-                    slot,
-                    bonus,
-                } => {
-                    let Some(uuid) = name_to_uuid_snapshot.get(entity) else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: ApplyIntModifier: unknown entity name '{entity}'"
-                        );
-                        continue;
-                    };
-                    let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: ApplyIntModifier: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                        );
-                        continue;
-                    };
-                    let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: ApplyIntModifier: entity '{entity}' has no ShipModifiers component"
-                        );
-                        continue;
-                    };
-                    mods.add_or_update_int(crate::modifiers::IntModifier {
-                        source: crate::messages::ModifierSource::World {
-                            id: "world".to_string(),
-                            tag: tag.clone(),
-                        },
-                        slot: slot.clone(),
-                        bonus: *bonus,
-                    });
-                }
-                TriggerAction::RemoveIntModifier { entity, tag, slot } => {
-                    let Some(uuid) = name_to_uuid_snapshot.get(entity) else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: RemoveIntModifier: unknown entity name '{entity}'"
-                        );
-                        continue;
-                    };
-                    let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: RemoveIntModifier: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                        );
-                        continue;
-                    };
-                    let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: RemoveIntModifier: entity '{entity}' has no ShipModifiers component"
-                        );
-                        continue;
-                    };
-                    mods.remove_int(
-                        &crate::messages::ModifierSource::World {
-                            id: "world".to_string(),
-                            tag: tag.clone(),
-                        },
-                        slot,
-                    );
-                }
-                TriggerAction::GameOver { message } => {
-                    let reason = message.clone().unwrap_or_default();
-                    if let Some(ref mut gr) = game_over_reason {
-                        gr.0 = Some(reason);
-                    }
-                    if let Some(ref mut ns) = next_state {
-                        ns.set(GamePhase::GameOver);
-                    }
-                }
-                TriggerAction::LoadWorld { path } => {
-                    if let Some(ref mut lc) = world_layers.pending_layers {
-                        // Comms responses load against the base world
-                        // (loader_path = None) since CommsTemplate has no
-                        // origin_layer concept today.
-                        lc.0.push(WorldLayerChange::Load {
-                            path: path.clone(),
-                            loader_path: origin_layer.clone(),
-                        });
-                    }
-                }
-                TriggerAction::UnloadWorld { path } => {
-                    if let Some(ref mut lc) = world_layers.pending_layers {
-                        lc.0.push(WorldLayerChange::Unload(path.clone()));
-                    }
-                }
-                TriggerAction::SetWorldFlag { name } => {
-                    if let Some((target_layer, stripped, before, after)) =
-                        crate::world::server::mutate_world_flag(
-                            &mut runtime.flags,
-                            world_layers.layer_map.as_deref_mut().map(|lm| &mut lm.0),
-                            &origin_layer,
-                            name,
-                            crate::world::server::FlagMutation::Set,
-                        )
-                    {
-                        crate::world::server::emit_flag_transition(
-                            &mut runtime.pending_world_events,
-                            &stripped,
-                            &target_layer,
-                            before,
-                            after,
-                        );
-                    }
-                }
-                TriggerAction::ClearWorldFlag { name } => {
-                    if let Some((target_layer, stripped, before, after)) =
-                        crate::world::server::mutate_world_flag(
-                            &mut runtime.flags,
-                            world_layers.layer_map.as_deref_mut().map(|lm| &mut lm.0),
-                            &origin_layer,
-                            name,
-                            crate::world::server::FlagMutation::Clear,
-                        )
-                    {
-                        crate::world::server::emit_flag_transition(
-                            &mut runtime.pending_world_events,
-                            &stripped,
-                            &target_layer,
-                            before,
-                            after,
-                        );
-                    }
-                }
-                TriggerAction::IncrementWorldFlag { name, by } => {
-                    if let Some((target_layer, stripped, before, after)) =
-                        crate::world::server::mutate_world_flag(
-                            &mut runtime.flags,
-                            world_layers.layer_map.as_deref_mut().map(|lm| &mut lm.0),
-                            &origin_layer,
-                            name,
-                            crate::world::server::FlagMutation::Increment(*by),
-                        )
-                    {
-                        crate::world::server::emit_flag_transition(
-                            &mut runtime.pending_world_events,
-                            &stripped,
-                            &target_layer,
-                            before,
-                            after,
-                        );
-                    }
-                }
-                TriggerAction::SetWorldFlagValue { name, value } => {
-                    if let Some((target_layer, stripped, before, after)) =
-                        crate::world::server::mutate_world_flag(
-                            &mut runtime.flags,
-                            world_layers.layer_map.as_deref_mut().map(|lm| &mut lm.0),
-                            &origin_layer,
-                            name,
-                            crate::world::server::FlagMutation::SetValue(*value),
-                        )
-                    {
-                        crate::world::server::emit_flag_transition(
-                            &mut runtime.pending_world_events,
-                            &stripped,
-                            &target_layer,
-                            before,
-                            after,
-                        );
-                    }
-                }
-                TriggerAction::SpawnEntity {
-                    template_path,
-                    name,
-                    anchor,
-                    position,
-                    rotation,
-                    scale,
-                    groups: _,
-                } => {
-                    let pos_arr: [f32; 3] = if let Some(pos) = position {
-                        *pos
-                    } else if let Some(anchor_name) = anchor {
-                        // origin_layer = None: resolve against base world anchors only.
-                        let lookup = world_layers
-                            .base_world_config
-                            .as_ref()
-                            .and_then(|wc| wc.anchors.get(anchor_name).copied());
-                        match lookup {
-                            Some(p) => p,
-                            None => {
-                                bevy::log::warn!(
-                                    "handle_respond_to_message: SpawnEntity '{name}' anchor '{anchor_name}' not found"
-                                );
-                                continue;
-                            }
-                        }
-                    } else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: SpawnEntity '{name}' has neither anchor nor position"
-                        );
-                        continue;
-                    };
+            let layers =
+                crate::world::server::project_layer_views(world_layers.layer_map.as_deref());
+            let result = {
+                let ctx = crate::world::dispatch::DispatchContext {
+                    origin_layer: origin_layer.clone(),
+                    entity_name: sender_entity_name.clone(),
+                    name_to_uuid: &name_to_uuid_snapshot,
+                    base_flags: &runtime.flags,
+                    layers: &layers,
+                    base_anchors: world_layers
+                        .base_world_config
+                        .as_ref()
+                        .map(|wc| &wc.anchors)
+                        .unwrap_or(&empty_anchors),
+                    factions: faction_dispatch.registry.as_deref().map(|r| &r.0),
+                    uuid_source: &crate::entity_loader::assign_uuid,
+                    template_loader: &template_loader,
+                };
+                crate::world::dispatch::dispatch_action(action, &ctx)
+            };
 
-                    let config_cache = crate::config_cache::get_config_cache();
-                    let template_inst = crate::world::config::WorldEntity {
-                        template_path: template_path.clone(),
-                        ..Default::default()
-                    };
-                    let entity_config = match crate::entity_loader::resolve_entity(
-                        &template_inst,
-                        &config_cache,
-                    ) {
-                        Ok(c) => c,
-                        Err(e) => {
-                            #[cfg(not(target_arch = "wasm32"))]
-                            {
-                                match std::fs::read_to_string(template_path) {
-                                    Ok(toml_str) => {
-                                        match crate::entity_config::EntityConfig::from_toml(
-                                            &toml_str,
-                                        ) {
-                                            Ok(c) => c,
-                                            Err(err) => {
-                                                bevy::log::warn!(
-                                                    "handle_respond_to_message: SpawnEntity '{name}' template '{template_path}' parse error: {err:?}"
-                                                );
-                                                continue;
-                                            }
-                                        }
-                                    }
-                                    Err(_) => {
-                                        bevy::log::warn!(
-                                            "handle_respond_to_message: SpawnEntity '{name}' template '{template_path}' not in cache nor on disk: {e}"
-                                        );
-                                        continue;
-                                    }
-                                }
-                            }
-                            #[cfg(target_arch = "wasm32")]
-                            {
-                                bevy::log::warn!(
-                                    "handle_respond_to_message: SpawnEntity '{name}' template '{template_path}' not in cache: {e}"
-                                );
-                                continue;
-                            }
-                        }
-                    };
-
-                    let uuid = crate::entity_loader::assign_uuid();
-                    let pos_vec = Vec3::new(pos_arr[0], pos_arr[1], pos_arr[2]);
-                    let spawned = crate::entity_spawner::spawn_entity(
-                        &mut commands,
-                        &entity_config,
-                        pos_vec,
-                        uuid.clone(),
-                        None,
-                    );
-
-                    if rotation.is_some() || scale.is_some() {
-                        let [rx, ry, rz] = rotation.unwrap_or([0.0, 0.0, 0.0]);
-                        let quat = Quat::from_euler(EulerRot::XYZ, rx, ry, rz);
-                        let [sx, sy, sz] = scale.unwrap_or([1.0, 1.0, 1.0]);
-                        let scale_vec = Vec3::new(sx, sy, sz);
-                        commands.entity(spawned).insert(Transform {
-                            translation: pos_vec,
-                            rotation: quat,
-                            scale: scale_vec,
-                        });
-                    }
-
-                    runtime.name_to_uuid.insert(name.clone(), uuid);
-                    // origin_layer = None => entity is not attached to any
-                    // sub-world layer's spawned_entities list. It persists
-                    // for the session (matches base-world trigger semantics).
-                }
-                TriggerAction::DestroyEntity { entity } => {
-                    let uuid = match name_to_uuid_snapshot.get(entity) {
-                        Some(u) => u.clone(),
-                        None => {
-                            bevy::log::warn!(
-                                "handle_respond_to_message: DestroyEntity: unknown entity name '{entity}'"
-                            );
-                            continue;
-                        }
-                    };
-                    let mut target_entity: Option<Entity> = None;
-                    for (ent, uuid_comp) in entity_uuid_query.iter() {
-                        if uuid_comp.0 == uuid {
-                            target_entity = Some(ent);
-                            break;
-                        }
-                    }
-                    // Defer AiEntityDestroyed via Commands::queue so
-                    // external consumers (and chained on_destroyed triggers
-                    // in tick_trigger_pipeline later this tick) observe the event.
-                    runtime
-                        .pending_world_events
-                        .push(WorldEvent::Destroyed { uuid: uuid.clone() });
-                    let msg_uuid = uuid.clone();
-                    commands.queue(move |world: &mut World| {
-                        if let Some(mut msgs) = world
-                            .get_resource_mut::<Messages<crate::ai_plugin::AiEntityDestroyed>>()
-                        {
-                            msgs.write(crate::ai_plugin::AiEntityDestroyed {
-                                entity_uuid: msg_uuid,
-                            });
-                        }
-                    });
-                    if let Some(ent) = target_entity {
-                        commands.entity(ent).try_despawn();
-                    }
-                }
-                TriggerAction::AddFactionEnemy { faction, enemy } => {
-                    let Some(registry) = faction_dispatch.registry.as_deref_mut() else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: AddFactionEnemy skipped: FactionRegistryResource not present"
-                        );
-                        continue;
-                    };
-                    let faction_uuid = match registry.0.uuid_by_name(faction) {
-                        Some(u) => u,
-                        None => {
-                            bevy::log::warn!(
-                                "handle_respond_to_message: AddFactionEnemy: unknown faction name '{faction}'"
-                            );
-                            continue;
-                        }
-                    };
-                    let enemy_uuid = match registry.0.uuid_by_name(enemy) {
-                        Some(u) => u,
-                        None => {
-                            bevy::log::warn!(
-                                "handle_respond_to_message: AddFactionEnemy: unknown enemy faction name '{enemy}'"
-                            );
-                            continue;
-                        }
-                    };
-                    // Idempotent. No target re-validation needed for the
-                    // add path — see tick_trigger_pipeline for the rationale.
-                    registry.0.add_enemy(faction_uuid, enemy_uuid);
-                }
-                TriggerAction::RemoveFactionEnemy { faction, enemy } => {
-                    let Some(registry) = faction_dispatch.registry.as_deref_mut() else {
-                        bevy::log::warn!(
-                            "handle_respond_to_message: RemoveFactionEnemy skipped: FactionRegistryResource not present"
-                        );
-                        continue;
-                    };
-                    let faction_uuid = match registry.0.uuid_by_name(faction) {
-                        Some(u) => u,
-                        None => {
-                            bevy::log::warn!(
-                                "handle_respond_to_message: RemoveFactionEnemy: unknown faction name '{faction}'"
-                            );
-                            continue;
-                        }
-                    };
-                    let enemy_uuid = match registry.0.uuid_by_name(enemy) {
-                        Some(u) => u,
-                        None => {
-                            bevy::log::warn!(
-                                "handle_respond_to_message: RemoveFactionEnemy: unknown enemy faction name '{enemy}'"
-                            );
-                            continue;
-                        }
-                    };
-                    let removed = registry.0.remove_enemy(faction_uuid, enemy_uuid);
-                    if removed {
-                        let ai_factions: Vec<(uuid::Uuid, uuid::Uuid)> = ai_query
-                            .iter()
-                            .filter_map(|(uid, _, fc)| {
-                                let self_uuid = uuid::Uuid::parse_str(&uid.0).ok()?;
-                                fc.map(|fc| (self_uuid, fc.0))
-                            })
-                            .collect();
-                        let uuid_to_faction = crate::world::server::build_uuid_to_faction(
-                            &faction_dispatch.non_ai_factions,
-                            &ai_factions,
-                        );
-                        crate::world::server::revalidate_ai_targets_after_faction_change(
-                            &mut ai_query,
-                            &registry.0,
-                            &uuid_to_faction,
-                        );
-                    }
-                }
-            }
+            // Single-shot dispatch, not a chaining pass — unlike
+            // `tick_trigger_pipeline` there is no within-tick loop here, so
+            // `new_events` always go onto `runtime.pending_world_events` for
+            // `tick_trigger_pipeline` to observe next, exactly like
+            // `tick_delayed_actions` does.
+            let mut new_events: Vec<WorldEvent> = Vec::new();
+            crate::world::server::apply_dispatch_result(
+                result,
+                "handle_respond_to_message",
+                &mut new_events,
+                &uuid_to_entity,
+                &mut runtime,
+                &mut objectives,
+                &mut commands,
+                &mut ship_modifiers,
+                world_layers.pending_layers.as_deref_mut(),
+                world_layers.layer_map.as_deref_mut(),
+                next_state.as_deref_mut(),
+                game_over_reason.as_deref_mut(),
+                &mut faction_dispatch,
+                &mut ai_query,
+            );
+            runtime.pending_world_events.extend(new_events);
         }
 
         // Record the chosen response on the inbox message.
@@ -1168,7 +682,7 @@ mod tests {
     // `pub(crate)`) and is imported here rather than duplicated.
     use crate::messages::{ClientMessage, CommsContact, ServerMessage};
     use crate::world::content::{
-        CommsDialogueNode, CommsResponse, CommsTemplateState, TriggerCondition,
+        CommsDialogueNode, CommsResponse, CommsTemplateState, TriggerAction, TriggerCondition,
     };
     use crate::world::server::{
         tests::{
@@ -1604,9 +1118,14 @@ mod tests {
 
     #[test]
     fn comms_response_dispatches_spawn_entity() {
-        use crate::entities::spawner::EntityUuid;
+        use crate::entities::spawner::{EntityName, EntityUuid};
 
         let template_path = write_spawn_template_fixture();
+        // Issue #722 fix 3+4: comms's old inline SpawnEntity match arm
+        // destructured `groups: _` (discarding them) and never patched the
+        // spawned entity's `EntityName` with the response's `name`. Unifying
+        // onto the shared `dispatch_spawn_entity` table fixes both — assert
+        // on them here since this test predates the fix.
         let app = fire_response_with_actions(vec![TriggerAction::SpawnEntity {
             template_path,
             name: "comms_spawn".into(),
@@ -1614,7 +1133,7 @@ mod tests {
             position: Some([5.0, 0.0, 9.0]),
             rotation: None,
             scale: None,
-            groups: vec![],
+            groups: vec!["wave_1".into()],
         }]);
 
         let uuid = app
@@ -1625,16 +1144,38 @@ mod tests {
             .cloned()
             .expect("SpawnEntity from comms response must register name_to_uuid");
 
+        // Fix 3: the `groups` field must register the entity for
+        // `OnAllDestroyed`-style tracking, not be silently discarded.
+        let groups = app
+            .world()
+            .resource::<WorldContentRuntime>()
+            .entity_groups
+            .clone();
+        assert!(
+            groups
+                .get("wave_1")
+                .is_some_and(|members| members.contains("comms_spawn")),
+            "SpawnEntity's authored groups must register in entity_groups: got {groups:?}"
+        );
+
         let mut app = app;
         let mut q = app
             .world_mut()
-            .query::<(&EntityUuid, &bevy::prelude::Transform)>();
+            .query::<(&EntityUuid, &bevy::prelude::Transform, Option<&EntityName>)>();
         let mut found = false;
-        for (eu, t) in q.iter(app.world()) {
+        for (eu, t, entity_name) in q.iter(app.world()) {
             if eu.0 == uuid {
                 found = true;
                 assert!((t.translation.x - 5.0).abs() < 1e-3);
                 assert!((t.translation.z - 9.0).abs() < 1e-3);
+                // Fix 4: the response's `name` must patch the spawned
+                // entity's display name, not leave the template's own
+                // (the fixture template carries no `name` at all).
+                assert_eq!(
+                    entity_name.map(|n| n.0.as_str()),
+                    Some("comms_spawn"),
+                    "SpawnEntity must patch EntityName with the response's name field"
+                );
             }
         }
         assert!(found, "spawned entity must exist in ECS");
@@ -1793,10 +1334,18 @@ mod tests {
     }
 
     /// Exhaustive enumeration: matches on every `TriggerAction` variant and
-    /// drives it through `handle_respond_to_message`, asserting that *some*
-    /// observable side-effect occurs. Adding a new variant without wiring it
-    /// into the response dispatch will be caught here as either a compile
-    /// error (missing arm) or an assertion failure (no side-effect).
+    /// drives it through `handle_respond_to_message`, asserting that dispatch
+    /// completes without panicking for every variant in a single response.
+    ///
+    /// Issue #722: `handle_respond_to_message` no longer hand-duplicates a
+    /// per-variant match — it dispatches through the shared
+    /// `world::dispatch::dispatch_action` table, same as `tick_trigger_pipeline`
+    /// / `tick_delayed_actions`. The exhaustive match below is no longer a
+    /// guard on production dispatch code (there is none left to drift here);
+    /// it exists purely so that adding a new `TriggerAction` variant is a
+    /// compile error in *this test*, forcing the author to update
+    /// `enumerate_variants` and add a representative instance — a reminder to
+    /// extend coverage, not a correctness guard on comms-specific logic.
     #[test]
     fn comms_response_dispatches_every_trigger_action_variant() {
         // Build one representative instance of every variant. The match below
@@ -1925,6 +1474,200 @@ mod tests {
         // a single response.
         let variants = enumerate_variants();
         let _ = fire_response_with_actions(variants);
+    }
+
+    /// `RemoveFactionEnemy` re-validates every AI controller's target after a
+    /// successful removal (issue #710 gave the delayed path this too; the
+    /// audit for issue #722 found comms independently replicated it
+    /// correctly already). This test proves unifying comms onto the shared
+    /// `dispatch_action` table doesn't silently drop that behaviour: a comms
+    /// response that tears down a hostility must clear an in-progress AI
+    /// engagement on the now-friendly target, exactly like
+    /// `tick_trigger_pipeline`'s
+    /// `remove_faction_enemy_action_clears_blackboard_target_when_target_becomes_friendly`
+    /// proves for the trigger path.
+    #[test]
+    fn comms_response_remove_faction_enemy_revalidates_ai_targets() {
+        use crate::ai_plugin::{AiPlugin, ShipAiMemory};
+        use crate::entities::spawner::FactionComponent;
+        use crate::entity_config::BehaviourConfig;
+        use crate::entity_spawner::BehaviourSection;
+
+        // Bundled TOML faction UUIDs (see `world::server::tests::{fed,harrow}_faction_uuid`).
+        let federation_uuid =
+            uuid::Uuid::parse_str("aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa").unwrap();
+        let harrow_uuid = uuid::Uuid::parse_str("cccccccc-3333-4333-8333-cccccccccccc").unwrap();
+
+        let station_uuid = "station-parity-refe-uuid";
+        let mut app = comms_parity_test_app();
+        app.add_plugins(AiPlugin)
+            .insert_resource(crate::config_cache::FactionRegistryResource(
+                crate::config_cache::get_faction_registry(),
+            ));
+
+        push_msg(
+            &mut app,
+            "captain",
+            ClientMessage::Identify {
+                token: "captain".into(),
+                name: "Alice".into(),
+            },
+        );
+        tick(&mut app);
+        push_msg(
+            &mut app,
+            "captain",
+            ClientMessage::SelectStation {
+                station: "Captain".into(),
+            },
+        );
+        tick(&mut app);
+        push_msg(
+            &mut app,
+            "comms",
+            ClientMessage::Identify {
+                token: "comms".into(),
+                name: "Uhura".into(),
+            },
+        );
+        tick(&mut app);
+        push_msg(
+            &mut app,
+            "comms",
+            ClientMessage::SelectStation {
+                station: "Comms".into(),
+            },
+        );
+        tick(&mut app);
+        push_msg(&mut app, "captain", ClientMessage::SetReady { ready: true });
+        push_msg(&mut app, "comms", ClientMessage::SetReady { ready: true });
+        tick(&mut app);
+
+        // Federation-factioned "player ship".
+        let player_uuid_str = "11111111-1111-1111-1111-111111111111";
+        app.world_mut().spawn((
+            Transform::from_xyz(0.0, 0.0, 0.0),
+            EntityUuid(player_uuid_str.to_string()),
+            FactionComponent(federation_uuid),
+        ));
+
+        // Harrow-factioned NPC with an AI behaviour.
+        let npc_uuid_str = "22222222-2222-2222-2222-222222222222";
+        let npc_entity = app
+            .world_mut()
+            .spawn((
+                Transform::from_xyz(10.0, 0.0, 0.0),
+                EntityUuid(npc_uuid_str.to_string()),
+                BehaviourSection(BehaviourConfig::default()),
+                FactionComponent(harrow_uuid),
+            ))
+            .id();
+
+        // Let `AiPlugin` attach `AiControllerComponent` + `ShipAiMemory`.
+        app.update();
+
+        // Seed the engagement: NPC's ShipAiMemory.target = player.
+        {
+            let mut mem = app
+                .world_mut()
+                .get_mut::<ShipAiMemory>(npc_entity)
+                .expect("ShipAiMemory must be attached");
+            mem.0.target = Some(uuid::Uuid::parse_str(player_uuid_str).unwrap());
+        }
+
+        // Install the comms template: one response carries all three
+        // actions, dispatched in order — establish mutual hostility, then
+        // tear it back down, all from a single `RespondToMessage`.
+        {
+            let _ = spawn_modifier_target(&mut app, "starbase_alpha", station_uuid);
+            let mut runtime = app.world_mut().resource_mut::<WorldContentRuntime>();
+            runtime.contacts.push(CommsContact {
+                uuid: station_uuid.into(),
+                name: "Starbase Alpha".into(),
+                in_range: true,
+                is_urgent: false,
+            });
+            runtime.comms_template_states.push(CommsTemplateState {
+                template: crate::world::content::CommsTemplate {
+                    from: "starbase_alpha".into(),
+                    trigger: TriggerCondition::OnHailed {
+                        entity_name: "starbase_alpha".into(),
+                    },
+                    node: CommsDialogueNode {
+                        body: "Hello, Phoenix.".into(),
+                        responses: vec![CommsResponse {
+                            text: "Acknowledge.".into(),
+                            actions: vec![
+                                TriggerAction::AddFactionEnemy {
+                                    faction: "Harrow".into(),
+                                    enemy: "Federation".into(),
+                                },
+                                TriggerAction::AddFactionEnemy {
+                                    faction: "Federation".into(),
+                                    enemy: "Harrow".into(),
+                                },
+                                TriggerAction::RemoveFactionEnemy {
+                                    faction: "Harrow".into(),
+                                    enemy: "Federation".into(),
+                                },
+                            ],
+                            follow_up: None,
+                        }],
+                        speaker: None,
+                        trigger: None,
+                    },
+                    thread_id: None,
+                    urgent: false,
+                    root_follow_up: None,
+                },
+                fired: false,
+            });
+            runtime.needs_broadcast = true;
+        }
+        let _ = tick(&mut app);
+
+        push_msg(
+            &mut app,
+            "comms",
+            ClientMessage::ControlSystem {
+                target: crate::system_registry::comms_system_id(),
+                payload: crate::messages::SystemControlPayload::Hail {
+                    target_uuid: station_uuid.into(),
+                },
+            },
+        );
+        let out = tick(&mut app);
+        let msg_id = out
+            .iter()
+            .find_map(|m| {
+                if let ServerMessage::CommsState { messages, .. } = &m.msg {
+                    messages.first().map(|msg| msg.id.clone())
+                } else {
+                    None
+                }
+            })
+            .expect("hail must deliver a comms message");
+
+        push_msg(
+            &mut app,
+            "comms",
+            ClientMessage::ControlSystem {
+                target: crate::system_registry::comms_system_id(),
+                payload: crate::messages::SystemControlPayload::RespondToMessage {
+                    message_id: msg_id,
+                    response_index: 0,
+                },
+            },
+        );
+        let _ = tick(&mut app);
+
+        // The NPC's ShipAiMemory.target must be cleared: Harrow no longer
+        // considers Federation hostile after the response's third action.
+        let mem = app.world().get::<ShipAiMemory>(npc_entity).unwrap();
+        assert_eq!(
+            mem.0.target, None,
+            "comms RemoveFactionEnemy must clear memory.target when the target is no longer hostile"
+        );
     }
 
     // -- Comms conversation-cycle tests (issue #608, moved from
@@ -2135,6 +1878,17 @@ mod tests {
         let objectives = obj_summary.unwrap();
         assert_eq!(objectives.len(), 1);
         assert_eq!(objectives[0].text, "Complete the survey");
+        // Known difference #1: the fixture's AddObjective action carries no
+        // explicit `targets`, so it must fall back to the comms sender's
+        // resolved entity NAME ("starbase_alpha", from
+        // `name_to_uuid[station_uuid]`) rather than being left empty — the
+        // pre-resolved `DispatchContext::entity_name` comms passes in place
+        // of a `TriggerState.entity_name` (which comms has none of).
+        assert_eq!(
+            objectives[0].targets,
+            vec!["starbase_alpha".to_string()],
+            "AddObjective's empty-targets fallback must resolve to the comms sender's name"
+        );
     }
 
     // -- Cycle 4: clear comms removes read/orphaned messages ------------------

--- a/src/entities/config_cache.rs
+++ b/src/entities/config_cache.rs
@@ -538,6 +538,14 @@ pub fn get_config_cache() -> ConfigCache {
     ConfigCache::new()
 }
 
+// Native twin of the WASM cache lookup. There is no preload cache on native —
+// templates are read from disk on demand — so the lookup always misses and the
+// caller is expected to fall back to the filesystem.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn get_cached_entity_config(_path: &str) -> Option<crate::entity_config::EntityConfig> {
+    None
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub fn wasm_load_world(_path: String, _toml_str: String) -> Result<JsValue, JsValue> {
     Ok(JsValue::from_bool(true))

--- a/src/entities/loader.rs
+++ b/src/entities/loader.rs
@@ -48,6 +48,73 @@ pub fn assign_uuid() -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
+// ── Template resolution ──────────────────────────────────────────────────────
+
+/// Resolve an entity-template path to a concrete `EntityConfig`, abstracting
+/// over *where* the template comes from: the filesystem on native
+/// (`FsTemplateLoader`), the preloaded config cache on WASM
+/// (`WasmTemplateLoader`).
+///
+/// Object-safe by design — `&self`, no generics on the method — so callers can
+/// hold a `&dyn TemplateLoader` and tests can inject a fake without touching
+/// the filesystem or the WASM thread-locals.
+///
+/// # Diagnostics are the caller's job
+///
+/// `load_template` returns `Option`, not `Result`: a missing template and a
+/// malformed one both collapse to `None`, and any `toml::de::Error` is
+/// intentionally dropped at this boundary. This module is deliberately free of
+/// Bevy (see the file header), so it must not log. The caller — which knows
+/// which entity, trigger, or spawn request asked for the template — is
+/// responsible for emitting the warning.
+pub trait TemplateLoader {
+    /// Load and parse the template at `path`, or `None` if it cannot be found
+    /// or parsed.
+    fn load_template(&self, path: &str) -> Option<EntityConfig>;
+}
+
+/// Native loader: reads the template TOML straight off the filesystem.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FsTemplateLoader;
+
+#[cfg(not(target_arch = "wasm32"))]
+impl TemplateLoader for FsTemplateLoader {
+    fn load_template(&self, path: &str) -> Option<EntityConfig> {
+        let toml_str = std::fs::read_to_string(path).ok()?;
+        EntityConfig::from_toml(&toml_str).ok()
+    }
+}
+
+/// WASM loader: serves templates out of the preloaded config cache, falling
+/// back to the filesystem on native.
+///
+/// Compiles on both targets so callers can name it unconditionally. On WASM
+/// the cache is the only source (there is no filesystem); on native the cache
+/// lookup always misses and the filesystem fallback does the work — which
+/// makes the fallback path testable under `cargo test`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WasmTemplateLoader;
+
+impl TemplateLoader for WasmTemplateLoader {
+    fn load_template(&self, path: &str) -> Option<EntityConfig> {
+        // Single-path lookup, not `get_config_cache()` — the latter clones the
+        // entire cache map on every call.
+        if let Some(config) = crate::config_cache::get_cached_entity_config(path) {
+            return Some(config);
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            FsTemplateLoader.load_template(path)
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,5 +248,131 @@ overrides     = { behaviour = { waypoint_arrival_radius = 42.0 } }
         let a = assign_uuid();
         let b = assign_uuid();
         assert_ne!(a, b);
+    }
+
+    // ── TemplateLoader ───────────────────────────────────────────────────────
+
+    /// Write a template TOML fixture to a unique temp path and return it.
+    fn write_template_fixture(body: &str) -> String {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static C: AtomicU32 = AtomicU32::new(0);
+        let tag = C.fetch_add(1, Ordering::Relaxed);
+        let p = std::env::temp_dir().join(format!("template_loader_fixture_{tag}.toml"));
+        std::fs::write(&p, body).expect("write template fixture");
+        p.to_string_lossy().into_owned()
+    }
+
+    // `r##"` (not `r#"`) — the `"#` in the colour literal would close a
+    // single-hash raw string early.
+    const VALID_TEMPLATE: &str = r##"
+tags = ["npc"]
+
+[appearance]
+colour = "#ff8800"
+size_min = 1.0
+size_max = 2.0
+"##;
+
+    #[test]
+    fn fs_template_loader_reads_and_parses_template_from_disk() {
+        let path = write_template_fixture(VALID_TEMPLATE);
+        let config = FsTemplateLoader
+            .load_template(&path)
+            .expect("valid template on disk must load");
+        assert_eq!(config.tags, vec!["npc"]);
+    }
+
+    #[test]
+    fn fs_template_loader_missing_path_returns_none() {
+        let path = std::env::temp_dir().join("template_loader_definitely_absent.toml");
+        assert!(
+            FsTemplateLoader
+                .load_template(&path.to_string_lossy())
+                .is_none(),
+            "a template that is not on disk must resolve to None"
+        );
+    }
+
+    #[test]
+    fn fs_template_loader_malformed_toml_returns_none() {
+        let path = write_template_fixture("this is not = = valid toml");
+        assert!(
+            FsTemplateLoader.load_template(&path).is_none(),
+            "a parse error must be swallowed into None, not panic"
+        );
+    }
+
+    /// On native the config cache is always empty, so `WasmTemplateLoader` must
+    /// fall through to the filesystem. This is the same fallback the WASM build
+    /// compiles out.
+    #[test]
+    fn wasm_template_loader_falls_back_to_filesystem_on_native() {
+        let path = write_template_fixture(VALID_TEMPLATE);
+        let config = WasmTemplateLoader
+            .load_template(&path)
+            .expect("native fallback must read the template from disk");
+        assert_eq!(config.tags, vec!["npc"]);
+    }
+
+    #[test]
+    fn wasm_template_loader_missing_everywhere_returns_none() {
+        let path = std::env::temp_dir().join("wasm_template_loader_definitely_absent.toml");
+        assert!(
+            WasmTemplateLoader
+                .load_template(&path.to_string_lossy())
+                .is_none(),
+            "not in cache and not on disk must resolve to None"
+        );
+    }
+
+    /// A hand-written fake proves the trait is object-safe and injectable —
+    /// the entire reason this is a trait rather than a cfg-split free fn.
+    /// #715's dispatch context will hold exactly this `&dyn TemplateLoader`.
+    struct FakeTemplateLoader {
+        templates: HashMap<String, String>,
+    }
+
+    impl TemplateLoader for FakeTemplateLoader {
+        fn load_template(&self, path: &str) -> Option<EntityConfig> {
+            EntityConfig::from_toml(self.templates.get(path)?).ok()
+        }
+    }
+
+    /// Stand-in for #715's applier: takes the loader as a trait object.
+    fn resolve_template_via(loader: &dyn TemplateLoader, path: &str) -> Option<EntityConfig> {
+        loader.load_template(path)
+    }
+
+    #[test]
+    fn dyn_template_loader_injection_resolves_via_fake() {
+        let mut templates = HashMap::new();
+        templates.insert(
+            "assets/entities/fake.toml".to_string(),
+            VALID_TEMPLATE.to_string(),
+        );
+        let fake = FakeTemplateLoader { templates };
+
+        let config = resolve_template_via(&fake, "assets/entities/fake.toml")
+            .expect("injected fake must serve its template");
+        assert_eq!(config.tags, vec!["npc"]);
+
+        assert!(
+            resolve_template_via(&fake, "assets/entities/unknown.toml").is_none(),
+            "injected fake must report unknown templates as None"
+        );
+    }
+
+    /// The real impls must also be usable as `&dyn TemplateLoader`, not just
+    /// the fake — otherwise injection buys nothing in production.
+    #[test]
+    fn real_loaders_are_usable_as_trait_objects() {
+        let path = write_template_fixture(VALID_TEMPLATE);
+        let loaders: Vec<&dyn TemplateLoader> = vec![&FsTemplateLoader, &WasmTemplateLoader];
+        for loader in loaders {
+            assert!(
+                resolve_template_via(loader, &path).is_some(),
+                "every real loader must resolve a valid on-disk template on native"
+            );
+        }
     }
 }

--- a/src/world/config.rs
+++ b/src/world/config.rs
@@ -3860,7 +3860,7 @@ transform = { position = [0.0, 0.0, 0.0] }
         // blocks reference entity templates that must be preloaded into the
         // EntityConfig cache before the trigger fires. Without this walk,
         // timer-driven wave spawns silently fail on WASM (cache miss →
-        // `continue` in handle_ai_events).
+        // `continue` in tick_trigger_pipeline).
         let toml = r#"
 [[trigger]]
 condition = "on_timer"

--- a/src/world/dispatch.rs
+++ b/src/world/dispatch.rs
@@ -449,18 +449,12 @@ pub fn dispatch_action(action: &TriggerAction, context: &DispatchContext) -> Dis
             }
         }
 
-        TriggerAction::DestroyEntity { entity } => {
-            let Some(uuid) = context.name_to_uuid.get(entity) else {
-                out.warnings
-                    .push(format!("DestroyEntity: unknown entity name '{entity}'"));
-                return out;
-            };
-            // The event lets chained `on_destroyed` triggers observe the kill;
-            // the command runs the despawn + destruction cascade.
-            out.new_events
-                .push(WorldEvent::Destroyed { uuid: uuid.clone() });
-            out.commands
-                .push(ActionCmd::DestroyEntity { uuid: uuid.clone() });
+        // Entity destruction — resolving the target's name to a UUID, then
+        // emitting the destroy command plus the `Destroyed` event — is
+        // handled by `dispatch_destroy_entity` (issue #714). Same routing
+        // shape as the mission-state arm above.
+        TriggerAction::DestroyEntity { .. } => {
+            return dispatch_destroy_entity(action, context);
         }
     }
 
@@ -894,6 +888,47 @@ fn dispatch_flag_mutation(
         mutation,
     });
     push_flag_transition(&mut out.new_events, &stripped, &target_layer, before, after);
+}
+
+/// Decide what a `DestroyEntity` `TriggerAction` should do.
+///
+/// Owns the single entity-destruction action. Split out of `dispatch_action`
+/// (issue #714), which routes exactly this variant here.
+///
+/// Resolves entity *name* → *UUID* via `context.name_to_uuid` (warn + no-op
+/// on an unknown name), then emits `ActionCmd::DestroyEntity` keyed by UUID
+/// and pushes `WorldEvent::Destroyed` into `new_events` so chained
+/// `on_destroyed` triggers observe the kill. The despawn + destruction
+/// cascade — and the `AiEntityDestroyed` queueing — stay in the applier; see
+/// "Purity boundaries" at the top of this file.
+///
+/// Pure, like `dispatch_action`: reads `context`, mutates nothing, returns a
+/// `DispatchResult`. Called only for the variant above; any other variant is
+/// a routing bug in `dispatch_action` and trips the `unreachable!`.
+fn dispatch_destroy_entity(action: &TriggerAction, context: &DispatchContext) -> DispatchResult {
+    let mut out = DispatchResult::default();
+
+    match action {
+        TriggerAction::DestroyEntity { entity } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("DestroyEntity: unknown entity name '{entity}'"));
+                return out;
+            };
+            // The event lets chained `on_destroyed` triggers observe the kill;
+            // the command runs the despawn + destruction cascade.
+            out.new_events
+                .push(WorldEvent::Destroyed { uuid: uuid.clone() });
+            out.commands
+                .push(ActionCmd::DestroyEntity { uuid: uuid.clone() });
+        }
+
+        other => {
+            unreachable!("dispatch_destroy_entity called with non-destroy action: {other:?}")
+        }
+    }
+
+    out
 }
 
 // ── Unit Tests ────────────────────────────────────────────────────────────
@@ -2952,5 +2987,79 @@ mod tests {
             path: "worlds/sub.toml".to_string(),
         };
         let _ = dispatch_world_flag_action(&action, &fx.ctx());
+    }
+
+    // ── dispatch_destroy_entity (direct) ──────────────────────────────────
+    //
+    // The tests above drive the DestroyEntity arm through `dispatch_action`
+    // (`destroy_entity_emits_command_and_destroyed_event`,
+    // `destroy_entity_unknown_name_warns_and_emits_nothing`), proving the
+    // routing arm delegates. These call `dispatch_destroy_entity` directly,
+    // proving the extracted function is what produces the result and that
+    // the two entry points agree (issue #714).
+
+    #[test]
+    fn destroy_known_entity_emits_command_and_destroyed_event_directly() {
+        let fx = Fixture::new().with_entity("wave_1", "uuid-wave-1");
+        let action = TriggerAction::DestroyEntity {
+            entity: "wave_1".to_string(),
+        };
+        let out = dispatch_destroy_entity(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::DestroyEntity {
+                    uuid: "uuid-wave-1".to_string()
+                }],
+                new_events: vec![WorldEvent::Destroyed {
+                    uuid: "uuid-wave-1".to_string()
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn destroy_unknown_entity_warns_and_emits_nothing_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::DestroyEntity {
+            entity: "ghost".to_string(),
+        };
+        let out = dispatch_destroy_entity(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                warnings: vec!["DestroyEntity: unknown entity name 'ghost'".to_string()],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn destroy_entity_matches_dispatch_action_routing() {
+        let fx = Fixture::new().with_entity("wave_1", "uuid-wave-1");
+        let action = TriggerAction::DestroyEntity {
+            entity: "wave_1".to_string(),
+        };
+
+        // Both entry points must produce byte-identical results.
+        assert_eq!(
+            dispatch_action(&action, &fx.ctx()),
+            dispatch_destroy_entity(&action, &fx.ctx())
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "dispatch_destroy_entity called with non-destroy action")]
+    fn destroy_entity_on_non_destroy_variant_panics() {
+        // The guard exists so a routing bug in `dispatch_action` fails loudly
+        // rather than silently returning an empty result.
+        let fx = Fixture::new();
+        let action = TriggerAction::UnloadWorld {
+            path: "worlds/sub.toml".to_string(),
+        };
+        let _ = dispatch_destroy_entity(&action, &fx.ctx());
     }
 }

--- a/src/world/dispatch.rs
+++ b/src/world/dispatch.rs
@@ -471,94 +471,17 @@ pub fn dispatch_action(action: &TriggerAction, context: &DispatchContext) -> Dis
             ));
         }
 
-        TriggerAction::ApplyModifier {
-            entity,
-            tag,
-            slot,
-            bonus,
-        } => {
-            let Some(uuid) = context.name_to_uuid.get(entity) else {
-                out.warnings
-                    .push(format!("ApplyModifier: unknown entity name '{entity}'"));
-                return out;
-            };
-            out.commands.push(ActionCmd::ApplyModifier {
-                uuid: uuid.clone(),
-                tag: tag.clone(),
-                slot: slot.clone(),
-                bonus: *bonus,
-            });
-        }
-
-        TriggerAction::RemoveModifier { entity, tag, slot } => {
-            let Some(uuid) = context.name_to_uuid.get(entity) else {
-                out.warnings
-                    .push(format!("RemoveModifier: unknown entity name '{entity}'"));
-                return out;
-            };
-            out.commands.push(ActionCmd::RemoveModifier {
-                uuid: uuid.clone(),
-                tag: tag.clone(),
-                slot: slot.clone(),
-            });
-        }
-
-        TriggerAction::ApplyFlag { entity, tag, kind } => {
-            let Some(uuid) = context.name_to_uuid.get(entity) else {
-                out.warnings
-                    .push(format!("ApplyFlag: unknown entity name '{entity}'"));
-                return out;
-            };
-            out.commands.push(ActionCmd::ApplyFlag {
-                uuid: uuid.clone(),
-                tag: tag.clone(),
-                kind: kind.clone(),
-            });
-        }
-
-        TriggerAction::RemoveFlag { entity, tag, kind } => {
-            let Some(uuid) = context.name_to_uuid.get(entity) else {
-                out.warnings
-                    .push(format!("RemoveFlag: unknown entity name '{entity}'"));
-                return out;
-            };
-            out.commands.push(ActionCmd::RemoveFlag {
-                uuid: uuid.clone(),
-                tag: tag.clone(),
-                kind: kind.clone(),
-            });
-        }
-
-        TriggerAction::ApplyIntModifier {
-            entity,
-            tag,
-            slot,
-            bonus,
-        } => {
-            let Some(uuid) = context.name_to_uuid.get(entity) else {
-                out.warnings
-                    .push(format!("ApplyIntModifier: unknown entity name '{entity}'"));
-                return out;
-            };
-            out.commands.push(ActionCmd::ApplyIntModifier {
-                uuid: uuid.clone(),
-                tag: tag.clone(),
-                slot: slot.clone(),
-                bonus: *bonus,
-            });
-        }
-
-        TriggerAction::RemoveIntModifier { entity, tag, slot } => {
-            let Some(uuid) = context.name_to_uuid.get(entity) else {
-                out.warnings
-                    .push(format!("RemoveIntModifier: unknown entity name '{entity}'"));
-                return out;
-            };
-            out.commands.push(ActionCmd::RemoveIntModifier {
-                uuid: uuid.clone(),
-                tag: tag.clone(),
-                slot: slot.clone(),
-            });
+        // Entity modifier/flag actions — float modifiers, bool flags, and
+        // integer modifiers on a named entity — are handled by
+        // `dispatch_entity_modifier_action` (issue #712). Same routing shape
+        // as the mission-state arm above.
+        TriggerAction::ApplyModifier { .. }
+        | TriggerAction::RemoveModifier { .. }
+        | TriggerAction::ApplyFlag { .. }
+        | TriggerAction::RemoveFlag { .. }
+        | TriggerAction::ApplyIntModifier { .. }
+        | TriggerAction::RemoveIntModifier { .. } => {
+            return dispatch_entity_modifier_action(action, context);
         }
 
         TriggerAction::LoadWorld { path } => {
@@ -799,6 +722,130 @@ fn dispatch_state_action(action: &TriggerAction, context: &DispatchContext) -> D
 
         other => {
             unreachable!("dispatch_state_action called with non-state action: {other:?}")
+        }
+    }
+
+    out
+}
+
+/// Decide what one entity-modifier `TriggerAction` should do.
+///
+/// Owns the six actions that stamp a modifier or flag onto a named entity —
+/// the float-modifier pair (`ApplyModifier`, `RemoveModifier`), the bool-flag
+/// pair (`ApplyFlag`, `RemoveFlag`), and the integer-modifier pair
+/// (`ApplyIntModifier`, `RemoveIntModifier`). Split out of `dispatch_action`
+/// (issue #712), which routes exactly these six variants here.
+///
+/// All six share one shape: resolve entity *name* → *UUID* via
+/// `context.name_to_uuid` (warn + no-op on an unknown name), then emit the
+/// matching `ActionCmd` keyed by UUID. The UUID → `Entity` → `ShipModifiers`
+/// step stays in the applier — see "Purity boundaries" at the top of this
+/// file.
+///
+/// Pure, like `dispatch_action`: reads `context`, mutates nothing, returns a
+/// `DispatchResult`. Called only for the six variants above; any other variant
+/// is a routing bug in `dispatch_action` and trips the `unreachable!`.
+fn dispatch_entity_modifier_action(
+    action: &TriggerAction,
+    context: &DispatchContext,
+) -> DispatchResult {
+    let mut out = DispatchResult::default();
+
+    match action {
+        TriggerAction::ApplyModifier {
+            entity,
+            tag,
+            slot,
+            bonus,
+        } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("ApplyModifier: unknown entity name '{entity}'"));
+                return out;
+            };
+            out.commands.push(ActionCmd::ApplyModifier {
+                uuid: uuid.clone(),
+                tag: tag.clone(),
+                slot: slot.clone(),
+                bonus: *bonus,
+            });
+        }
+
+        TriggerAction::RemoveModifier { entity, tag, slot } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("RemoveModifier: unknown entity name '{entity}'"));
+                return out;
+            };
+            out.commands.push(ActionCmd::RemoveModifier {
+                uuid: uuid.clone(),
+                tag: tag.clone(),
+                slot: slot.clone(),
+            });
+        }
+
+        TriggerAction::ApplyFlag { entity, tag, kind } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("ApplyFlag: unknown entity name '{entity}'"));
+                return out;
+            };
+            out.commands.push(ActionCmd::ApplyFlag {
+                uuid: uuid.clone(),
+                tag: tag.clone(),
+                kind: kind.clone(),
+            });
+        }
+
+        TriggerAction::RemoveFlag { entity, tag, kind } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("RemoveFlag: unknown entity name '{entity}'"));
+                return out;
+            };
+            out.commands.push(ActionCmd::RemoveFlag {
+                uuid: uuid.clone(),
+                tag: tag.clone(),
+                kind: kind.clone(),
+            });
+        }
+
+        TriggerAction::ApplyIntModifier {
+            entity,
+            tag,
+            slot,
+            bonus,
+        } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("ApplyIntModifier: unknown entity name '{entity}'"));
+                return out;
+            };
+            out.commands.push(ActionCmd::ApplyIntModifier {
+                uuid: uuid.clone(),
+                tag: tag.clone(),
+                slot: slot.clone(),
+                bonus: *bonus,
+            });
+        }
+
+        TriggerAction::RemoveIntModifier { entity, tag, slot } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("RemoveIntModifier: unknown entity name '{entity}'"));
+                return out;
+            };
+            out.commands.push(ActionCmd::RemoveIntModifier {
+                uuid: uuid.clone(),
+                tag: tag.clone(),
+                slot: slot.clone(),
+            });
+        }
+
+        other => {
+            unreachable!(
+                "dispatch_entity_modifier_action called with non-modifier action: {other:?}"
+            )
         }
     }
 
@@ -2295,5 +2342,300 @@ mod tests {
             path: "worlds/sub.toml".to_string(),
         };
         let _ = dispatch_state_action(&action, &fx.ctx());
+    }
+
+    // ── dispatch_entity_modifier_action (direct) ──────────────────────────
+    //
+    // The tests above drive the six modifier/flag arms through
+    // `dispatch_action`, proving the routing arm delegates. These call
+    // `dispatch_entity_modifier_action` directly, proving the extracted
+    // function is what produces the result and that the two entry points
+    // agree (issue #712).
+
+    #[test]
+    fn modifier_apply_modifier_resolves_name_to_uuid_directly() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::ApplyModifier {
+            entity: "raider".to_string(),
+            tag: "buff".to_string(),
+            slot: ModifierSlot::MaxSpeed,
+            bonus: 2.5,
+        };
+        let out = dispatch_entity_modifier_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::ApplyModifier {
+                    uuid: "uuid-raider".to_string(),
+                    tag: "buff".to_string(),
+                    slot: ModifierSlot::MaxSpeed,
+                    bonus: 2.5,
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn modifier_apply_modifier_unknown_entity_warns_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::ApplyModifier {
+            entity: "ghost".to_string(),
+            tag: "buff".to_string(),
+            slot: ModifierSlot::MaxSpeed,
+            bonus: 2.5,
+        };
+        let out = dispatch_entity_modifier_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                warnings: vec!["ApplyModifier: unknown entity name 'ghost'".to_string()],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn modifier_apply_modifier_matches_dispatch_action_routing() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::ApplyModifier {
+            entity: "raider".to_string(),
+            tag: "buff".to_string(),
+            slot: ModifierSlot::MaxSpeed,
+            bonus: 2.5,
+        };
+
+        // Both entry points must produce byte-identical results.
+        assert_eq!(
+            dispatch_action(&action, &fx.ctx()),
+            dispatch_entity_modifier_action(&action, &fx.ctx())
+        );
+    }
+
+    #[test]
+    fn modifier_remove_modifier_resolves_name_to_uuid_directly() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::RemoveModifier {
+            entity: "raider".to_string(),
+            tag: "buff".to_string(),
+            slot: ModifierSlot::MaxSpeed,
+        };
+        let out = dispatch_entity_modifier_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::RemoveModifier {
+                    uuid: "uuid-raider".to_string(),
+                    tag: "buff".to_string(),
+                    slot: ModifierSlot::MaxSpeed,
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn modifier_remove_modifier_unknown_entity_warns_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::RemoveModifier {
+            entity: "ghost".to_string(),
+            tag: "buff".to_string(),
+            slot: ModifierSlot::MaxSpeed,
+        };
+        let out = dispatch_entity_modifier_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                warnings: vec!["RemoveModifier: unknown entity name 'ghost'".to_string()],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn modifier_apply_flag_resolves_name_to_uuid_directly() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::ApplyFlag {
+            entity: "raider".to_string(),
+            tag: "cloak".to_string(),
+            kind: FlagKind::CommsJammed,
+        };
+        let out = dispatch_entity_modifier_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::ApplyFlag {
+                    uuid: "uuid-raider".to_string(),
+                    tag: "cloak".to_string(),
+                    kind: FlagKind::CommsJammed,
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn modifier_apply_flag_unknown_entity_warns_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::ApplyFlag {
+            entity: "ghost".to_string(),
+            tag: "cloak".to_string(),
+            kind: FlagKind::CommsJammed,
+        };
+        let out = dispatch_entity_modifier_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                warnings: vec!["ApplyFlag: unknown entity name 'ghost'".to_string()],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn modifier_remove_flag_resolves_name_to_uuid_directly() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::RemoveFlag {
+            entity: "raider".to_string(),
+            tag: "cloak".to_string(),
+            kind: FlagKind::CommsJammed,
+        };
+        let out = dispatch_entity_modifier_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::RemoveFlag {
+                    uuid: "uuid-raider".to_string(),
+                    tag: "cloak".to_string(),
+                    kind: FlagKind::CommsJammed,
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn modifier_remove_flag_unknown_entity_warns_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::RemoveFlag {
+            entity: "ghost".to_string(),
+            tag: "cloak".to_string(),
+            kind: FlagKind::CommsJammed,
+        };
+        let out = dispatch_entity_modifier_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                warnings: vec!["RemoveFlag: unknown entity name 'ghost'".to_string()],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn modifier_apply_int_modifier_resolves_name_to_uuid_directly() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::ApplyIntModifier {
+            entity: "raider".to_string(),
+            tag: "crew".to_string(),
+            slot: IntModifierSlot::RepairTeams,
+            bonus: 3,
+        };
+        let out = dispatch_entity_modifier_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::ApplyIntModifier {
+                    uuid: "uuid-raider".to_string(),
+                    tag: "crew".to_string(),
+                    slot: IntModifierSlot::RepairTeams,
+                    bonus: 3,
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn modifier_apply_int_modifier_unknown_entity_warns_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::ApplyIntModifier {
+            entity: "ghost".to_string(),
+            tag: "crew".to_string(),
+            slot: IntModifierSlot::RepairTeams,
+            bonus: 3,
+        };
+        let out = dispatch_entity_modifier_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                warnings: vec!["ApplyIntModifier: unknown entity name 'ghost'".to_string()],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn modifier_remove_int_modifier_resolves_name_to_uuid_directly() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::RemoveIntModifier {
+            entity: "raider".to_string(),
+            tag: "crew".to_string(),
+            slot: IntModifierSlot::RepairTeams,
+        };
+        let out = dispatch_entity_modifier_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::RemoveIntModifier {
+                    uuid: "uuid-raider".to_string(),
+                    tag: "crew".to_string(),
+                    slot: IntModifierSlot::RepairTeams,
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn modifier_remove_int_modifier_unknown_entity_warns_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::RemoveIntModifier {
+            entity: "ghost".to_string(),
+            tag: "crew".to_string(),
+            slot: IntModifierSlot::RepairTeams,
+        };
+        let out = dispatch_entity_modifier_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                warnings: vec!["RemoveIntModifier: unknown entity name 'ghost'".to_string()],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "dispatch_entity_modifier_action called with non-modifier action")]
+    fn entity_modifier_action_on_non_modifier_variant_panics() {
+        // The guard exists so a routing bug in `dispatch_action` fails loudly
+        // rather than silently returning an empty result.
+        let fx = Fixture::new();
+        let action = TriggerAction::UnloadWorld {
+            path: "worlds/sub.toml".to_string(),
+        };
+        let _ = dispatch_entity_modifier_action(&action, &fx.ctx());
     }
 }

--- a/src/world/dispatch.rs
+++ b/src/world/dispatch.rs
@@ -9,7 +9,7 @@
 // # Why a pure table
 //
 // The dispatch table used to be inlined twice inside `world::server` — once in
-// `handle_ai_events` for immediate actions and once in `dispatch_single_action`
+// `tick_trigger_pipeline` for immediate actions and once in `dispatch_single_action`
 // for delayed ones. Both copies mixed decision logic (name lookups, `parent:`
 // walking, anchor resolution, transition detection) with ECS mutation, so none
 // of it could be tested without spinning up a Bevy `App`. Splitting the
@@ -117,10 +117,11 @@ pub struct DispatchContext<'a> {
     /// the next action. `before`/`after` — and hence whether a transition event
     /// is emitted at all — are computed against it.
     ///
-    /// `server::handle_ai_events`'s per-pass `base_flags_snapshot` /
-    /// `layer_flags_snapshot` locals exist for **condition evaluation only**
-    /// (deciding which triggers fire) and MUST NOT be passed here. They are in
-    /// scope at the call site, so this is the tempting wrong move. It breaks
+    /// Condition evaluation in `server::tick_trigger_pipeline` borrows these
+    /// same live stores, which is safe only because every condition of a pass
+    /// is evaluated before any of its actions is dispatched. What MUST NOT be
+    /// passed here is a store copied before the pass's dispatches began — the
+    /// tempting wrong move when refactoring the call site. It breaks
     /// flag idempotence: two triggers both `set_flag aphelion_armed`
     /// (`assets/worlds/before_the_fire.toml:275`) against live stores go `0→1`
     /// (emits `FlagSet`) then `1→1` (emits nothing) = one event, so the

--- a/src/world/dispatch.rs
+++ b/src/world/dispatch.rs
@@ -446,41 +446,17 @@ pub fn dispatch_action(action: &TriggerAction, context: &DispatchContext) -> Dis
     let mut out = DispatchResult::default();
 
     match action {
-        TriggerAction::AddObjective {
-            id,
-            text,
-            mandatory,
-            targets,
-            directive,
-            utility,
-            source,
-        } => {
-            // Explicit targets win; otherwise fall back to the trigger
-            // condition's entity (legacy behaviour).
-            let resolved: Vec<String> = if targets.is_empty() {
-                context.entity_name.clone().into_iter().collect()
-            } else {
-                targets.clone()
-            };
-            out.commands.push(ActionCmd::AddObjective {
-                id: id.clone(),
-                text: text.clone(),
-                mandatory: *mandatory,
-                targets: resolved,
-                directive: directive.clone(),
-                utility: utility.clone(),
-                source: source.clone(),
-            });
-        }
-
-        TriggerAction::CompleteObjective { id } => {
-            out.commands
-                .push(ActionCmd::CompleteObjective { id: id.clone() });
-        }
-
-        TriggerAction::FailObjective { id } => {
-            out.commands
-                .push(ActionCmd::FailObjective { id: id.clone() });
+        // Mission-state actions — objectives, faction hostility, and the
+        // game-over transition — are handled by `dispatch_state_action`
+        // (issue #711). This table remains the single entry point over every
+        // variant; it just routes these six to their own function.
+        TriggerAction::AddObjective { .. }
+        | TriggerAction::CompleteObjective { .. }
+        | TriggerAction::FailObjective { .. }
+        | TriggerAction::GameOver { .. }
+        | TriggerAction::AddFactionEnemy { .. }
+        | TriggerAction::RemoveFactionEnemy { .. } => {
+            return dispatch_state_action(action, context);
         }
 
         TriggerAction::SetAiState {
@@ -582,16 +558,6 @@ pub fn dispatch_action(action: &TriggerAction, context: &DispatchContext) -> Dis
                 uuid: uuid.clone(),
                 tag: tag.clone(),
                 slot: slot.clone(),
-            });
-        }
-
-        TriggerAction::GameOver { message } => {
-            // `None` becomes `Some("")`, not `None` — preserved verbatim.
-            let reason = message.clone().unwrap_or_default();
-            // Reason first: `OnEnter(GamePhase::GameOver)` reads it.
-            out.commands.push(ActionCmd::SetGameOverReason { reason });
-            out.commands.push(ActionCmd::SetNextState {
-                phase: GamePhase::GameOver,
             });
         }
 
@@ -715,6 +681,72 @@ pub fn dispatch_action(action: &TriggerAction, context: &DispatchContext) -> Dis
             out.commands
                 .push(ActionCmd::DestroyEntity { uuid: uuid.clone() });
         }
+    }
+
+    out
+}
+
+/// Decide what one mission-state `TriggerAction` should do.
+///
+/// Owns the six actions that touch mission state — the three objective actions
+/// (`AddObjective`, `CompleteObjective`, `FailObjective`), the two faction-
+/// hostility actions (`AddFactionEnemy`, `RemoveFactionEnemy`), and the
+/// `GameOver` transition. Split out of `dispatch_action` (issue #711), which
+/// routes exactly these six variants here.
+///
+/// Pure, like `dispatch_action`: reads `context`, mutates nothing, returns a
+/// `DispatchResult`. Called only for the six variants above; any other variant
+/// is a routing bug in `dispatch_action` and trips the `unreachable!`.
+fn dispatch_state_action(action: &TriggerAction, context: &DispatchContext) -> DispatchResult {
+    let mut out = DispatchResult::default();
+
+    match action {
+        TriggerAction::AddObjective {
+            id,
+            text,
+            mandatory,
+            targets,
+            directive,
+            utility,
+            source,
+        } => {
+            // Explicit targets win; otherwise fall back to the trigger
+            // condition's entity (legacy behaviour).
+            let resolved: Vec<String> = if targets.is_empty() {
+                context.entity_name.clone().into_iter().collect()
+            } else {
+                targets.clone()
+            };
+            out.commands.push(ActionCmd::AddObjective {
+                id: id.clone(),
+                text: text.clone(),
+                mandatory: *mandatory,
+                targets: resolved,
+                directive: directive.clone(),
+                utility: utility.clone(),
+                source: source.clone(),
+            });
+        }
+
+        TriggerAction::CompleteObjective { id } => {
+            out.commands
+                .push(ActionCmd::CompleteObjective { id: id.clone() });
+        }
+
+        TriggerAction::FailObjective { id } => {
+            out.commands
+                .push(ActionCmd::FailObjective { id: id.clone() });
+        }
+
+        TriggerAction::GameOver { message } => {
+            // `None` becomes `Some("")`, not `None` — preserved verbatim.
+            let reason = message.clone().unwrap_or_default();
+            // Reason first: `OnEnter(GamePhase::GameOver)` reads it.
+            out.commands.push(ActionCmd::SetGameOverReason { reason });
+            out.commands.push(ActionCmd::SetNextState {
+                phase: GamePhase::GameOver,
+            });
+        }
 
         TriggerAction::AddFactionEnemy { faction, enemy } => {
             let Some(registry) = context.factions else {
@@ -763,6 +795,10 @@ pub fn dispatch_action(action: &TriggerAction, context: &DispatchContext) -> Dis
                 faction_uuid,
                 enemy_uuid,
             });
+        }
+
+        other => {
+            unreachable!("dispatch_state_action called with non-state action: {other:?}")
         }
     }
 
@@ -2078,5 +2114,186 @@ mod tests {
             out.warnings,
             vec!["RemoveFactionEnemy: unknown enemy faction name 'Nobody'".to_string()]
         );
+    }
+
+    // ── dispatch_state_action (direct) ────────────────────────────────────
+    //
+    // The tests above drive the six state arms through `dispatch_action`,
+    // proving the routing arm delegates. These call `dispatch_state_action`
+    // directly, proving the extracted function is what produces the result and
+    // that the two entry points agree (issue #711).
+
+    #[test]
+    fn state_add_objective_falls_back_to_trigger_entity_directly() {
+        let mut fx = Fixture::new();
+        fx.entity_name = Some("trigger_ship".to_string());
+        let out = dispatch_state_action(&add_objective(vec![]), &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::AddObjective {
+                id: "obj1".to_string(),
+                text: "Destroy the convoy".to_string(),
+                mandatory: true,
+                targets: vec!["trigger_ship".to_string()],
+                directive: AiDirective::default(),
+                utility: UtilityConfig::default(),
+                source: ObjectiveSource::default(),
+            }]
+        );
+        assert!(out.warnings.is_empty());
+        assert!(out.new_events.is_empty());
+    }
+
+    #[test]
+    fn state_add_objective_matches_dispatch_action_routing() {
+        let mut fx = Fixture::new();
+        fx.entity_name = Some("trigger_ship".to_string());
+        let action = add_objective(vec!["alpha", "beta"]);
+
+        // Both entry points must produce byte-identical results.
+        assert_eq!(
+            dispatch_action(&action, &fx.ctx()),
+            dispatch_state_action(&action, &fx.ctx())
+        );
+    }
+
+    #[test]
+    fn state_complete_objective_emits_command_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::CompleteObjective {
+            id: "obj1".to_string(),
+        };
+        let out = dispatch_state_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::CompleteObjective {
+                id: "obj1".to_string()
+            }]
+        );
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn state_fail_objective_emits_command_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::FailObjective {
+            id: "obj1".to_string(),
+        };
+        let out = dispatch_state_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::FailObjective {
+                id: "obj1".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn state_game_over_sets_reason_before_state_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::GameOver {
+            message: Some("The ship was lost".to_string()),
+        };
+        let out = dispatch_state_action(&action, &fx.ctx());
+
+        // Ordering is load-bearing: OnEnter(GameOver) reads the reason first.
+        assert_eq!(
+            out.commands,
+            vec![
+                ActionCmd::SetGameOverReason {
+                    reason: "The ship was lost".to_string()
+                },
+                ActionCmd::SetNextState {
+                    phase: GamePhase::GameOver
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn state_game_over_without_message_yields_empty_reason_not_none_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::GameOver { message: None };
+        let out = dispatch_state_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands[0],
+            ActionCmd::SetGameOverReason {
+                reason: String::new()
+            }
+        );
+    }
+
+    #[test]
+    fn state_add_faction_enemy_emits_command_directly() {
+        let (registry, harrow, federation) = two_factions();
+        let mut fx = Fixture::new();
+        fx.factions = Some(registry);
+        let action = TriggerAction::AddFactionEnemy {
+            faction: "Harrow".to_string(),
+            enemy: "Federation".to_string(),
+        };
+        let out = dispatch_state_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::AddFactionEnemy {
+                faction_uuid: harrow,
+                enemy_uuid: federation,
+            }]
+        );
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn state_add_faction_enemy_without_registry_warns_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::AddFactionEnemy {
+            faction: "Harrow".to_string(),
+            enemy: "Federation".to_string(),
+        };
+        let out = dispatch_state_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["AddFactionEnemy skipped: FactionRegistryResource not present".to_string()]
+        );
+    }
+
+    #[test]
+    fn state_remove_faction_enemy_emits_command_directly() {
+        let (registry, harrow, federation) = two_factions();
+        let mut fx = Fixture::new();
+        fx.factions = Some(registry);
+        let action = TriggerAction::RemoveFactionEnemy {
+            faction: "Harrow".to_string(),
+            enemy: "Federation".to_string(),
+        };
+        let out = dispatch_state_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::RemoveFactionEnemy {
+                faction_uuid: harrow,
+                enemy_uuid: federation,
+            }]
+        );
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "dispatch_state_action called with non-state action")]
+    fn state_action_on_non_state_variant_panics() {
+        // The guard exists so a routing bug in `dispatch_action` fails loudly
+        // rather than silently returning an empty result.
+        let fx = Fixture::new();
+        let action = TriggerAction::UnloadWorld {
+            path: "worlds/sub.toml".to_string(),
+        };
+        let _ = dispatch_state_action(&action, &fx.ctx());
     }
 }

--- a/src/world/dispatch.rs
+++ b/src/world/dispatch.rs
@@ -1,0 +1,2082 @@
+// Pure trigger-action dispatch table for the world engine (issue #708).
+//
+// Pure Rust module — no Bevy. This module owns the single `match` over every
+// `TriggerAction` variant. It reads a read-only `DispatchContext` and returns a
+// `DispatchResult` describing *what should happen*, without performing any of
+// it. The Bevy layer (`world::server`) builds the context, calls
+// `dispatch_action`, and applies the result (issue #710 wires it up).
+//
+// # Why a pure table
+//
+// The dispatch table used to be inlined twice inside `world::server` — once in
+// `handle_ai_events` for immediate actions and once in `dispatch_single_action`
+// for delayed ones. Both copies mixed decision logic (name lookups, `parent:`
+// walking, anchor resolution, transition detection) with ECS mutation, so none
+// of it could be tested without spinning up a Bevy `App`. Splitting the
+// decision out makes every arm — including every failure path — a plain
+// function call over plain data.
+//
+// # Purity boundaries
+//
+// * **Entities are UUID strings, never `Entity`.** The six modifier arms
+//   ultimately write a `ShipModifiers` component, which is irreducibly impure.
+//   `dispatch_action` resolves entity *name* → *UUID* from
+//   `DispatchContext::name_to_uuid` and stops there; the applier does
+//   UUID → `Entity` → component.
+// * **Logging becomes data.** Failure paths push a message onto
+//   `DispatchResult::warnings` instead of calling the Bevy log macros. The
+//   applier logs them at warn level; tests assert on them.
+// * **Flag mutation is previewed, not performed.** The `parent:` layer walk and
+//   the before/after transition are computed here (mirroring `FlagStore`'s own
+//   semantics exactly); the applier performs the write. This is the idiom
+//   `world::flags` already documents. The preview reads the *live* stores, so
+//   the applier must apply each `DispatchResult` before dispatching the next
+//   action or flag idempotence breaks — see `DispatchContext::base_flags`.
+// * **New events are destination-agnostic.** `DispatchResult::new_events` are
+//   returned, not routed. The immediate path feeds them into the next chaining
+//   pass (same tick); the delayed path queues them for the next tick. The
+//   caller decides.
+// * **Non-determinism is injected.** `SpawnEntity` takes its UUID from
+//   `DispatchContext::uuid_source` so tests can stub it.
+// * **Template loading is deferred** (issue #715). `ActionCmd::SpawnEntity`
+//   carries what the pure layer resolved — position, name, uuid, groups — and
+//   the applier loads the template.
+
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::faction::FactionRegistry;
+use crate::flag_kind::FlagKind;
+use crate::messages::{AiDirective, GamePhase, ModifierSlot, ObjectiveSource};
+use crate::modifiers::IntModifierSlot;
+use crate::objectives::UtilityConfig;
+use crate::world::config::TriggerAction;
+use crate::world::content::WorldEvent;
+use crate::world::flags::FlagStore;
+
+/// The `ModifierSource::World { id }` discriminator used by every modifier and
+/// flag arm. This is a source *identity*, not a tunable gameplay value: it is
+/// what lets `RemoveModifier` find the modifier a previous `ApplyModifier`
+/// added. The applier reconstructs `ModifierSource::World { id, tag }` from
+/// this const plus the `ActionCmd`'s `tag`.
+pub const WORLD_MODIFIER_SOURCE_ID: &str = "world";
+
+// ── Context ───────────────────────────────────────────────────────────────
+
+/// Read-only view of one additively-loaded world layer.
+///
+/// Mirrors the fields of `world::server::WorldRuntime` that the dispatch table
+/// reads. The Bevy layer projects `WorldLayerMap` into these. Freshness is
+/// per-field, not per-struct — see each field, and `DispatchContext`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct LayerView {
+    /// The layer's own flag store. **Must be the live store** — same rule, and
+    /// same reason, as `DispatchContext::base_flags`.
+    pub flags: FlagStore,
+    /// Path of the layer whose trigger loaded this one (`None` = base world).
+    /// Each `parent:` prefix on a flag name walks one step along these.
+    pub loader_path: Option<String>,
+    /// The layer's anchor table, used to resolve `SpawnEntity { anchor }` for
+    /// triggers authored in this layer.
+    pub anchors: HashMap<String, [f32; 3]>,
+}
+
+/// Everything `dispatch_action` is allowed to read.
+///
+/// Built fresh per fired trigger by the Bevy caller. **Freshness is specified
+/// per field, not for the struct as a whole** — the rules genuinely differ, so
+/// read the field docs rather than assuming one blanket rule. In short:
+/// `name_to_uuid` is rebuilt once per chaining pass, whereas `base_flags` and
+/// `layers[].flags` must be the *live* stores, never a per-pass snapshot.
+pub struct DispatchContext<'a> {
+    /// Authoring layer of the trigger that fired (`None` = base world).
+    /// Anchors `parent:` walks, `LoadWorld`'s `loader_path`, and
+    /// `SpawnEntity`'s anchor lookup.
+    pub origin_layer: Option<String>,
+    /// The trigger condition's entity, if any. `AddObjective` falls back to
+    /// this when the action lists no explicit `targets`.
+    pub entity_name: Option<String>,
+    /// Live entity name → UUID map.
+    ///
+    /// Rebuilt once per chaining pass (as is the runtime's `entity_groups`
+    /// map, which this module only writes to via
+    /// `DispatchResult::entity_group_inserts`) — a deliberate decision, so an
+    /// action resolves names a `SpawnEntity` earlier in the pass registered.
+    /// Issue #708: the old code read a tick-stale snapshot in the modifier arms
+    /// but the live map in `DestroyEntity`.
+    pub name_to_uuid: &'a HashMap<String, String>,
+    /// The base world's flag store (the root of every `parent:` walk).
+    ///
+    /// **MUST be the live store**, reflecting every command already applied
+    /// this pass: the applier applies each `DispatchResult` before dispatching
+    /// the next action. `before`/`after` — and hence whether a transition event
+    /// is emitted at all — are computed against it.
+    ///
+    /// `server::handle_ai_events`'s per-pass `base_flags_snapshot` /
+    /// `layer_flags_snapshot` locals exist for **condition evaluation only**
+    /// (deciding which triggers fire) and MUST NOT be passed here. They are in
+    /// scope at the call site, so this is the tempting wrong move. It breaks
+    /// flag idempotence: two triggers both `set_flag aphelion_armed`
+    /// (`assets/worlds/before_the_fire.toml:275`) against live stores go `0→1`
+    /// (emits `FlagSet`) then `1→1` (emits nothing) = one event, so the
+    /// downstream `on_flag_set` trigger fires exactly once. Against a snapshot
+    /// both read `before = 0`, emit `FlagSet` twice, and it double-fires.
+    pub base_flags: &'a FlagStore,
+    /// Loaded sub-world layers, keyed by world TOML path. Each layer's `flags`
+    /// carries the same live-store requirement as `base_flags`.
+    pub layers: &'a HashMap<String, LayerView>,
+    /// The base world's anchor table. Empty when no world config is loaded.
+    pub base_anchors: &'a HashMap<String, [f32; 3]>,
+    /// The live faction registry. `None` when the registry resource is absent,
+    /// which makes the two faction arms warn and skip.
+    pub factions: Option<&'a FactionRegistry>,
+    /// Source of fresh UUIDs for `SpawnEntity`. Injected because
+    /// `Uuid::new_v4()` is non-deterministic and would make the returned
+    /// `DispatchResult` unassertable.
+    pub uuid_source: &'a dyn Fn() -> String,
+}
+
+// ── Result ────────────────────────────────────────────────────────────────
+
+/// A flag mutation to apply to a resolved `FlagStore`.
+///
+/// Mirrors `FlagStore`'s mutators one-for-one.
+#[derive(Clone, Debug, PartialEq)]
+pub enum FlagMutation {
+    /// `set_flag` — counter := 1.
+    Set,
+    /// `clear_flag` — counter := 0.
+    Clear,
+    /// `increment_flag` — counter := counter.saturating_add(by).
+    Increment(i64),
+    /// `set_flag_value` — counter := value.
+    SetValue(i64),
+}
+
+/// A single side effect for the Bevy applier to perform.
+///
+/// Entity targets are UUID strings; faction targets are already-resolved
+/// `Uuid`s. Nothing here names a Bevy `Entity`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ActionCmd {
+    /// Add an objective with `targets` already resolved (explicit targets, or
+    /// the trigger entity as fallback).
+    AddObjective {
+        id: String,
+        text: String,
+        mandatory: bool,
+        targets: Vec<String>,
+        directive: AiDirective,
+        utility: UtilityConfig,
+        source: ObjectiveSource,
+    },
+    /// Mark an objective complete. A no-op for unknown / non-Active ids.
+    CompleteObjective { id: String },
+    /// Mark an objective failed. A no-op for unknown / non-Active ids.
+    FailObjective { id: String },
+    /// Add or update a float modifier on the entity with `uuid`.
+    ApplyModifier {
+        uuid: String,
+        tag: String,
+        slot: ModifierSlot,
+        bonus: f32,
+    },
+    /// Remove a float modifier from the entity with `uuid`.
+    RemoveModifier {
+        uuid: String,
+        tag: String,
+        slot: ModifierSlot,
+    },
+    /// Add a boolean flag modifier to the entity with `uuid`.
+    ApplyFlag {
+        uuid: String,
+        tag: String,
+        kind: FlagKind,
+    },
+    /// Remove a boolean flag modifier from the entity with `uuid`.
+    RemoveFlag {
+        uuid: String,
+        tag: String,
+        kind: FlagKind,
+    },
+    /// Add or update an integer modifier on the entity with `uuid`.
+    ApplyIntModifier {
+        uuid: String,
+        tag: String,
+        slot: IntModifierSlot,
+        bonus: i32,
+    },
+    /// Remove an integer modifier from the entity with `uuid`.
+    RemoveIntModifier {
+        uuid: String,
+        tag: String,
+        slot: IntModifierSlot,
+    },
+    /// Write the game-over reason resource.
+    ///
+    /// Always emitted *before* `SetNextState` — `OnEnter(GamePhase::GameOver)`
+    /// reads the reason, so the ordering is load-bearing.
+    SetGameOverReason { reason: String },
+    /// Queue a game-phase transition.
+    SetNextState { phase: GamePhase },
+    /// Additively load a sub-world. `loader_path` is the layer that issued the
+    /// action, recorded so `parent:` from the new layer resolves up to it.
+    LoadWorld {
+        path: String,
+        loader_path: Option<String>,
+    },
+    /// Unload a previously loaded sub-world.
+    UnloadWorld { path: String },
+    /// Apply `mutation` to `name` in `target_layer`'s store (`None` = base
+    /// world). `name` is already stripped of `parent:` prefixes and
+    /// `target_layer` is the walk's resolved destination.
+    MutateFlag {
+        target_layer: Option<String>,
+        name: String,
+        mutation: FlagMutation,
+    },
+    /// Spawn an entity. `position` is resolved (anchor lookups already done);
+    /// `uuid` came from `DispatchContext::uuid_source`. The applier loads
+    /// `template_path` and, when `layer_path` is `Some`, records the spawned
+    /// entity on that layer so `UnloadWorld` despawns it.
+    ///
+    /// If the template fails to resolve, nothing spawns and the result's
+    /// `name_to_uuid_inserts` / `entity_group_inserts` must be dropped too.
+    SpawnEntity {
+        template_path: String,
+        name: String,
+        uuid: String,
+        position: [f32; 3],
+        rotation: Option<[f32; 3]>,
+        scale: Option<[f32; 3]>,
+        groups: Vec<String>,
+        layer_path: Option<String>,
+    },
+    /// Destroy the entity with `uuid` and run the destruction cascade.
+    DestroyEntity { uuid: String },
+    /// Add `enemy_uuid` to `faction_uuid`'s enemies.
+    ///
+    /// Deliberately does *not* re-validate AI targets: adding a hostility
+    /// cannot invalidate an existing engagement, and the next `enemy_in_range`
+    /// tick picks the new relationship up organically.
+    AddFactionEnemy {
+        faction_uuid: Uuid,
+        enemy_uuid: Uuid,
+    },
+    /// Remove `enemy_uuid` from `faction_uuid`'s enemies. **Only if the removal
+    /// actually changed the registry** (`remove_enemy` returned true),
+    /// re-validate every AI controller's target so an in-progress engagement
+    /// does not stick on a now-friendly entity. Removing an absent hostility
+    /// changes nothing, so it must not trigger the revalidation sweep.
+    RemoveFactionEnemy {
+        faction_uuid: Uuid,
+        enemy_uuid: Uuid,
+    },
+}
+
+/// What one `TriggerAction` decided to do.
+///
+/// Every field is additive and may be empty — an action that hit a failure path
+/// returns only `warnings`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct DispatchResult {
+    /// Side effects for the applier, in the order they must be applied.
+    pub commands: Vec<ActionCmd>,
+    /// World events the action produced. **Destination-agnostic**: the caller
+    /// routes them (into the current tick's chaining pass, or onto the next
+    /// tick's queue).
+    pub new_events: Vec<WorldEvent>,
+    /// `(entity_name, uuid)` pairs to register in the runtime's name map.
+    ///
+    /// **Contingent when they come from `SpawnEntity`**: the applier MUST apply
+    /// them only if the accompanying `ActionCmd::SpawnEntity` actually spawned
+    /// (i.e. its template resolved). See that arm for why.
+    pub name_to_uuid_inserts: Vec<(String, String)>,
+    /// `(group, entity_name)` pairs to register for `OnAllDestroyed` tracking.
+    ///
+    /// Same contingency as `name_to_uuid_inserts`.
+    pub entity_group_inserts: Vec<(String, String)>,
+    /// Messages the applier should log at warn level.
+    pub warnings: Vec<String>,
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/// Push a `FlagSet` / `FlagCleared` event when the boolean view (`counter != 0`)
+/// of a flag flips.
+///
+/// `target_layer` is the *resolved* layer of the mutation (after `parent:`
+/// walking) — embedded in the event so layer-scoped `on_flag_set` /
+/// `on_flag_cleared` triggers only react to transitions in their own layer.
+fn push_flag_transition(
+    events: &mut Vec<WorldEvent>,
+    name: &str,
+    target_layer: &Option<String>,
+    before: i64,
+    after: i64,
+) {
+    let was_set = before != 0;
+    let is_set = after != 0;
+    if was_set == is_set {
+        return;
+    }
+    if is_set {
+        events.push(WorldEvent::FlagSet {
+            name: name.to_string(),
+            origin_layer: target_layer.clone(),
+        });
+    } else {
+        events.push(WorldEvent::FlagCleared {
+            name: name.to_string(),
+            origin_layer: target_layer.clone(),
+        });
+    }
+}
+
+/// Resolve which layer a flag mutation targets, honouring `parent:` prefixes.
+///
+/// Each leading `parent:` walks one step up the loader chain from
+/// `ctx.origin_layer`. Returns `(target_layer, stripped_name)` on success, or
+/// the warning text on failure. There are two distinct failure modes and one
+/// deliberate silent case:
+///
+/// * The walk overruns the base world → `Err` (no mutation, no event). This
+///   keeps two scenarios from polluting each other's flag namespace.
+/// * The resolved target layer is absent from the layer map → `Err`.
+/// * A layer is missing from the map *mid-walk* → silently treated as the base
+///   world, and the walk continues.
+fn resolve_flag_target(
+    ctx: &DispatchContext,
+    name: &str,
+) -> Result<(Option<String>, String), String> {
+    let mut depth = 0usize;
+    let mut rest = name;
+    while let Some(stripped) = rest.strip_prefix("parent:") {
+        depth += 1;
+        rest = stripped;
+    }
+    let stripped = rest.to_string();
+
+    let origin_layer = &ctx.origin_layer;
+    let mut cur = origin_layer.clone();
+    for _ in 0..depth {
+        match cur {
+            None => {
+                return Err(format!(
+                    "'{name}' from origin {origin_layer:?} walks past base world — ignoring"
+                ));
+            }
+            Some(ref path) => {
+                // A missing layer entry resolves to `None` — i.e. treated as
+                // the base world — and the walk continues from there.
+                cur = ctx.layers.get(path).and_then(|l| l.loader_path.clone());
+            }
+        }
+    }
+    let target_layer = cur;
+
+    if let Some(path) = &target_layer {
+        if !ctx.layers.contains_key(path) {
+            return Err(format!(
+                "target layer '{path}' missing from WorldLayerMap — ignoring '{name}'"
+            ));
+        }
+    }
+    Ok((target_layer, stripped))
+}
+
+/// Compute what `mutation` *would* do to `name` in `store`, without mutating.
+///
+/// Mirrors `FlagStore::set_flag` / `clear_flag` / `increment_flag` /
+/// `set_flag_value` exactly, including `increment`'s saturating add.
+fn preview_mutation(store: &FlagStore, name: &str, mutation: &FlagMutation) -> (i64, i64) {
+    let before = store.counter(name);
+    let after = match mutation {
+        FlagMutation::Set => 1,
+        FlagMutation::Clear => 0,
+        FlagMutation::Increment(by) => before.saturating_add(*by),
+        FlagMutation::SetValue(v) => *v,
+    };
+    (before, after)
+}
+
+/// Read-only lookup of the store a resolved `target_layer` points at.
+fn store_for<'a>(ctx: &'a DispatchContext, target_layer: &Option<String>) -> &'a FlagStore {
+    match target_layer {
+        None => ctx.base_flags,
+        // `resolve_flag_target` already proved the entry exists.
+        Some(path) => ctx
+            .layers
+            .get(path)
+            .map(|l| &l.flags)
+            .unwrap_or(ctx.base_flags),
+    }
+}
+
+/// Shared body of the four flag-mutation arms.
+fn dispatch_flag_mutation(
+    ctx: &DispatchContext,
+    name: &str,
+    mutation: FlagMutation,
+    out: &mut DispatchResult,
+) {
+    let (target_layer, stripped) = match resolve_flag_target(ctx, name) {
+        Ok(v) => v,
+        Err(warning) => {
+            out.warnings.push(warning);
+            return;
+        }
+    };
+    let (before, after) = preview_mutation(store_for(ctx, &target_layer), &stripped, &mutation);
+    out.commands.push(ActionCmd::MutateFlag {
+        target_layer: target_layer.clone(),
+        name: stripped.clone(),
+        mutation,
+    });
+    push_flag_transition(&mut out.new_events, &stripped, &target_layer, before, after);
+}
+
+// ── Dispatch ──────────────────────────────────────────────────────────────
+
+/// Decide what a single `TriggerAction` should do.
+///
+/// Pure: reads `context`, mutates nothing, returns a `DispatchResult` the Bevy
+/// applier turns into real side effects. Covers every `TriggerAction` variant.
+pub fn dispatch_action(action: &TriggerAction, context: &DispatchContext) -> DispatchResult {
+    let mut out = DispatchResult::default();
+
+    match action {
+        TriggerAction::AddObjective {
+            id,
+            text,
+            mandatory,
+            targets,
+            directive,
+            utility,
+            source,
+        } => {
+            // Explicit targets win; otherwise fall back to the trigger
+            // condition's entity (legacy behaviour).
+            let resolved: Vec<String> = if targets.is_empty() {
+                context.entity_name.clone().into_iter().collect()
+            } else {
+                targets.clone()
+            };
+            out.commands.push(ActionCmd::AddObjective {
+                id: id.clone(),
+                text: text.clone(),
+                mandatory: *mandatory,
+                targets: resolved,
+                directive: directive.clone(),
+                utility: utility.clone(),
+                source: source.clone(),
+            });
+        }
+
+        TriggerAction::CompleteObjective { id } => {
+            out.commands
+                .push(ActionCmd::CompleteObjective { id: id.clone() });
+        }
+
+        TriggerAction::FailObjective { id } => {
+            out.commands
+                .push(ActionCmd::FailObjective { id: id.clone() });
+        }
+
+        TriggerAction::SetAiState {
+            entity,
+            state,
+            target: _,
+        } => {
+            // No-op in doctrine-based AI (issue #572). FSM state slots are
+            // gone; NPC behaviour is now driven by the scored doctrine pool.
+            out.warnings.push(format!(
+                "SetAiState('{entity}' → '{state}') ignored — doctrine-based AI"
+            ));
+        }
+
+        TriggerAction::ApplyModifier {
+            entity,
+            tag,
+            slot,
+            bonus,
+        } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("ApplyModifier: unknown entity name '{entity}'"));
+                return out;
+            };
+            out.commands.push(ActionCmd::ApplyModifier {
+                uuid: uuid.clone(),
+                tag: tag.clone(),
+                slot: slot.clone(),
+                bonus: *bonus,
+            });
+        }
+
+        TriggerAction::RemoveModifier { entity, tag, slot } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("RemoveModifier: unknown entity name '{entity}'"));
+                return out;
+            };
+            out.commands.push(ActionCmd::RemoveModifier {
+                uuid: uuid.clone(),
+                tag: tag.clone(),
+                slot: slot.clone(),
+            });
+        }
+
+        TriggerAction::ApplyFlag { entity, tag, kind } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("ApplyFlag: unknown entity name '{entity}'"));
+                return out;
+            };
+            out.commands.push(ActionCmd::ApplyFlag {
+                uuid: uuid.clone(),
+                tag: tag.clone(),
+                kind: kind.clone(),
+            });
+        }
+
+        TriggerAction::RemoveFlag { entity, tag, kind } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("RemoveFlag: unknown entity name '{entity}'"));
+                return out;
+            };
+            out.commands.push(ActionCmd::RemoveFlag {
+                uuid: uuid.clone(),
+                tag: tag.clone(),
+                kind: kind.clone(),
+            });
+        }
+
+        TriggerAction::ApplyIntModifier {
+            entity,
+            tag,
+            slot,
+            bonus,
+        } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("ApplyIntModifier: unknown entity name '{entity}'"));
+                return out;
+            };
+            out.commands.push(ActionCmd::ApplyIntModifier {
+                uuid: uuid.clone(),
+                tag: tag.clone(),
+                slot: slot.clone(),
+                bonus: *bonus,
+            });
+        }
+
+        TriggerAction::RemoveIntModifier { entity, tag, slot } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("RemoveIntModifier: unknown entity name '{entity}'"));
+                return out;
+            };
+            out.commands.push(ActionCmd::RemoveIntModifier {
+                uuid: uuid.clone(),
+                tag: tag.clone(),
+                slot: slot.clone(),
+            });
+        }
+
+        TriggerAction::GameOver { message } => {
+            // `None` becomes `Some("")`, not `None` — preserved verbatim.
+            let reason = message.clone().unwrap_or_default();
+            // Reason first: `OnEnter(GamePhase::GameOver)` reads it.
+            out.commands.push(ActionCmd::SetGameOverReason { reason });
+            out.commands.push(ActionCmd::SetNextState {
+                phase: GamePhase::GameOver,
+            });
+        }
+
+        TriggerAction::LoadWorld { path } => {
+            out.commands.push(ActionCmd::LoadWorld {
+                path: path.clone(),
+                loader_path: context.origin_layer.clone(),
+            });
+        }
+
+        TriggerAction::UnloadWorld { path } => {
+            out.commands
+                .push(ActionCmd::UnloadWorld { path: path.clone() });
+        }
+
+        TriggerAction::SetWorldFlag { name } => {
+            dispatch_flag_mutation(context, name, FlagMutation::Set, &mut out);
+        }
+
+        TriggerAction::ClearWorldFlag { name } => {
+            dispatch_flag_mutation(context, name, FlagMutation::Clear, &mut out);
+        }
+
+        TriggerAction::IncrementWorldFlag { name, by } => {
+            dispatch_flag_mutation(context, name, FlagMutation::Increment(*by), &mut out);
+        }
+
+        TriggerAction::SetWorldFlagValue { name, value } => {
+            dispatch_flag_mutation(context, name, FlagMutation::SetValue(*value), &mut out);
+        }
+
+        TriggerAction::SpawnEntity {
+            template_path,
+            name,
+            anchor,
+            position,
+            rotation,
+            scale,
+            groups,
+        } => {
+            // Resolve spawn position. `anchor` looks up in the origin layer's
+            // anchors (or the base world's anchors for a `None` origin).
+            // `position` is used directly.
+            let resolved_position: [f32; 3] = if let Some(pos) = position {
+                *pos
+            } else if let Some(anchor_name) = anchor {
+                let lookup = match &context.origin_layer {
+                    Some(layer_path) => context
+                        .layers
+                        .get(layer_path)
+                        .and_then(|l| l.anchors.get(anchor_name).copied()),
+                    None => context.base_anchors.get(anchor_name).copied(),
+                };
+                match lookup {
+                    Some(p) => p,
+                    None => {
+                        out.warnings.push(format!(
+                            "SpawnEntity '{name}' anchor '{anchor_name}' not found"
+                        ));
+                        return out;
+                    }
+                }
+            } else {
+                out.warnings.push(format!(
+                    "SpawnEntity '{name}' has neither anchor nor position"
+                ));
+                return out;
+            };
+
+            let uuid = (context.uuid_source)();
+
+            out.commands.push(ActionCmd::SpawnEntity {
+                template_path: template_path.clone(),
+                name: name.clone(),
+                uuid: uuid.clone(),
+                position: resolved_position,
+                rotation: *rotation,
+                scale: *scale,
+                groups: groups.clone(),
+                layer_path: context.origin_layer.clone(),
+            });
+
+            // Register name → uuid for subsequent triggers, and the entity in
+            // its groups for `OnAllDestroyed` tracking.
+            //
+            // Both are **contingent on the spawn succeeding**. Template loading
+            // is still the applier's job (issue #715 moves it in here behind a
+            // `TemplateLoader` trait), and these live in `DispatchResult` fields
+            // separate from `commands`, so nothing in the data says they depend
+            // on the `ActionCmd::SpawnEntity` above. The applier MUST apply them
+            // only if that command actually spawned — `server::handle_ai_events`
+            // resolves the template first and `continue`s on failure, so a
+            // failed spawn registers no name and no group membership.
+            //
+            // Registering them anyway leaves a phantom name → uuid entry. That
+            // mostly degrades to a "no ECS entity with UUID" warning, but
+            // `DestroyEntity` would still emit `WorldEvent::Destroyed` +
+            // `AiEntityDestroyed` for an entity that never spawned, firing
+            // `on_destroyed` triggers for a ghost.
+            //
+            // `ActionCmd::SpawnEntity` already carries `name`, `uuid` and
+            // `groups`, so the applier may instead derive both from the command
+            // at the point it knows the spawn succeeded.
+            out.name_to_uuid_inserts.push((name.clone(), uuid));
+
+            for g in groups {
+                out.entity_group_inserts.push((g.clone(), name.clone()));
+            }
+        }
+
+        TriggerAction::DestroyEntity { entity } => {
+            let Some(uuid) = context.name_to_uuid.get(entity) else {
+                out.warnings
+                    .push(format!("DestroyEntity: unknown entity name '{entity}'"));
+                return out;
+            };
+            // The event lets chained `on_destroyed` triggers observe the kill;
+            // the command runs the despawn + destruction cascade.
+            out.new_events
+                .push(WorldEvent::Destroyed { uuid: uuid.clone() });
+            out.commands
+                .push(ActionCmd::DestroyEntity { uuid: uuid.clone() });
+        }
+
+        TriggerAction::AddFactionEnemy { faction, enemy } => {
+            let Some(registry) = context.factions else {
+                out.warnings.push(
+                    "AddFactionEnemy skipped: FactionRegistryResource not present".to_string(),
+                );
+                return out;
+            };
+            let Some(faction_uuid) = registry.uuid_by_name(faction) else {
+                out.warnings
+                    .push(format!("AddFactionEnemy: unknown faction name '{faction}'"));
+                return out;
+            };
+            let Some(enemy_uuid) = registry.uuid_by_name(enemy) else {
+                out.warnings.push(format!(
+                    "AddFactionEnemy: unknown enemy faction name '{enemy}'"
+                ));
+                return out;
+            };
+            out.commands.push(ActionCmd::AddFactionEnemy {
+                faction_uuid,
+                enemy_uuid,
+            });
+        }
+
+        TriggerAction::RemoveFactionEnemy { faction, enemy } => {
+            let Some(registry) = context.factions else {
+                out.warnings.push(
+                    "RemoveFactionEnemy skipped: FactionRegistryResource not present".to_string(),
+                );
+                return out;
+            };
+            let Some(faction_uuid) = registry.uuid_by_name(faction) else {
+                out.warnings.push(format!(
+                    "RemoveFactionEnemy: unknown faction name '{faction}'"
+                ));
+                return out;
+            };
+            let Some(enemy_uuid) = registry.uuid_by_name(enemy) else {
+                out.warnings.push(format!(
+                    "RemoveFactionEnemy: unknown enemy faction name '{enemy}'"
+                ));
+                return out;
+            };
+            out.commands.push(ActionCmd::RemoveFactionEnemy {
+                faction_uuid,
+                enemy_uuid,
+            });
+        }
+    }
+
+    out
+}
+
+// ── Unit Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::faction::FactionConfig;
+
+    /// Deterministic stand-in for `entity_loader::assign_uuid()`.
+    const STUB_UUID: &str = "stub-uuid-0001";
+
+    fn stub_uuid() -> String {
+        STUB_UUID.to_string()
+    }
+
+    /// Owned backing store for a `DispatchContext`. Tests mutate the public
+    /// fields then call `ctx()` to borrow a context out of it.
+    #[derive(Default)]
+    struct Fixture {
+        origin_layer: Option<String>,
+        entity_name: Option<String>,
+        name_to_uuid: HashMap<String, String>,
+        base_flags: FlagStore,
+        layers: HashMap<String, LayerView>,
+        base_anchors: HashMap<String, [f32; 3]>,
+        factions: Option<FactionRegistry>,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn ctx(&self) -> DispatchContext<'_> {
+            DispatchContext {
+                origin_layer: self.origin_layer.clone(),
+                entity_name: self.entity_name.clone(),
+                name_to_uuid: &self.name_to_uuid,
+                base_flags: &self.base_flags,
+                layers: &self.layers,
+                base_anchors: &self.base_anchors,
+                factions: self.factions.as_ref(),
+                uuid_source: &stub_uuid,
+            }
+        }
+
+        fn with_entity(mut self, name: &str, uuid: &str) -> Self {
+            self.name_to_uuid.insert(name.to_string(), uuid.to_string());
+            self
+        }
+    }
+
+    fn layer(loader_path: Option<&str>) -> LayerView {
+        LayerView {
+            flags: FlagStore::new(),
+            loader_path: loader_path.map(str::to_string),
+            anchors: HashMap::new(),
+        }
+    }
+
+    /// A registry with two named factions plus their UUIDs.
+    fn two_factions() -> (FactionRegistry, Uuid, Uuid) {
+        let harrow = Uuid::from_u128(1);
+        let federation = Uuid::from_u128(2);
+        let mut registry = FactionRegistry::new();
+        registry.insert(FactionConfig {
+            uuid: harrow,
+            name: "Harrow".to_string(),
+            enemies: vec![],
+        });
+        registry.insert(FactionConfig {
+            uuid: federation,
+            name: "Federation".to_string(),
+            enemies: vec![],
+        });
+        (registry, harrow, federation)
+    }
+
+    fn add_objective(targets: Vec<&str>) -> TriggerAction {
+        TriggerAction::AddObjective {
+            id: "obj1".to_string(),
+            text: "Destroy the convoy".to_string(),
+            mandatory: true,
+            targets: targets.into_iter().map(str::to_string).collect(),
+            directive: AiDirective::default(),
+            utility: UtilityConfig::default(),
+            source: ObjectiveSource::default(),
+        }
+    }
+
+    fn spawn(anchor: Option<&str>, position: Option<[f32; 3]>, groups: Vec<&str>) -> TriggerAction {
+        TriggerAction::SpawnEntity {
+            template_path: "assets/entities/destroyer.toml".to_string(),
+            name: "wave_1".to_string(),
+            anchor: anchor.map(str::to_string),
+            position,
+            rotation: None,
+            scale: None,
+            groups: groups.into_iter().map(str::to_string).collect(),
+        }
+    }
+
+    // ── AddObjective ──────────────────────────────────────────────────────
+
+    #[test]
+    fn add_objective_uses_explicit_targets() {
+        let mut fx = Fixture::new();
+        fx.entity_name = Some("trigger_ship".to_string());
+        let out = dispatch_action(&add_objective(vec!["alpha", "beta"]), &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::AddObjective {
+                id: "obj1".to_string(),
+                text: "Destroy the convoy".to_string(),
+                mandatory: true,
+                targets: vec!["alpha".to_string(), "beta".to_string()],
+                directive: AiDirective::default(),
+                utility: UtilityConfig::default(),
+                source: ObjectiveSource::default(),
+            }]
+        );
+        assert!(out.warnings.is_empty());
+        assert!(out.new_events.is_empty());
+    }
+
+    #[test]
+    fn add_objective_empty_targets_falls_back_to_trigger_entity() {
+        let mut fx = Fixture::new();
+        fx.entity_name = Some("trigger_ship".to_string());
+        let out = dispatch_action(&add_objective(vec![]), &fx.ctx());
+
+        let ActionCmd::AddObjective { targets, .. } = &out.commands[0] else {
+            panic!("expected AddObjective");
+        };
+        assert_eq!(targets, &vec!["trigger_ship".to_string()]);
+    }
+
+    #[test]
+    fn add_objective_empty_targets_and_no_entity_name_resolves_empty() {
+        let fx = Fixture::new();
+        let out = dispatch_action(&add_objective(vec![]), &fx.ctx());
+
+        let ActionCmd::AddObjective { targets, .. } = &out.commands[0] else {
+            panic!("expected AddObjective");
+        };
+        assert!(targets.is_empty());
+    }
+
+    // ── CompleteObjective / FailObjective ─────────────────────────────────
+
+    #[test]
+    fn complete_objective_emits_command() {
+        let fx = Fixture::new();
+        let action = TriggerAction::CompleteObjective {
+            id: "obj1".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::CompleteObjective {
+                id: "obj1".to_string()
+            }]
+        );
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn fail_objective_emits_command() {
+        let fx = Fixture::new();
+        let action = TriggerAction::FailObjective {
+            id: "obj1".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::FailObjective {
+                id: "obj1".to_string()
+            }]
+        );
+    }
+
+    // ── SetAiState ────────────────────────────────────────────────────────
+
+    #[test]
+    fn set_ai_state_is_a_noop_that_warns() {
+        let fx = Fixture::new();
+        let action = TriggerAction::SetAiState {
+            entity: "raider".to_string(),
+            state: "Attack".to_string(),
+            target: Some("player".to_string()),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert!(out.new_events.is_empty());
+        assert_eq!(out.warnings.len(), 1);
+        assert!(out.warnings[0].contains("doctrine-based AI"));
+    }
+
+    // ── Modifier arms ─────────────────────────────────────────────────────
+
+    #[test]
+    fn apply_modifier_resolves_name_to_uuid() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::ApplyModifier {
+            entity: "raider".to_string(),
+            tag: "buff".to_string(),
+            slot: ModifierSlot::MaxSpeed,
+            bonus: 2.5,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::ApplyModifier {
+                uuid: "uuid-raider".to_string(),
+                tag: "buff".to_string(),
+                slot: ModifierSlot::MaxSpeed,
+                bonus: 2.5,
+            }]
+        );
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn apply_modifier_unknown_entity_warns_and_emits_nothing() {
+        let fx = Fixture::new();
+        let action = TriggerAction::ApplyModifier {
+            entity: "ghost".to_string(),
+            tag: "buff".to_string(),
+            slot: ModifierSlot::MaxSpeed,
+            bonus: 2.5,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["ApplyModifier: unknown entity name 'ghost'".to_string()]
+        );
+    }
+
+    #[test]
+    fn remove_modifier_resolves_name_to_uuid() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::RemoveModifier {
+            entity: "raider".to_string(),
+            tag: "buff".to_string(),
+            slot: ModifierSlot::MaxSpeed,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::RemoveModifier {
+                uuid: "uuid-raider".to_string(),
+                tag: "buff".to_string(),
+                slot: ModifierSlot::MaxSpeed,
+            }]
+        );
+    }
+
+    #[test]
+    fn remove_modifier_unknown_entity_warns_and_emits_nothing() {
+        let fx = Fixture::new();
+        let action = TriggerAction::RemoveModifier {
+            entity: "ghost".to_string(),
+            tag: "buff".to_string(),
+            slot: ModifierSlot::MaxSpeed,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["RemoveModifier: unknown entity name 'ghost'".to_string()]
+        );
+    }
+
+    #[test]
+    fn apply_flag_resolves_name_to_uuid() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::ApplyFlag {
+            entity: "raider".to_string(),
+            tag: "cloak".to_string(),
+            kind: FlagKind::CommsJammed,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::ApplyFlag {
+                uuid: "uuid-raider".to_string(),
+                tag: "cloak".to_string(),
+                kind: FlagKind::CommsJammed,
+            }]
+        );
+    }
+
+    #[test]
+    fn apply_flag_unknown_entity_warns_and_emits_nothing() {
+        let fx = Fixture::new();
+        let action = TriggerAction::ApplyFlag {
+            entity: "ghost".to_string(),
+            tag: "cloak".to_string(),
+            kind: FlagKind::CommsJammed,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["ApplyFlag: unknown entity name 'ghost'".to_string()]
+        );
+    }
+
+    #[test]
+    fn remove_flag_resolves_name_to_uuid() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::RemoveFlag {
+            entity: "raider".to_string(),
+            tag: "cloak".to_string(),
+            kind: FlagKind::CommsJammed,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::RemoveFlag {
+                uuid: "uuid-raider".to_string(),
+                tag: "cloak".to_string(),
+                kind: FlagKind::CommsJammed,
+            }]
+        );
+    }
+
+    #[test]
+    fn remove_flag_unknown_entity_warns_and_emits_nothing() {
+        let fx = Fixture::new();
+        let action = TriggerAction::RemoveFlag {
+            entity: "ghost".to_string(),
+            tag: "cloak".to_string(),
+            kind: FlagKind::CommsJammed,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["RemoveFlag: unknown entity name 'ghost'".to_string()]
+        );
+    }
+
+    #[test]
+    fn apply_int_modifier_resolves_name_to_uuid() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::ApplyIntModifier {
+            entity: "raider".to_string(),
+            tag: "crew".to_string(),
+            slot: IntModifierSlot::RepairTeams,
+            bonus: 3,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::ApplyIntModifier {
+                uuid: "uuid-raider".to_string(),
+                tag: "crew".to_string(),
+                slot: IntModifierSlot::RepairTeams,
+                bonus: 3,
+            }]
+        );
+    }
+
+    #[test]
+    fn apply_int_modifier_unknown_entity_warns_and_emits_nothing() {
+        let fx = Fixture::new();
+        let action = TriggerAction::ApplyIntModifier {
+            entity: "ghost".to_string(),
+            tag: "crew".to_string(),
+            slot: IntModifierSlot::RepairTeams,
+            bonus: 3,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["ApplyIntModifier: unknown entity name 'ghost'".to_string()]
+        );
+    }
+
+    #[test]
+    fn remove_int_modifier_resolves_name_to_uuid() {
+        let fx = Fixture::new().with_entity("raider", "uuid-raider");
+        let action = TriggerAction::RemoveIntModifier {
+            entity: "raider".to_string(),
+            tag: "crew".to_string(),
+            slot: IntModifierSlot::RepairTeams,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::RemoveIntModifier {
+                uuid: "uuid-raider".to_string(),
+                tag: "crew".to_string(),
+                slot: IntModifierSlot::RepairTeams,
+            }]
+        );
+    }
+
+    #[test]
+    fn remove_int_modifier_unknown_entity_warns_and_emits_nothing() {
+        let fx = Fixture::new();
+        let action = TriggerAction::RemoveIntModifier {
+            entity: "ghost".to_string(),
+            tag: "crew".to_string(),
+            slot: IntModifierSlot::RepairTeams,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["RemoveIntModifier: unknown entity name 'ghost'".to_string()]
+        );
+    }
+
+    // ── GameOver ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn game_over_sets_reason_before_state() {
+        let fx = Fixture::new();
+        let action = TriggerAction::GameOver {
+            message: Some("The ship was lost".to_string()),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        // Ordering is load-bearing: OnEnter(GameOver) reads the reason.
+        assert_eq!(
+            out.commands,
+            vec![
+                ActionCmd::SetGameOverReason {
+                    reason: "The ship was lost".to_string()
+                },
+                ActionCmd::SetNextState {
+                    phase: GamePhase::GameOver
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn game_over_without_message_yields_empty_reason_not_none() {
+        let fx = Fixture::new();
+        let action = TriggerAction::GameOver { message: None };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands[0],
+            ActionCmd::SetGameOverReason {
+                reason: String::new()
+            }
+        );
+    }
+
+    // ── LoadWorld / UnloadWorld ───────────────────────────────────────────
+
+    #[test]
+    fn load_world_records_origin_layer_as_loader_path() {
+        let mut fx = Fixture::new();
+        fx.origin_layer = Some("worlds/sub.toml".to_string());
+        let action = TriggerAction::LoadWorld {
+            path: "worlds/next.toml".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::LoadWorld {
+                path: "worlds/next.toml".to_string(),
+                loader_path: Some("worlds/sub.toml".to_string()),
+            }]
+        );
+    }
+
+    #[test]
+    fn load_world_from_base_world_has_no_loader_path() {
+        let fx = Fixture::new();
+        let action = TriggerAction::LoadWorld {
+            path: "worlds/next.toml".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::LoadWorld {
+                path: "worlds/next.toml".to_string(),
+                loader_path: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn unload_world_emits_command() {
+        let fx = Fixture::new();
+        let action = TriggerAction::UnloadWorld {
+            path: "worlds/sub.toml".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::UnloadWorld {
+                path: "worlds/sub.toml".to_string()
+            }]
+        );
+    }
+
+    // ── SetWorldFlag ──────────────────────────────────────────────────────
+
+    #[test]
+    fn set_world_flag_emits_mutation_and_flag_set_event() {
+        let fx = Fixture::new();
+        let action = TriggerAction::SetWorldFlag {
+            name: "alarm".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::MutateFlag {
+                target_layer: None,
+                name: "alarm".to_string(),
+                mutation: FlagMutation::Set,
+            }]
+        );
+        assert_eq!(
+            out.new_events,
+            vec![WorldEvent::FlagSet {
+                name: "alarm".to_string(),
+                origin_layer: None,
+            }]
+        );
+    }
+
+    /// Pins flag idempotence, which depends on `base_flags` being the *live*
+    /// store: a second `set_flag` of an armed flag must still command the
+    /// mutation but emit no transition, so a downstream `on_flag_set` trigger
+    /// fires exactly once no matter how many triggers set it
+    /// (`assets/worlds/before_the_fire.toml:275`). Passing a per-pass snapshot
+    /// instead would make both setters read `before = 0` and double-fire.
+    #[test]
+    fn set_world_flag_on_already_set_flag_emits_no_transition_event() {
+        let mut fx = Fixture::new();
+        fx.base_flags.set_flag_value("alarm", 1);
+        let action = TriggerAction::SetWorldFlag {
+            name: "alarm".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::MutateFlag {
+                target_layer: None,
+                name: "alarm".to_string(),
+                mutation: FlagMutation::Set,
+            }]
+        );
+        assert!(out.new_events.is_empty());
+    }
+
+    // ── ClearWorldFlag ────────────────────────────────────────────────────
+
+    #[test]
+    fn clear_world_flag_emits_mutation_and_flag_cleared_event() {
+        let mut fx = Fixture::new();
+        fx.base_flags.set_flag_value("alarm", 1);
+        let action = TriggerAction::ClearWorldFlag {
+            name: "alarm".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::MutateFlag {
+                target_layer: None,
+                name: "alarm".to_string(),
+                mutation: FlagMutation::Clear,
+            }]
+        );
+        assert_eq!(
+            out.new_events,
+            vec![WorldEvent::FlagCleared {
+                name: "alarm".to_string(),
+                origin_layer: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn clear_world_flag_already_clear_mutates_without_an_event() {
+        let fx = Fixture::new();
+        let action = TriggerAction::ClearWorldFlag {
+            name: "alarm".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(out.commands.len(), 1);
+        assert!(out.new_events.is_empty());
+    }
+
+    // ── IncrementWorldFlag ────────────────────────────────────────────────
+
+    #[test]
+    fn increment_world_flag_zero_to_nonzero_emits_flag_set() {
+        let fx = Fixture::new();
+        let action = TriggerAction::IncrementWorldFlag {
+            name: "kills".to_string(),
+            by: 1,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::MutateFlag {
+                target_layer: None,
+                name: "kills".to_string(),
+                mutation: FlagMutation::Increment(1),
+            }]
+        );
+        assert_eq!(
+            out.new_events,
+            vec![WorldEvent::FlagSet {
+                name: "kills".to_string(),
+                origin_layer: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn increment_world_flag_nonzero_to_nonzero_emits_no_event() {
+        let mut fx = Fixture::new();
+        fx.base_flags.set_flag_value("kills", 3);
+        let action = TriggerAction::IncrementWorldFlag {
+            name: "kills".to_string(),
+            by: 2,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(out.commands.len(), 1);
+        assert!(out.new_events.is_empty());
+    }
+
+    #[test]
+    fn increment_world_flag_to_zero_emits_flag_cleared() {
+        let mut fx = Fixture::new();
+        fx.base_flags.set_flag_value("kills", 2);
+        let action = TriggerAction::IncrementWorldFlag {
+            name: "kills".to_string(),
+            by: -2,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.new_events,
+            vec![WorldEvent::FlagCleared {
+                name: "kills".to_string(),
+                origin_layer: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn increment_world_flag_overflow_does_not_panic() {
+        let mut fx = Fixture::new();
+        fx.base_flags.set_flag_value("kills", i64::MAX);
+        let action = TriggerAction::IncrementWorldFlag {
+            name: "kills".to_string(),
+            by: 5,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        // Only the no-panic property is testable here: `ActionCmd::MutateFlag`
+        // carries the mutation, not the resulting value, so saturating-vs-
+        // wrapping is unobservable through `dispatch_action` — both stay
+        // non-zero, so both emit one command and no event. `saturating_add`
+        // fidelity is `FlagStore`'s contract and is tested at `flags.rs`.
+        assert_eq!(out.commands.len(), 1);
+        assert!(out.new_events.is_empty());
+    }
+
+    // ── SetWorldFlagValue ─────────────────────────────────────────────────
+
+    #[test]
+    fn set_world_flag_value_zero_emits_flag_cleared() {
+        let mut fx = Fixture::new();
+        fx.base_flags.set_flag_value("alarm", 7);
+        let action = TriggerAction::SetWorldFlagValue {
+            name: "alarm".to_string(),
+            value: 0,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::MutateFlag {
+                target_layer: None,
+                name: "alarm".to_string(),
+                mutation: FlagMutation::SetValue(0),
+            }]
+        );
+        assert_eq!(
+            out.new_events,
+            vec![WorldEvent::FlagCleared {
+                name: "alarm".to_string(),
+                origin_layer: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn set_world_flag_value_nonzero_to_nonzero_emits_no_event() {
+        let mut fx = Fixture::new();
+        fx.base_flags.set_flag_value("alarm", 7);
+        let action = TriggerAction::SetWorldFlagValue {
+            name: "alarm".to_string(),
+            value: 9,
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(out.commands.len(), 1);
+        assert!(out.new_events.is_empty());
+    }
+
+    // ── Flag layer walking ────────────────────────────────────────────────
+
+    #[test]
+    fn flag_without_prefix_targets_the_origin_layer() {
+        let mut fx = Fixture::new();
+        fx.origin_layer = Some("sub.toml".to_string());
+        fx.layers.insert("sub.toml".to_string(), layer(None));
+        let action = TriggerAction::SetWorldFlag {
+            name: "alarm".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::MutateFlag {
+                target_layer: Some("sub.toml".to_string()),
+                name: "alarm".to_string(),
+                mutation: FlagMutation::Set,
+            }]
+        );
+        assert_eq!(
+            out.new_events,
+            vec![WorldEvent::FlagSet {
+                name: "alarm".to_string(),
+                origin_layer: Some("sub.toml".to_string()),
+            }]
+        );
+    }
+
+    #[test]
+    fn flag_parent_prefix_walks_one_layer_up_to_base() {
+        let mut fx = Fixture::new();
+        fx.origin_layer = Some("sub.toml".to_string());
+        // `loader_path: None` = loaded by the base world.
+        fx.layers.insert("sub.toml".to_string(), layer(None));
+        let action = TriggerAction::SetWorldFlag {
+            name: "parent:alarm".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::MutateFlag {
+                target_layer: None,
+                name: "alarm".to_string(),
+                mutation: FlagMutation::Set,
+            }]
+        );
+        assert_eq!(
+            out.new_events,
+            vec![WorldEvent::FlagSet {
+                name: "alarm".to_string(),
+                origin_layer: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn flag_parent_prefix_reads_the_target_layers_store_not_the_origins() {
+        let mut fx = Fixture::new();
+        fx.origin_layer = Some("inner.toml".to_string());
+        // inner was loaded by outer; outer was loaded by the base world.
+        fx.layers
+            .insert("inner.toml".to_string(), layer(Some("outer.toml")));
+        let mut outer = layer(None);
+        // Already set in the *parent* store: no transition should be emitted.
+        outer.flags.set_flag_value("alarm", 1);
+        fx.layers.insert("outer.toml".to_string(), outer);
+
+        let action = TriggerAction::SetWorldFlag {
+            name: "parent:alarm".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::MutateFlag {
+                target_layer: Some("outer.toml".to_string()),
+                name: "alarm".to_string(),
+                mutation: FlagMutation::Set,
+            }]
+        );
+        assert!(out.new_events.is_empty());
+    }
+
+    #[test]
+    fn flag_double_parent_prefix_walks_two_layers_up() {
+        let mut fx = Fixture::new();
+        fx.origin_layer = Some("inner.toml".to_string());
+        fx.layers
+            .insert("inner.toml".to_string(), layer(Some("outer.toml")));
+        fx.layers.insert("outer.toml".to_string(), layer(None));
+
+        let action = TriggerAction::SetWorldFlag {
+            name: "parent:parent:alarm".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::MutateFlag {
+                target_layer: None,
+                name: "alarm".to_string(),
+                mutation: FlagMutation::Set,
+            }]
+        );
+    }
+
+    #[test]
+    fn flag_walk_past_base_world_warns_and_emits_nothing() {
+        // Origin is already the base world, so any `parent:` overruns.
+        let fx = Fixture::new();
+        let action = TriggerAction::SetWorldFlag {
+            name: "parent:alarm".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert!(out.new_events.is_empty());
+        assert_eq!(out.warnings.len(), 1);
+        assert!(out.warnings[0].contains("walks past base world"));
+    }
+
+    #[test]
+    fn flag_walk_past_base_world_from_a_layer_warns_and_emits_nothing() {
+        let mut fx = Fixture::new();
+        fx.origin_layer = Some("sub.toml".to_string());
+        fx.layers.insert("sub.toml".to_string(), layer(None));
+        // sub → base → overrun.
+        let action = TriggerAction::SetWorldFlag {
+            name: "parent:parent:alarm".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert!(out.new_events.is_empty());
+        assert_eq!(out.warnings.len(), 1);
+        assert!(out.warnings[0].contains("walks past base world"));
+    }
+
+    #[test]
+    fn flag_target_layer_missing_from_map_warns_and_emits_nothing() {
+        let mut fx = Fixture::new();
+        // The trigger's own layer is not in the map, and there is no `parent:`
+        // to walk, so the resolved target is a layer we cannot find.
+        fx.origin_layer = Some("ghost.toml".to_string());
+        let action = TriggerAction::SetWorldFlag {
+            name: "alarm".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert!(out.new_events.is_empty());
+        assert_eq!(out.warnings.len(), 1);
+        assert!(out.warnings[0].contains("missing from WorldLayerMap"));
+    }
+
+    #[test]
+    fn flag_layer_missing_mid_walk_is_silent_and_treated_as_base() {
+        let mut fx = Fixture::new();
+        // `ghost.toml` is absent from the map: the walk silently resolves its
+        // loader_path to `None` (base) and carries on. This is deliberate —
+        // only the *final* lookup warns.
+        fx.origin_layer = Some("ghost.toml".to_string());
+        let action = TriggerAction::SetWorldFlag {
+            name: "parent:alarm".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.warnings.is_empty());
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::MutateFlag {
+                target_layer: None,
+                name: "alarm".to_string(),
+                mutation: FlagMutation::Set,
+            }]
+        );
+        assert_eq!(
+            out.new_events,
+            vec![WorldEvent::FlagSet {
+                name: "alarm".to_string(),
+                origin_layer: None,
+            }]
+        );
+    }
+
+    // ── SpawnEntity ───────────────────────────────────────────────────────
+
+    #[test]
+    fn spawn_entity_with_explicit_position() {
+        let fx = Fixture::new();
+        let out = dispatch_action(&spawn(None, Some([1.0, 2.0, 3.0]), vec![]), &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::SpawnEntity {
+                template_path: "assets/entities/destroyer.toml".to_string(),
+                name: "wave_1".to_string(),
+                uuid: STUB_UUID.to_string(),
+                position: [1.0, 2.0, 3.0],
+                rotation: None,
+                scale: None,
+                groups: vec![],
+                layer_path: None,
+            }]
+        );
+        assert_eq!(
+            out.name_to_uuid_inserts,
+            vec![("wave_1".to_string(), STUB_UUID.to_string())]
+        );
+        assert!(out.entity_group_inserts.is_empty());
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn spawn_entity_resolves_anchor_from_base_world() {
+        let mut fx = Fixture::new();
+        fx.base_anchors
+            .insert("staging".to_string(), [10.0, 0.0, -5.0]);
+        let out = dispatch_action(&spawn(Some("staging"), None, vec![]), &fx.ctx());
+
+        let ActionCmd::SpawnEntity { position, .. } = &out.commands[0] else {
+            panic!("expected SpawnEntity");
+        };
+        assert_eq!(position, &[10.0, 0.0, -5.0]);
+    }
+
+    #[test]
+    fn spawn_entity_resolves_anchor_from_the_origin_layer() {
+        let mut fx = Fixture::new();
+        fx.origin_layer = Some("sub.toml".to_string());
+        let mut sub = layer(None);
+        sub.anchors.insert("staging".to_string(), [4.0, 5.0, 6.0]);
+        fx.layers.insert("sub.toml".to_string(), sub);
+        // A same-named base anchor must NOT win for a layer-authored trigger.
+        fx.base_anchors
+            .insert("staging".to_string(), [99.0, 99.0, 99.0]);
+
+        let out = dispatch_action(&spawn(Some("staging"), None, vec![]), &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::SpawnEntity {
+                template_path: "assets/entities/destroyer.toml".to_string(),
+                name: "wave_1".to_string(),
+                uuid: STUB_UUID.to_string(),
+                position: [4.0, 5.0, 6.0],
+                rotation: None,
+                scale: None,
+                groups: vec![],
+                layer_path: Some("sub.toml".to_string()),
+            }]
+        );
+    }
+
+    #[test]
+    fn spawn_entity_position_wins_over_anchor() {
+        let mut fx = Fixture::new();
+        fx.base_anchors
+            .insert("staging".to_string(), [10.0, 0.0, -5.0]);
+        let out = dispatch_action(
+            &spawn(Some("staging"), Some([1.0, 1.0, 1.0]), vec![]),
+            &fx.ctx(),
+        );
+
+        let ActionCmd::SpawnEntity { position, .. } = &out.commands[0] else {
+            panic!("expected SpawnEntity");
+        };
+        assert_eq!(position, &[1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn spawn_entity_unknown_anchor_warns_and_emits_nothing() {
+        let fx = Fixture::new();
+        let out = dispatch_action(&spawn(Some("nowhere"), None, vec![]), &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert!(out.name_to_uuid_inserts.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["SpawnEntity 'wave_1' anchor 'nowhere' not found".to_string()]
+        );
+    }
+
+    #[test]
+    fn spawn_entity_without_anchor_or_position_warns_and_emits_nothing() {
+        let fx = Fixture::new();
+        let out = dispatch_action(&spawn(None, None, vec![]), &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert!(out.name_to_uuid_inserts.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["SpawnEntity 'wave_1' has neither anchor nor position".to_string()]
+        );
+    }
+
+    #[test]
+    fn spawn_entity_registers_every_group() {
+        let fx = Fixture::new();
+        let out = dispatch_action(
+            &spawn(None, Some([0.0, 0.0, 0.0]), vec!["wave", "hostiles"]),
+            &fx.ctx(),
+        );
+
+        assert_eq!(
+            out.entity_group_inserts,
+            vec![
+                ("wave".to_string(), "wave_1".to_string()),
+                ("hostiles".to_string(), "wave_1".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn spawn_entity_carries_rotation_and_scale_through() {
+        let fx = Fixture::new();
+        let action = TriggerAction::SpawnEntity {
+            template_path: "assets/entities/destroyer.toml".to_string(),
+            name: "wave_1".to_string(),
+            anchor: None,
+            position: Some([0.0, 0.0, 0.0]),
+            rotation: Some([0.0, 1.57, 0.0]),
+            scale: Some([2.0, 2.0, 2.0]),
+            groups: vec![],
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        let ActionCmd::SpawnEntity {
+            rotation, scale, ..
+        } = &out.commands[0]
+        else {
+            panic!("expected SpawnEntity");
+        };
+        assert_eq!(rotation, &Some([0.0, 1.57, 0.0]));
+        assert_eq!(scale, &Some([2.0, 2.0, 2.0]));
+    }
+
+    #[test]
+    fn spawn_entity_uuid_comes_from_the_injected_source() {
+        let fx = Fixture::new();
+        let counter = std::cell::Cell::new(0u32);
+        let source = || {
+            counter.set(counter.get() + 1);
+            format!("uuid-{}", counter.get())
+        };
+        let ctx = DispatchContext {
+            uuid_source: &source,
+            ..fx.ctx()
+        };
+
+        let first = dispatch_action(&spawn(None, Some([0.0, 0.0, 0.0]), vec![]), &ctx);
+        let second = dispatch_action(&spawn(None, Some([0.0, 0.0, 0.0]), vec![]), &ctx);
+
+        assert_eq!(
+            first.name_to_uuid_inserts,
+            vec![("wave_1".to_string(), "uuid-1".to_string())]
+        );
+        assert_eq!(
+            second.name_to_uuid_inserts,
+            vec![("wave_1".to_string(), "uuid-2".to_string())]
+        );
+    }
+
+    // ── DestroyEntity ─────────────────────────────────────────────────────
+
+    #[test]
+    fn destroy_entity_emits_command_and_destroyed_event() {
+        let fx = Fixture::new().with_entity("wave_1", "uuid-wave-1");
+        let action = TriggerAction::DestroyEntity {
+            entity: "wave_1".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::DestroyEntity {
+                uuid: "uuid-wave-1".to_string()
+            }]
+        );
+        // The event lets chained `on_destroyed` triggers fire.
+        assert_eq!(
+            out.new_events,
+            vec![WorldEvent::Destroyed {
+                uuid: "uuid-wave-1".to_string()
+            }]
+        );
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn destroy_entity_unknown_name_warns_and_emits_nothing() {
+        let fx = Fixture::new();
+        let action = TriggerAction::DestroyEntity {
+            entity: "ghost".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert!(out.new_events.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["DestroyEntity: unknown entity name 'ghost'".to_string()]
+        );
+    }
+
+    // ── AddFactionEnemy ───────────────────────────────────────────────────
+
+    #[test]
+    fn add_faction_enemy_resolves_both_names_to_uuids() {
+        let (registry, harrow, federation) = two_factions();
+        let mut fx = Fixture::new();
+        fx.factions = Some(registry);
+        let action = TriggerAction::AddFactionEnemy {
+            faction: "Harrow".to_string(),
+            enemy: "Federation".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::AddFactionEnemy {
+                faction_uuid: harrow,
+                enemy_uuid: federation,
+            }]
+        );
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn add_faction_enemy_without_registry_warns_and_emits_nothing() {
+        let fx = Fixture::new();
+        let action = TriggerAction::AddFactionEnemy {
+            faction: "Harrow".to_string(),
+            enemy: "Federation".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["AddFactionEnemy skipped: FactionRegistryResource not present".to_string()]
+        );
+    }
+
+    #[test]
+    fn add_faction_enemy_unknown_faction_warns_and_emits_nothing() {
+        let (registry, _, _) = two_factions();
+        let mut fx = Fixture::new();
+        fx.factions = Some(registry);
+        let action = TriggerAction::AddFactionEnemy {
+            faction: "Nobody".to_string(),
+            enemy: "Federation".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["AddFactionEnemy: unknown faction name 'Nobody'".to_string()]
+        );
+    }
+
+    #[test]
+    fn add_faction_enemy_unknown_enemy_warns_and_emits_nothing() {
+        let (registry, _, _) = two_factions();
+        let mut fx = Fixture::new();
+        fx.factions = Some(registry);
+        let action = TriggerAction::AddFactionEnemy {
+            faction: "Harrow".to_string(),
+            enemy: "Nobody".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["AddFactionEnemy: unknown enemy faction name 'Nobody'".to_string()]
+        );
+    }
+
+    #[test]
+    fn faction_name_lookup_is_case_sensitive() {
+        let (registry, _, _) = two_factions();
+        let mut fx = Fixture::new();
+        fx.factions = Some(registry);
+        let action = TriggerAction::AddFactionEnemy {
+            faction: "harrow".to_string(),
+            enemy: "Federation".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(out.warnings.len(), 1);
+    }
+
+    // ── RemoveFactionEnemy ────────────────────────────────────────────────
+
+    #[test]
+    fn remove_faction_enemy_resolves_both_names_to_uuids() {
+        let (registry, harrow, federation) = two_factions();
+        let mut fx = Fixture::new();
+        fx.factions = Some(registry);
+        let action = TriggerAction::RemoveFactionEnemy {
+            faction: "Harrow".to_string(),
+            enemy: "Federation".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out.commands,
+            vec![ActionCmd::RemoveFactionEnemy {
+                faction_uuid: harrow,
+                enemy_uuid: federation,
+            }]
+        );
+        assert!(out.warnings.is_empty());
+    }
+
+    #[test]
+    fn remove_faction_enemy_without_registry_warns_and_emits_nothing() {
+        let fx = Fixture::new();
+        let action = TriggerAction::RemoveFactionEnemy {
+            faction: "Harrow".to_string(),
+            enemy: "Federation".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["RemoveFactionEnemy skipped: FactionRegistryResource not present".to_string()]
+        );
+    }
+
+    #[test]
+    fn remove_faction_enemy_unknown_faction_warns_and_emits_nothing() {
+        let (registry, _, _) = two_factions();
+        let mut fx = Fixture::new();
+        fx.factions = Some(registry);
+        let action = TriggerAction::RemoveFactionEnemy {
+            faction: "Nobody".to_string(),
+            enemy: "Federation".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["RemoveFactionEnemy: unknown faction name 'Nobody'".to_string()]
+        );
+    }
+
+    #[test]
+    fn remove_faction_enemy_unknown_enemy_warns_and_emits_nothing() {
+        let (registry, _, _) = two_factions();
+        let mut fx = Fixture::new();
+        fx.factions = Some(registry);
+        let action = TriggerAction::RemoveFactionEnemy {
+            faction: "Harrow".to_string(),
+            enemy: "Nobody".to_string(),
+        };
+        let out = dispatch_action(&action, &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec!["RemoveFactionEnemy: unknown enemy faction name 'Nobody'".to_string()]
+        );
+    }
+}

--- a/src/world/dispatch.rs
+++ b/src/world/dispatch.rs
@@ -38,13 +38,18 @@
 //   caller decides.
 // * **Non-determinism is injected.** `SpawnEntity` takes its UUID from
 //   `DispatchContext::uuid_source` so tests can stub it.
-// * **Template loading is deferred** (issue #715). `ActionCmd::SpawnEntity`
-//   carries what the pure layer resolved — position, name, uuid, groups — and
-//   the applier loads the template.
+// * **Template loading is injected** (issue #715). `SpawnEntity` resolves its
+//   template through `DispatchContext::template_loader`, so this module never
+//   touches the filesystem or the WASM config cache itself — and the
+//   failed-spawn contingency gate lives *here*: a template that fails to
+//   resolve returns a warning-only result with no command and no name/group
+//   inserts, so the applier applies `DispatchResult`s unconditionally.
 
 use std::collections::HashMap;
 use uuid::Uuid;
 
+use crate::entity_config::EntityConfig;
+use crate::entity_loader::TemplateLoader;
 use crate::faction::FactionRegistry;
 use crate::flag_kind::FlagKind;
 use crate::messages::{AiDirective, GamePhase, ModifierSlot, ObjectiveSource};
@@ -134,6 +139,14 @@ pub struct DispatchContext<'a> {
     /// `Uuid::new_v4()` is non-deterministic and would make the returned
     /// `DispatchResult` unassertable.
     pub uuid_source: &'a dyn Fn() -> String,
+    /// Source of `SpawnEntity` templates. Injected (like `uuid_source`) so
+    /// this module never touches the filesystem or the WASM config cache: the
+    /// applier passes `entity_loader::WasmTemplateLoader` — config cache
+    /// first, filesystem fallback on native — and tests pass a hand-written
+    /// fake. Diagnostics are this module's job: `TemplateLoader` deliberately
+    /// collapses "missing" and "malformed" into `None`, and the `SpawnEntity`
+    /// arm turns that into a warning naming the entity and template path.
+    pub template_loader: &'a dyn TemplateLoader,
 }
 
 // ── Result ────────────────────────────────────────────────────────────────
@@ -235,21 +248,25 @@ pub enum ActionCmd {
         name: String,
         mutation: FlagMutation,
     },
-    /// Spawn an entity. `position` is resolved (anchor lookups already done);
-    /// `uuid` came from `DispatchContext::uuid_source`. The applier loads
-    /// `template_path` and, when `layer_path` is `Some`, records the spawned
-    /// entity on that layer so `UnloadWorld` despawns it.
+    /// Spawn an entity. `config` is the template already resolved via
+    /// `DispatchContext::template_loader`, with the trigger's `name` patched
+    /// in — the applier loads nothing. `position` is resolved (anchor lookups
+    /// already done); `uuid` came from `DispatchContext::uuid_source`. When
+    /// `layer_path` is `Some`, the applier records the spawned entity on that
+    /// layer so `UnloadWorld` despawns it.
     ///
-    /// If the template fails to resolve, nothing spawns and the result's
-    /// `name_to_uuid_inserts` / `entity_group_inserts` must be dropped too.
+    /// A template that fails to resolve never reaches here: the dispatch arm
+    /// returns a warning-only result instead — see `dispatch_spawn_entity`.
+    ///
+    /// `config` is boxed because `EntityConfig` dwarfs every other variant
+    /// (clippy: `large_enum_variant`) and commands travel in `Vec<ActionCmd>`.
     SpawnEntity {
-        template_path: String,
+        config: Box<EntityConfig>,
         name: String,
         uuid: String,
         position: [f32; 3],
         rotation: Option<[f32; 3]>,
         scale: Option<[f32; 3]>,
-        groups: Vec<String>,
         layer_path: Option<String>,
     },
     /// Destroy the entity with `uuid` and run the destruction cascade.
@@ -288,13 +305,14 @@ pub struct DispatchResult {
     pub new_events: Vec<WorldEvent>,
     /// `(entity_name, uuid)` pairs to register in the runtime's name map.
     ///
-    /// **Contingent when they come from `SpawnEntity`**: the applier MUST apply
-    /// them only if the accompanying `ActionCmd::SpawnEntity` actually spawned
-    /// (i.e. its template resolved). See that arm for why.
+    /// Unconditional, including from `SpawnEntity`: a spawn whose template
+    /// fails to resolve returns a warning-only result with no inserts (issue
+    /// #715 moved that contingency gate into `dispatch_spawn_entity`), so
+    /// whatever arrives here the applier applies as-is.
     pub name_to_uuid_inserts: Vec<(String, String)>,
     /// `(group, entity_name)` pairs to register for `OnAllDestroyed` tracking.
     ///
-    /// Same contingency as `name_to_uuid_inserts`.
+    /// Unconditional, like `name_to_uuid_inserts`.
     pub entity_group_inserts: Vec<(String, String)>,
     /// Messages the applier should log at warn level.
     pub warnings: Vec<String>,
@@ -370,83 +388,12 @@ pub fn dispatch_action(action: &TriggerAction, context: &DispatchContext) -> Dis
             return dispatch_world_flag_action(action, context);
         }
 
-        TriggerAction::SpawnEntity {
-            template_path,
-            name,
-            anchor,
-            position,
-            rotation,
-            scale,
-            groups,
-        } => {
-            // Resolve spawn position. `anchor` looks up in the origin layer's
-            // anchors (or the base world's anchors for a `None` origin).
-            // `position` is used directly.
-            let resolved_position: [f32; 3] = if let Some(pos) = position {
-                *pos
-            } else if let Some(anchor_name) = anchor {
-                let lookup = match &context.origin_layer {
-                    Some(layer_path) => context
-                        .layers
-                        .get(layer_path)
-                        .and_then(|l| l.anchors.get(anchor_name).copied()),
-                    None => context.base_anchors.get(anchor_name).copied(),
-                };
-                match lookup {
-                    Some(p) => p,
-                    None => {
-                        out.warnings.push(format!(
-                            "SpawnEntity '{name}' anchor '{anchor_name}' not found"
-                        ));
-                        return out;
-                    }
-                }
-            } else {
-                out.warnings.push(format!(
-                    "SpawnEntity '{name}' has neither anchor nor position"
-                ));
-                return out;
-            };
-
-            let uuid = (context.uuid_source)();
-
-            out.commands.push(ActionCmd::SpawnEntity {
-                template_path: template_path.clone(),
-                name: name.clone(),
-                uuid: uuid.clone(),
-                position: resolved_position,
-                rotation: *rotation,
-                scale: *scale,
-                groups: groups.clone(),
-                layer_path: context.origin_layer.clone(),
-            });
-
-            // Register name → uuid for subsequent triggers, and the entity in
-            // its groups for `OnAllDestroyed` tracking.
-            //
-            // Both are **contingent on the spawn succeeding**. Template loading
-            // is still the applier's job (issue #715 moves it in here behind a
-            // `TemplateLoader` trait), and these live in `DispatchResult` fields
-            // separate from `commands`, so nothing in the data says they depend
-            // on the `ActionCmd::SpawnEntity` above. The applier MUST apply them
-            // only if that command actually spawned — `server::handle_ai_events`
-            // resolves the template first and `continue`s on failure, so a
-            // failed spawn registers no name and no group membership.
-            //
-            // Registering them anyway leaves a phantom name → uuid entry. That
-            // mostly degrades to a "no ECS entity with UUID" warning, but
-            // `DestroyEntity` would still emit `WorldEvent::Destroyed` +
-            // `AiEntityDestroyed` for an entity that never spawned, firing
-            // `on_destroyed` triggers for a ghost.
-            //
-            // `ActionCmd::SpawnEntity` already carries `name`, `uuid` and
-            // `groups`, so the applier may instead derive both from the command
-            // at the point it knows the spawn succeeded.
-            out.name_to_uuid_inserts.push((name.clone(), uuid));
-
-            for g in groups {
-                out.entity_group_inserts.push((g.clone(), name.clone()));
-            }
+        // Entity spawning — position resolution, template loading via the
+        // injected `TemplateLoader`, uuid assignment, and the name/group
+        // registrations — is handled by `dispatch_spawn_entity` (issue #715).
+        // Same routing shape as the mission-state arm above.
+        TriggerAction::SpawnEntity { .. } => {
+            return dispatch_spawn_entity(action, context);
         }
 
         // Entity destruction — resolving the target's name to a UUID, then
@@ -931,6 +878,129 @@ fn dispatch_destroy_entity(action: &TriggerAction, context: &DispatchContext) ->
     out
 }
 
+/// Decide what a `SpawnEntity` `TriggerAction` should do.
+///
+/// Owns the single entity-spawn action. Split out of `dispatch_action`
+/// (issue #715), which routes exactly this variant here. Unlike the four
+/// earlier extractions this one also *moved* work into the pure layer:
+/// template loading, previously the applier's job, now goes through
+/// `DispatchContext::template_loader`.
+///
+/// Steps, in order (template before uuid — matching the pre-#710 inline
+/// semantics in `world::server`):
+///
+/// 1. Resolve the spawn position: an inline `position` wins; otherwise
+///    `anchor` is looked up in the origin layer's anchor table (base-world
+///    triggers look only in the base table, layer triggers only in their own
+///    layer's — no fallback between them); otherwise warn + no-op.
+/// 2. Load the template. `None` — missing or malformed; the trait collapses
+///    both — warns and returns with **no command and no inserts**. This is
+///    the contingency gate that used to live in the applier (`spawn_failed`):
+///    registering the name/groups anyway would leave a phantom name → uuid
+///    entry, and a later `DestroyEntity` would emit `WorldEvent::Destroyed`
+///    for an entity that never existed, firing `on_destroyed` triggers for a
+///    ghost.
+/// 3. Draw the uuid from `context.uuid_source` — only after a successful
+///    template load, so a failed spawn does not consume a uuid.
+/// 4. Patch the trigger's `name` into the config, emit the command, and
+///    register name → uuid plus group memberships (unconditional within this
+///    function because step 2 already gated the failure path).
+///
+/// Pure, like `dispatch_action`: reads `context`, mutates nothing, returns a
+/// `DispatchResult`. Called only for the variant above; any other variant is
+/// a routing bug in `dispatch_action` and trips the `unreachable!`.
+fn dispatch_spawn_entity(action: &TriggerAction, context: &DispatchContext) -> DispatchResult {
+    let mut out = DispatchResult::default();
+
+    match action {
+        TriggerAction::SpawnEntity {
+            template_path,
+            name,
+            anchor,
+            position,
+            rotation,
+            scale,
+            groups,
+        } => {
+            // 1. Resolve spawn position. `anchor` looks up in the origin
+            // layer's anchors (or the base world's anchors for a `None`
+            // origin). `position` is used directly.
+            let resolved_position: [f32; 3] = if let Some(pos) = position {
+                *pos
+            } else if let Some(anchor_name) = anchor {
+                let lookup = match &context.origin_layer {
+                    Some(layer_path) => context
+                        .layers
+                        .get(layer_path)
+                        .and_then(|l| l.anchors.get(anchor_name).copied()),
+                    None => context.base_anchors.get(anchor_name).copied(),
+                };
+                match lookup {
+                    Some(p) => p,
+                    None => {
+                        out.warnings.push(format!(
+                            "SpawnEntity '{name}' anchor '{anchor_name}' not found"
+                        ));
+                        return out;
+                    }
+                }
+            } else {
+                out.warnings.push(format!(
+                    "SpawnEntity '{name}' has neither anchor nor position"
+                ));
+                return out;
+            };
+
+            // 2. Load the template — the contingency gate (see doc comment).
+            let Some(mut config) = context.template_loader.load_template(template_path) else {
+                out.warnings.push(format!(
+                    "SpawnEntity '{name}' template '{template_path}' not found"
+                ));
+                return out;
+            };
+
+            // 3. Only a spawn that will actually happen consumes a uuid.
+            let uuid = (context.uuid_source)();
+
+            // 4. Patch the entity name with the trigger's `name` field so the
+            // spawned ECS entity gets EntityName("wave_1") (not the template's
+            // display name like "Harrow Destroyer"). This mirrors what
+            // `spawn_world_entities` does for static `[[entity]]` entries and
+            // is required for `resolve_objective_target` to match Destroy
+            // directives by the scenario name.
+            if !name.is_empty() {
+                config.name = Some(name.clone());
+            }
+
+            out.commands.push(ActionCmd::SpawnEntity {
+                config: Box::new(config),
+                name: name.clone(),
+                uuid: uuid.clone(),
+                position: resolved_position,
+                rotation: *rotation,
+                scale: *scale,
+                layer_path: context.origin_layer.clone(),
+            });
+
+            // Register name → uuid for subsequent triggers, and the entity in
+            // its groups for `OnAllDestroyed` tracking. Unconditional here:
+            // step 2 already returned on the one failure mode that used to
+            // make these contingent.
+            out.name_to_uuid_inserts.push((name.clone(), uuid));
+
+            for g in groups {
+                out.entity_group_inserts.push((g.clone(), name.clone()));
+            }
+        }
+
+        other => {
+            unreachable!("dispatch_spawn_entity called with non-spawn action: {other:?}")
+        }
+    }
+
+    out
+}
+
 // ── Unit Tests ────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -945,6 +1015,43 @@ mod tests {
         STUB_UUID.to_string()
     }
 
+    /// Template path the `spawn()` helper names.
+    const DESTROYER_TEMPLATE: &str = "assets/entities/destroyer.toml";
+
+    /// Hand-written `TemplateLoader` fake serving `EntityConfig`s out of a
+    /// map. The dispatch tests need their own local fake (test modules don't
+    /// share the one in `entities::loader::tests`). The `Default` — an empty
+    /// map, i.e. every template missing — is what non-spawn tests carry.
+    #[derive(Default)]
+    struct FakeTemplateLoader {
+        templates: HashMap<String, EntityConfig>,
+    }
+
+    impl TemplateLoader for FakeTemplateLoader {
+        fn load_template(&self, path: &str) -> Option<EntityConfig> {
+            self.templates.get(path).cloned()
+        }
+    }
+
+    /// A minimal template config with a display name, so tests can observe
+    /// the trigger `name` overwriting it (or not, for an empty trigger name).
+    fn destroyer_template() -> EntityConfig {
+        EntityConfig {
+            name: Some("Harrow Destroyer".to_string()),
+            tags: vec!["npc".to_string()],
+            ..Default::default()
+        }
+    }
+
+    /// `destroyer_template()` as `dispatch_spawn_entity` patches and boxes
+    /// it: the trigger's `name` wins over the template's display name.
+    fn patched_destroyer_template(name: &str) -> Box<EntityConfig> {
+        Box::new(EntityConfig {
+            name: Some(name.to_string()),
+            ..destroyer_template()
+        })
+    }
+
     /// Owned backing store for a `DispatchContext`. Tests mutate the public
     /// fields then call `ctx()` to borrow a context out of it.
     #[derive(Default)]
@@ -956,6 +1063,7 @@ mod tests {
         layers: HashMap<String, LayerView>,
         base_anchors: HashMap<String, [f32; 3]>,
         factions: Option<FactionRegistry>,
+        loader: FakeTemplateLoader,
     }
 
     impl Fixture {
@@ -973,11 +1081,21 @@ mod tests {
                 base_anchors: &self.base_anchors,
                 factions: self.factions.as_ref(),
                 uuid_source: &stub_uuid,
+                template_loader: &self.loader,
             }
         }
 
         fn with_entity(mut self, name: &str, uuid: &str) -> Self {
             self.name_to_uuid.insert(name.to_string(), uuid.to_string());
+            self
+        }
+
+        /// Pre-load the destroyer template that `spawn()` names, so the
+        /// spawn arm's template load succeeds.
+        fn with_destroyer(mut self) -> Self {
+            self.loader
+                .templates
+                .insert(DESTROYER_TEMPLATE.to_string(), destroyer_template());
             self
         }
     }
@@ -1022,7 +1140,7 @@ mod tests {
 
     fn spawn(anchor: Option<&str>, position: Option<[f32; 3]>, groups: Vec<&str>) -> TriggerAction {
         TriggerAction::SpawnEntity {
-            template_path: "assets/entities/destroyer.toml".to_string(),
+            template_path: DESTROYER_TEMPLATE.to_string(),
             name: "wave_1".to_string(),
             anchor: anchor.map(str::to_string),
             position,
@@ -1861,19 +1979,18 @@ mod tests {
 
     #[test]
     fn spawn_entity_with_explicit_position() {
-        let fx = Fixture::new();
+        let fx = Fixture::new().with_destroyer();
         let out = dispatch_action(&spawn(None, Some([1.0, 2.0, 3.0]), vec![]), &fx.ctx());
 
         assert_eq!(
             out.commands,
             vec![ActionCmd::SpawnEntity {
-                template_path: "assets/entities/destroyer.toml".to_string(),
+                config: patched_destroyer_template("wave_1"),
                 name: "wave_1".to_string(),
                 uuid: STUB_UUID.to_string(),
                 position: [1.0, 2.0, 3.0],
                 rotation: None,
                 scale: None,
-                groups: vec![],
                 layer_path: None,
             }]
         );
@@ -1887,7 +2004,7 @@ mod tests {
 
     #[test]
     fn spawn_entity_resolves_anchor_from_base_world() {
-        let mut fx = Fixture::new();
+        let mut fx = Fixture::new().with_destroyer();
         fx.base_anchors
             .insert("staging".to_string(), [10.0, 0.0, -5.0]);
         let out = dispatch_action(&spawn(Some("staging"), None, vec![]), &fx.ctx());
@@ -1900,7 +2017,7 @@ mod tests {
 
     #[test]
     fn spawn_entity_resolves_anchor_from_the_origin_layer() {
-        let mut fx = Fixture::new();
+        let mut fx = Fixture::new().with_destroyer();
         fx.origin_layer = Some("sub.toml".to_string());
         let mut sub = layer(None);
         sub.anchors.insert("staging".to_string(), [4.0, 5.0, 6.0]);
@@ -1914,13 +2031,12 @@ mod tests {
         assert_eq!(
             out.commands,
             vec![ActionCmd::SpawnEntity {
-                template_path: "assets/entities/destroyer.toml".to_string(),
+                config: patched_destroyer_template("wave_1"),
                 name: "wave_1".to_string(),
                 uuid: STUB_UUID.to_string(),
                 position: [4.0, 5.0, 6.0],
                 rotation: None,
                 scale: None,
-                groups: vec![],
                 layer_path: Some("sub.toml".to_string()),
             }]
         );
@@ -1928,7 +2044,7 @@ mod tests {
 
     #[test]
     fn spawn_entity_position_wins_over_anchor() {
-        let mut fx = Fixture::new();
+        let mut fx = Fixture::new().with_destroyer();
         fx.base_anchors
             .insert("staging".to_string(), [10.0, 0.0, -5.0]);
         let out = dispatch_action(
@@ -1968,9 +2084,31 @@ mod tests {
         );
     }
 
+    /// The contingency gate (issue #715): a spawn whose template fails to
+    /// resolve must produce NO command and NO name/group inserts — only a
+    /// warning. Before #715 this gate was the applier's `spawn_failed` local,
+    /// exercisable only through a full Bevy app.
+    #[test]
+    fn spawn_entity_template_not_found_warns_and_emits_nothing() {
+        // No `.with_destroyer()`: the loader has no templates at all.
+        let fx = Fixture::new();
+        let out = dispatch_action(&spawn(None, Some([0.0, 0.0, 0.0]), vec!["wave"]), &fx.ctx());
+
+        assert!(out.commands.is_empty());
+        assert!(out.name_to_uuid_inserts.is_empty());
+        assert!(out.entity_group_inserts.is_empty());
+        assert_eq!(
+            out.warnings,
+            vec![
+                "SpawnEntity 'wave_1' template 'assets/entities/destroyer.toml' not found"
+                    .to_string()
+            ]
+        );
+    }
+
     #[test]
     fn spawn_entity_registers_every_group() {
-        let fx = Fixture::new();
+        let fx = Fixture::new().with_destroyer();
         let out = dispatch_action(
             &spawn(None, Some([0.0, 0.0, 0.0]), vec!["wave", "hostiles"]),
             &fx.ctx(),
@@ -1987,9 +2125,9 @@ mod tests {
 
     #[test]
     fn spawn_entity_carries_rotation_and_scale_through() {
-        let fx = Fixture::new();
+        let fx = Fixture::new().with_destroyer();
         let action = TriggerAction::SpawnEntity {
-            template_path: "assets/entities/destroyer.toml".to_string(),
+            template_path: DESTROYER_TEMPLATE.to_string(),
             name: "wave_1".to_string(),
             anchor: None,
             position: Some([0.0, 0.0, 0.0]),
@@ -2011,7 +2149,7 @@ mod tests {
 
     #[test]
     fn spawn_entity_uuid_comes_from_the_injected_source() {
-        let fx = Fixture::new();
+        let fx = Fixture::new().with_destroyer();
         let counter = std::cell::Cell::new(0u32);
         let source = || {
             counter.set(counter.get() + 1);
@@ -3061,5 +3199,268 @@ mod tests {
             path: "worlds/sub.toml".to_string(),
         };
         let _ = dispatch_destroy_entity(&action, &fx.ctx());
+    }
+
+    // ── dispatch_spawn_entity (direct) ────────────────────────────────────
+    //
+    // The tests above drive the SpawnEntity arm through `dispatch_action`,
+    // proving the routing arm delegates. These call `dispatch_spawn_entity`
+    // directly, proving the extracted function is what produces the result
+    // and that the two entry points agree (issue #715). This is also where
+    // the behaviour that MOVED in #715 — template loading behind
+    // `DispatchContext::template_loader`, and the failed-spawn contingency
+    // gate — is pinned.
+
+    #[test]
+    fn spawn_template_loads_with_patched_name_and_inserts_directly() {
+        let fx = Fixture::new().with_destroyer();
+        let out = dispatch_spawn_entity(
+            &spawn(None, Some([1.0, 2.0, 3.0]), vec!["wave", "hostiles"]),
+            &fx.ctx(),
+        );
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::SpawnEntity {
+                    config: patched_destroyer_template("wave_1"),
+                    name: "wave_1".to_string(),
+                    uuid: STUB_UUID.to_string(),
+                    position: [1.0, 2.0, 3.0],
+                    rotation: None,
+                    scale: None,
+                    layer_path: None,
+                }],
+                name_to_uuid_inserts: vec![("wave_1".to_string(), STUB_UUID.to_string())],
+                entity_group_inserts: vec![
+                    ("wave".to_string(), "wave_1".to_string()),
+                    ("hostiles".to_string(), "wave_1".to_string()),
+                ],
+                ..Default::default()
+            }
+        );
+    }
+
+    /// The shipped test for the contingency gate (issue #715): a template
+    /// that fails to resolve produces a warning-only result — no command, no
+    /// name → uuid insert, no group insert. Before #715 this gate lived in
+    /// the applier (`spawn_failed`), where a #710 review flagged it had only
+    /// throwaway coverage.
+    #[test]
+    fn spawn_template_not_found_warns_and_emits_nothing_directly() {
+        // No `.with_destroyer()`: the loader has no templates at all.
+        let fx = Fixture::new();
+        let out =
+            dispatch_spawn_entity(&spawn(None, Some([1.0, 2.0, 3.0]), vec!["wave"]), &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                warnings: vec![
+                    "SpawnEntity 'wave_1' template 'assets/entities/destroyer.toml' not found"
+                        .to_string()
+                ],
+                ..Default::default()
+            }
+        );
+    }
+
+    /// A failed spawn must not consume a uuid: the source is drawn only
+    /// after the template resolves (template before uuid — the pre-#710
+    /// inline ordering), so failures leave the uuid sequence untouched.
+    #[test]
+    fn spawn_failed_template_load_does_not_consume_a_uuid_directly() {
+        let fx = Fixture::new().with_destroyer();
+        let counter = std::cell::Cell::new(0u32);
+        let source = || {
+            counter.set(counter.get() + 1);
+            format!("uuid-{}", counter.get())
+        };
+        let ctx = DispatchContext {
+            uuid_source: &source,
+            ..fx.ctx()
+        };
+
+        // A template the loader does not know: warns, draws nothing.
+        let missing = TriggerAction::SpawnEntity {
+            template_path: "assets/entities/missing.toml".to_string(),
+            name: "wave_1".to_string(),
+            anchor: None,
+            position: Some([0.0, 0.0, 0.0]),
+            rotation: None,
+            scale: None,
+            groups: vec![],
+        };
+        let out = dispatch_spawn_entity(&missing, &ctx);
+        assert_eq!(out.warnings.len(), 1);
+        assert_eq!(counter.get(), 0, "a failed spawn must not consume a uuid");
+
+        // The next successful spawn draws the FIRST uuid, not the second.
+        let out = dispatch_spawn_entity(&spawn(None, Some([0.0, 0.0, 0.0]), vec![]), &ctx);
+        assert_eq!(
+            out.name_to_uuid_inserts,
+            vec![("wave_1".to_string(), "uuid-1".to_string())]
+        );
+    }
+
+    #[test]
+    fn spawn_anchor_resolves_from_the_origin_layer_directly() {
+        let mut fx = Fixture::new().with_destroyer();
+        fx.origin_layer = Some("sub.toml".to_string());
+        let mut sub = layer(None);
+        sub.anchors.insert("staging".to_string(), [4.0, 5.0, 6.0]);
+        fx.layers.insert("sub.toml".to_string(), sub);
+        // A same-named base anchor must NOT win for a layer-authored trigger.
+        fx.base_anchors
+            .insert("staging".to_string(), [99.0, 99.0, 99.0]);
+
+        let out = dispatch_spawn_entity(&spawn(Some("staging"), None, vec![]), &fx.ctx());
+
+        let ActionCmd::SpawnEntity {
+            position,
+            layer_path,
+            ..
+        } = &out.commands[0]
+        else {
+            panic!("expected SpawnEntity");
+        };
+        assert_eq!(position, &[4.0, 5.0, 6.0]);
+        // Origin-layer tracking: the command records the authoring layer so
+        // the applier attaches the spawn to it for cascade unload.
+        assert_eq!(layer_path, &Some("sub.toml".to_string()));
+    }
+
+    /// Layer-originated triggers look ONLY in their own layer's anchor
+    /// table: a same-named base-world anchor must not rescue a layer trigger
+    /// whose own layer lacks the anchor.
+    #[test]
+    fn spawn_origin_layer_anchor_missing_warns_despite_base_anchor_directly() {
+        let mut fx = Fixture::new().with_destroyer();
+        fx.origin_layer = Some("sub.toml".to_string());
+        fx.layers.insert("sub.toml".to_string(), layer(None)); // no anchors
+        fx.base_anchors
+            .insert("staging".to_string(), [99.0, 99.0, 99.0]);
+
+        let out = dispatch_spawn_entity(&spawn(Some("staging"), None, vec![]), &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                warnings: vec!["SpawnEntity 'wave_1' anchor 'staging' not found".to_string()],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn spawn_anchor_resolves_from_the_base_world_directly() {
+        let mut fx = Fixture::new().with_destroyer();
+        fx.base_anchors
+            .insert("staging".to_string(), [10.0, 0.0, -5.0]);
+
+        let out = dispatch_spawn_entity(&spawn(Some("staging"), None, vec![]), &fx.ctx());
+
+        let ActionCmd::SpawnEntity {
+            position,
+            layer_path,
+            ..
+        } = &out.commands[0]
+        else {
+            panic!("expected SpawnEntity");
+        };
+        assert_eq!(position, &[10.0, 0.0, -5.0]);
+        // Base-world origin: no layer to attach the spawn to.
+        assert_eq!(layer_path, &None);
+    }
+
+    #[test]
+    fn spawn_rotation_and_scale_pass_through_directly() {
+        let fx = Fixture::new().with_destroyer();
+        let action = TriggerAction::SpawnEntity {
+            template_path: DESTROYER_TEMPLATE.to_string(),
+            name: "wave_1".to_string(),
+            anchor: None,
+            position: Some([0.0, 0.0, 0.0]),
+            rotation: Some([0.0, 1.57, 0.0]),
+            scale: Some([2.0, 2.0, 2.0]),
+            groups: vec![],
+        };
+        let out = dispatch_spawn_entity(&action, &fx.ctx());
+
+        let ActionCmd::SpawnEntity {
+            rotation, scale, ..
+        } = &out.commands[0]
+        else {
+            panic!("expected SpawnEntity");
+        };
+        assert_eq!(rotation, &Some([0.0, 1.57, 0.0]));
+        assert_eq!(scale, &Some([2.0, 2.0, 2.0]));
+    }
+
+    #[test]
+    fn spawn_registers_every_group_directly() {
+        let fx = Fixture::new().with_destroyer();
+        let out = dispatch_spawn_entity(
+            &spawn(None, Some([0.0, 0.0, 0.0]), vec!["wave", "hostiles"]),
+            &fx.ctx(),
+        );
+
+        assert_eq!(
+            out.entity_group_inserts,
+            vec![
+                ("wave".to_string(), "wave_1".to_string()),
+                ("hostiles".to_string(), "wave_1".to_string()),
+            ]
+        );
+    }
+
+    /// An empty trigger `name` leaves the template's display name in place —
+    /// the patch is conditional on `!name.is_empty()`.
+    #[test]
+    fn spawn_empty_name_keeps_the_template_display_name_directly() {
+        let fx = Fixture::new().with_destroyer();
+        let action = TriggerAction::SpawnEntity {
+            template_path: DESTROYER_TEMPLATE.to_string(),
+            name: String::new(),
+            anchor: None,
+            position: Some([0.0, 0.0, 0.0]),
+            rotation: None,
+            scale: None,
+            groups: vec![],
+        };
+        let out = dispatch_spawn_entity(&action, &fx.ctx());
+
+        let ActionCmd::SpawnEntity { config, .. } = &out.commands[0] else {
+            panic!("expected SpawnEntity");
+        };
+        assert_eq!(config.name, Some("Harrow Destroyer".to_string()));
+    }
+
+    #[test]
+    fn spawn_entity_matches_dispatch_action_routing() {
+        let mut fx = Fixture::new().with_destroyer();
+        fx.origin_layer = Some("sub.toml".to_string());
+        let mut sub = layer(None);
+        sub.anchors.insert("staging".to_string(), [4.0, 5.0, 6.0]);
+        fx.layers.insert("sub.toml".to_string(), sub);
+        let action = spawn(Some("staging"), None, vec!["wave"]);
+
+        // Both entry points must produce byte-identical results.
+        assert_eq!(
+            dispatch_action(&action, &fx.ctx()),
+            dispatch_spawn_entity(&action, &fx.ctx())
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "dispatch_spawn_entity called with non-spawn action")]
+    fn spawn_entity_on_non_spawn_variant_panics() {
+        // The guard exists so a routing bug in `dispatch_action` fails loudly
+        // rather than silently returning an empty result.
+        let fx = Fixture::new();
+        let action = TriggerAction::UnloadWorld {
+            path: "worlds/sub.toml".to_string(),
+        };
+        let _ = dispatch_spawn_entity(&action, &fx.ctx());
     }
 }

--- a/src/world/dispatch.rs
+++ b/src/world/dispatch.rs
@@ -300,142 +300,6 @@ pub struct DispatchResult {
     pub warnings: Vec<String>,
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────
-
-/// Push a `FlagSet` / `FlagCleared` event when the boolean view (`counter != 0`)
-/// of a flag flips.
-///
-/// `target_layer` is the *resolved* layer of the mutation (after `parent:`
-/// walking) — embedded in the event so layer-scoped `on_flag_set` /
-/// `on_flag_cleared` triggers only react to transitions in their own layer.
-fn push_flag_transition(
-    events: &mut Vec<WorldEvent>,
-    name: &str,
-    target_layer: &Option<String>,
-    before: i64,
-    after: i64,
-) {
-    let was_set = before != 0;
-    let is_set = after != 0;
-    if was_set == is_set {
-        return;
-    }
-    if is_set {
-        events.push(WorldEvent::FlagSet {
-            name: name.to_string(),
-            origin_layer: target_layer.clone(),
-        });
-    } else {
-        events.push(WorldEvent::FlagCleared {
-            name: name.to_string(),
-            origin_layer: target_layer.clone(),
-        });
-    }
-}
-
-/// Resolve which layer a flag mutation targets, honouring `parent:` prefixes.
-///
-/// Each leading `parent:` walks one step up the loader chain from
-/// `ctx.origin_layer`. Returns `(target_layer, stripped_name)` on success, or
-/// the warning text on failure. There are two distinct failure modes and one
-/// deliberate silent case:
-///
-/// * The walk overruns the base world → `Err` (no mutation, no event). This
-///   keeps two scenarios from polluting each other's flag namespace.
-/// * The resolved target layer is absent from the layer map → `Err`.
-/// * A layer is missing from the map *mid-walk* → silently treated as the base
-///   world, and the walk continues.
-fn resolve_flag_target(
-    ctx: &DispatchContext,
-    name: &str,
-) -> Result<(Option<String>, String), String> {
-    let mut depth = 0usize;
-    let mut rest = name;
-    while let Some(stripped) = rest.strip_prefix("parent:") {
-        depth += 1;
-        rest = stripped;
-    }
-    let stripped = rest.to_string();
-
-    let origin_layer = &ctx.origin_layer;
-    let mut cur = origin_layer.clone();
-    for _ in 0..depth {
-        match cur {
-            None => {
-                return Err(format!(
-                    "'{name}' from origin {origin_layer:?} walks past base world — ignoring"
-                ));
-            }
-            Some(ref path) => {
-                // A missing layer entry resolves to `None` — i.e. treated as
-                // the base world — and the walk continues from there.
-                cur = ctx.layers.get(path).and_then(|l| l.loader_path.clone());
-            }
-        }
-    }
-    let target_layer = cur;
-
-    if let Some(path) = &target_layer {
-        if !ctx.layers.contains_key(path) {
-            return Err(format!(
-                "target layer '{path}' missing from WorldLayerMap — ignoring '{name}'"
-            ));
-        }
-    }
-    Ok((target_layer, stripped))
-}
-
-/// Compute what `mutation` *would* do to `name` in `store`, without mutating.
-///
-/// Mirrors `FlagStore::set_flag` / `clear_flag` / `increment_flag` /
-/// `set_flag_value` exactly, including `increment`'s saturating add.
-fn preview_mutation(store: &FlagStore, name: &str, mutation: &FlagMutation) -> (i64, i64) {
-    let before = store.counter(name);
-    let after = match mutation {
-        FlagMutation::Set => 1,
-        FlagMutation::Clear => 0,
-        FlagMutation::Increment(by) => before.saturating_add(*by),
-        FlagMutation::SetValue(v) => *v,
-    };
-    (before, after)
-}
-
-/// Read-only lookup of the store a resolved `target_layer` points at.
-fn store_for<'a>(ctx: &'a DispatchContext, target_layer: &Option<String>) -> &'a FlagStore {
-    match target_layer {
-        None => ctx.base_flags,
-        // `resolve_flag_target` already proved the entry exists.
-        Some(path) => ctx
-            .layers
-            .get(path)
-            .map(|l| &l.flags)
-            .unwrap_or(ctx.base_flags),
-    }
-}
-
-/// Shared body of the four flag-mutation arms.
-fn dispatch_flag_mutation(
-    ctx: &DispatchContext,
-    name: &str,
-    mutation: FlagMutation,
-    out: &mut DispatchResult,
-) {
-    let (target_layer, stripped) = match resolve_flag_target(ctx, name) {
-        Ok(v) => v,
-        Err(warning) => {
-            out.warnings.push(warning);
-            return;
-        }
-    };
-    let (before, after) = preview_mutation(store_for(ctx, &target_layer), &stripped, &mutation);
-    out.commands.push(ActionCmd::MutateFlag {
-        target_layer: target_layer.clone(),
-        name: stripped.clone(),
-        mutation,
-    });
-    push_flag_transition(&mut out.new_events, &stripped, &target_layer, before, after);
-}
-
 // ── Dispatch ──────────────────────────────────────────────────────────────
 
 /// Decide what a single `TriggerAction` should do.
@@ -496,20 +360,14 @@ pub fn dispatch_action(action: &TriggerAction, context: &DispatchContext) -> Dis
                 .push(ActionCmd::UnloadWorld { path: path.clone() });
         }
 
-        TriggerAction::SetWorldFlag { name } => {
-            dispatch_flag_mutation(context, name, FlagMutation::Set, &mut out);
-        }
-
-        TriggerAction::ClearWorldFlag { name } => {
-            dispatch_flag_mutation(context, name, FlagMutation::Clear, &mut out);
-        }
-
-        TriggerAction::IncrementWorldFlag { name, by } => {
-            dispatch_flag_mutation(context, name, FlagMutation::Increment(*by), &mut out);
-        }
-
-        TriggerAction::SetWorldFlagValue { name, value } => {
-            dispatch_flag_mutation(context, name, FlagMutation::SetValue(*value), &mut out);
+        // World-flag actions — the four mutations of a named flag in a
+        // layer-resolved store — are handled by `dispatch_world_flag_action`
+        // (issue #713). Same routing shape as the mission-state arm above.
+        TriggerAction::SetWorldFlag { .. }
+        | TriggerAction::ClearWorldFlag { .. }
+        | TriggerAction::IncrementWorldFlag { .. }
+        | TriggerAction::SetWorldFlagValue { .. } => {
+            return dispatch_world_flag_action(action, context);
         }
 
         TriggerAction::SpawnEntity {
@@ -850,6 +708,192 @@ fn dispatch_entity_modifier_action(
     }
 
     out
+}
+
+/// Decide what one world-flag `TriggerAction` should do.
+///
+/// Owns the four actions that mutate a named world flag — `SetWorldFlag`,
+/// `ClearWorldFlag`, `IncrementWorldFlag`, and `SetWorldFlagValue`. Split out
+/// of `dispatch_action` (issue #713), which routes exactly these four
+/// variants here.
+///
+/// All four share one body, `dispatch_flag_mutation` (below): resolve the
+/// target layer across the loader chain (`resolve_flag_target`, honouring
+/// `parent:` prefixes), preview the mutation against the resolved *live*
+/// store (`preview_mutation` — see `DispatchContext::base_flags` for why it
+/// must be live), emit the `ActionCmd::MutateFlag`, and push a `FlagSet` /
+/// `FlagCleared` event when the boolean view flips (`push_flag_transition`).
+/// The write itself stays in the applier — see "Purity boundaries" at the top
+/// of this file.
+///
+/// Pure, like `dispatch_action`: reads `context`, mutates nothing, returns a
+/// `DispatchResult`. Called only for the four variants above; any other
+/// variant is a routing bug in `dispatch_action` and trips the `unreachable!`.
+fn dispatch_world_flag_action(action: &TriggerAction, context: &DispatchContext) -> DispatchResult {
+    let mut out = DispatchResult::default();
+
+    match action {
+        TriggerAction::SetWorldFlag { name } => {
+            dispatch_flag_mutation(context, name, FlagMutation::Set, &mut out);
+        }
+
+        TriggerAction::ClearWorldFlag { name } => {
+            dispatch_flag_mutation(context, name, FlagMutation::Clear, &mut out);
+        }
+
+        TriggerAction::IncrementWorldFlag { name, by } => {
+            dispatch_flag_mutation(context, name, FlagMutation::Increment(*by), &mut out);
+        }
+
+        TriggerAction::SetWorldFlagValue { name, value } => {
+            dispatch_flag_mutation(context, name, FlagMutation::SetValue(*value), &mut out);
+        }
+
+        other => {
+            unreachable!("dispatch_world_flag_action called with non-world-flag action: {other:?}")
+        }
+    }
+
+    out
+}
+
+// ── Flag-mutation helpers ─────────────────────────────────────────────────
+//
+// Used exclusively by `dispatch_world_flag_action` above (via
+// `dispatch_flag_mutation`), so they live next to it.
+
+/// Push a `FlagSet` / `FlagCleared` event when the boolean view (`counter != 0`)
+/// of a flag flips.
+///
+/// `target_layer` is the *resolved* layer of the mutation (after `parent:`
+/// walking) — embedded in the event so layer-scoped `on_flag_set` /
+/// `on_flag_cleared` triggers only react to transitions in their own layer.
+fn push_flag_transition(
+    events: &mut Vec<WorldEvent>,
+    name: &str,
+    target_layer: &Option<String>,
+    before: i64,
+    after: i64,
+) {
+    let was_set = before != 0;
+    let is_set = after != 0;
+    if was_set == is_set {
+        return;
+    }
+    if is_set {
+        events.push(WorldEvent::FlagSet {
+            name: name.to_string(),
+            origin_layer: target_layer.clone(),
+        });
+    } else {
+        events.push(WorldEvent::FlagCleared {
+            name: name.to_string(),
+            origin_layer: target_layer.clone(),
+        });
+    }
+}
+
+/// Resolve which layer a flag mutation targets, honouring `parent:` prefixes.
+///
+/// Each leading `parent:` walks one step up the loader chain from
+/// `ctx.origin_layer`. Returns `(target_layer, stripped_name)` on success, or
+/// the warning text on failure. There are two distinct failure modes and one
+/// deliberate silent case:
+///
+/// * The walk overruns the base world → `Err` (no mutation, no event). This
+///   keeps two scenarios from polluting each other's flag namespace.
+/// * The resolved target layer is absent from the layer map → `Err`.
+/// * A layer is missing from the map *mid-walk* → silently treated as the base
+///   world, and the walk continues.
+fn resolve_flag_target(
+    ctx: &DispatchContext,
+    name: &str,
+) -> Result<(Option<String>, String), String> {
+    let mut depth = 0usize;
+    let mut rest = name;
+    while let Some(stripped) = rest.strip_prefix("parent:") {
+        depth += 1;
+        rest = stripped;
+    }
+    let stripped = rest.to_string();
+
+    let origin_layer = &ctx.origin_layer;
+    let mut cur = origin_layer.clone();
+    for _ in 0..depth {
+        match cur {
+            None => {
+                return Err(format!(
+                    "'{name}' from origin {origin_layer:?} walks past base world — ignoring"
+                ));
+            }
+            Some(ref path) => {
+                // A missing layer entry resolves to `None` — i.e. treated as
+                // the base world — and the walk continues from there.
+                cur = ctx.layers.get(path).and_then(|l| l.loader_path.clone());
+            }
+        }
+    }
+    let target_layer = cur;
+
+    if let Some(path) = &target_layer {
+        if !ctx.layers.contains_key(path) {
+            return Err(format!(
+                "target layer '{path}' missing from WorldLayerMap — ignoring '{name}'"
+            ));
+        }
+    }
+    Ok((target_layer, stripped))
+}
+
+/// Compute what `mutation` *would* do to `name` in `store`, without mutating.
+///
+/// Mirrors `FlagStore::set_flag` / `clear_flag` / `increment_flag` /
+/// `set_flag_value` exactly, including `increment`'s saturating add.
+fn preview_mutation(store: &FlagStore, name: &str, mutation: &FlagMutation) -> (i64, i64) {
+    let before = store.counter(name);
+    let after = match mutation {
+        FlagMutation::Set => 1,
+        FlagMutation::Clear => 0,
+        FlagMutation::Increment(by) => before.saturating_add(*by),
+        FlagMutation::SetValue(v) => *v,
+    };
+    (before, after)
+}
+
+/// Read-only lookup of the store a resolved `target_layer` points at.
+fn store_for<'a>(ctx: &'a DispatchContext, target_layer: &Option<String>) -> &'a FlagStore {
+    match target_layer {
+        None => ctx.base_flags,
+        // `resolve_flag_target` already proved the entry exists.
+        Some(path) => ctx
+            .layers
+            .get(path)
+            .map(|l| &l.flags)
+            .unwrap_or(ctx.base_flags),
+    }
+}
+
+/// Shared body of `dispatch_world_flag_action`'s four flag-mutation arms.
+fn dispatch_flag_mutation(
+    ctx: &DispatchContext,
+    name: &str,
+    mutation: FlagMutation,
+    out: &mut DispatchResult,
+) {
+    let (target_layer, stripped) = match resolve_flag_target(ctx, name) {
+        Ok(v) => v,
+        Err(warning) => {
+            out.warnings.push(warning);
+            return;
+        }
+    };
+    let (before, after) = preview_mutation(store_for(ctx, &target_layer), &stripped, &mutation);
+    out.commands.push(ActionCmd::MutateFlag {
+        target_layer: target_layer.clone(),
+        name: stripped.clone(),
+        mutation,
+    });
+    push_flag_transition(&mut out.new_events, &stripped, &target_layer, before, after);
 }
 
 // ── Unit Tests ────────────────────────────────────────────────────────────
@@ -2637,5 +2681,276 @@ mod tests {
             path: "worlds/sub.toml".to_string(),
         };
         let _ = dispatch_entity_modifier_action(&action, &fx.ctx());
+    }
+
+    // ── dispatch_world_flag_action (direct) ───────────────────────────────
+    //
+    // The tests above drive the four world-flag arms through
+    // `dispatch_action`, proving the routing arm delegates. These call
+    // `dispatch_world_flag_action` directly, proving the extracted function
+    // is what produces the result and that the two entry points agree
+    // (issue #713).
+
+    #[test]
+    fn world_flag_set_emits_mutation_and_flag_set_event_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::SetWorldFlag {
+            name: "alarm".to_string(),
+        };
+        let out = dispatch_world_flag_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::MutateFlag {
+                    target_layer: None,
+                    name: "alarm".to_string(),
+                    mutation: FlagMutation::Set,
+                }],
+                new_events: vec![WorldEvent::FlagSet {
+                    name: "alarm".to_string(),
+                    origin_layer: None,
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn world_flag_clear_emits_mutation_and_flag_cleared_event_directly() {
+        let mut fx = Fixture::new();
+        fx.base_flags.set_flag_value("alarm", 1);
+        let action = TriggerAction::ClearWorldFlag {
+            name: "alarm".to_string(),
+        };
+        let out = dispatch_world_flag_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::MutateFlag {
+                    target_layer: None,
+                    name: "alarm".to_string(),
+                    mutation: FlagMutation::Clear,
+                }],
+                new_events: vec![WorldEvent::FlagCleared {
+                    name: "alarm".to_string(),
+                    origin_layer: None,
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn world_flag_increment_zero_to_nonzero_emits_flag_set_directly() {
+        let fx = Fixture::new();
+        let action = TriggerAction::IncrementWorldFlag {
+            name: "kills".to_string(),
+            by: 2,
+        };
+        let out = dispatch_world_flag_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::MutateFlag {
+                    target_layer: None,
+                    name: "kills".to_string(),
+                    mutation: FlagMutation::Increment(2),
+                }],
+                new_events: vec![WorldEvent::FlagSet {
+                    name: "kills".to_string(),
+                    origin_layer: None,
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn world_flag_set_value_to_zero_emits_flag_cleared_directly() {
+        let mut fx = Fixture::new();
+        fx.base_flags.set_flag_value("alarm", 7);
+        let action = TriggerAction::SetWorldFlagValue {
+            name: "alarm".to_string(),
+            value: 0,
+        };
+        let out = dispatch_world_flag_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::MutateFlag {
+                    target_layer: None,
+                    name: "alarm".to_string(),
+                    mutation: FlagMutation::SetValue(0),
+                }],
+                new_events: vec![WorldEvent::FlagCleared {
+                    name: "alarm".to_string(),
+                    origin_layer: None,
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    /// Layer-chain happy path: a `parent:` prefix from a nested layer resolves
+    /// to its loader layer, and both the command and the event carry the
+    /// stripped name plus the *resolved* target layer.
+    #[test]
+    fn world_flag_parent_prefix_resolves_to_the_loader_layer_directly() {
+        let mut fx = Fixture::new();
+        fx.origin_layer = Some("inner.toml".to_string());
+        // inner was loaded by outer; outer was loaded by the base world.
+        fx.layers
+            .insert("inner.toml".to_string(), layer(Some("outer.toml")));
+        fx.layers.insert("outer.toml".to_string(), layer(None));
+        let action = TriggerAction::SetWorldFlag {
+            name: "parent:alarm".to_string(),
+        };
+        let out = dispatch_world_flag_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::MutateFlag {
+                    target_layer: Some("outer.toml".to_string()),
+                    name: "alarm".to_string(),
+                    mutation: FlagMutation::Set,
+                }],
+                new_events: vec![WorldEvent::FlagSet {
+                    name: "alarm".to_string(),
+                    origin_layer: Some("outer.toml".to_string()),
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn world_flag_walk_past_base_world_warns_and_emits_nothing_directly() {
+        // Origin is already the base world, so any `parent:` overruns.
+        let fx = Fixture::new();
+        let action = TriggerAction::SetWorldFlag {
+            name: "parent:alarm".to_string(),
+        };
+        let out = dispatch_world_flag_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                warnings: vec![
+                    "'parent:alarm' from origin None walks past base world — ignoring".to_string()
+                ],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn world_flag_target_layer_missing_warns_and_emits_nothing_directly() {
+        let mut fx = Fixture::new();
+        // The trigger's own layer is not in the map, and there is no `parent:`
+        // to walk, so the resolved target is a layer we cannot find.
+        fx.origin_layer = Some("ghost.toml".to_string());
+        let action = TriggerAction::SetWorldFlag {
+            name: "alarm".to_string(),
+        };
+        let out = dispatch_world_flag_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                warnings: vec![
+                    "target layer 'ghost.toml' missing from WorldLayerMap — ignoring 'alarm'"
+                        .to_string()
+                ],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn world_flag_layer_missing_mid_walk_is_silent_and_treated_as_base_directly() {
+        let mut fx = Fixture::new();
+        // `ghost.toml` is absent from the map: the walk silently resolves its
+        // loader_path to `None` (base) and carries on. This is deliberate —
+        // only the *final* lookup warns.
+        fx.origin_layer = Some("ghost.toml".to_string());
+        let action = TriggerAction::SetWorldFlag {
+            name: "parent:alarm".to_string(),
+        };
+        let out = dispatch_world_flag_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::MutateFlag {
+                    target_layer: None,
+                    name: "alarm".to_string(),
+                    mutation: FlagMutation::Set,
+                }],
+                new_events: vec![WorldEvent::FlagSet {
+                    name: "alarm".to_string(),
+                    origin_layer: None,
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    /// Transition-edge case: setting an already-set flag still commands the
+    /// mutation but emits no event, because the boolean view did not flip.
+    /// The routed twin (`set_world_flag_on_already_set_flag_emits_no_transition_event`,
+    /// issue #708) pins why this depends on `base_flags` being the live store.
+    #[test]
+    fn world_flag_set_on_already_set_flag_emits_no_event_directly() {
+        let mut fx = Fixture::new();
+        fx.base_flags.set_flag_value("alarm", 1);
+        let action = TriggerAction::SetWorldFlag {
+            name: "alarm".to_string(),
+        };
+        let out = dispatch_world_flag_action(&action, &fx.ctx());
+
+        assert_eq!(
+            out,
+            DispatchResult {
+                commands: vec![ActionCmd::MutateFlag {
+                    target_layer: None,
+                    name: "alarm".to_string(),
+                    mutation: FlagMutation::Set,
+                }],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn world_flag_set_matches_dispatch_action_routing() {
+        let mut fx = Fixture::new();
+        fx.origin_layer = Some("sub.toml".to_string());
+        fx.layers.insert("sub.toml".to_string(), layer(None));
+        let action = TriggerAction::SetWorldFlag {
+            name: "parent:alarm".to_string(),
+        };
+
+        // Both entry points must produce byte-identical results.
+        assert_eq!(
+            dispatch_action(&action, &fx.ctx()),
+            dispatch_world_flag_action(&action, &fx.ctx())
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "dispatch_world_flag_action called with non-world-flag action")]
+    fn world_flag_action_on_non_world_flag_variant_panics() {
+        // The guard exists so a routing bug in `dispatch_action` fails loudly
+        // rather than silently returning an empty result.
+        let fx = Fixture::new();
+        let action = TriggerAction::UnloadWorld {
+            path: "worlds/sub.toml".to_string(),
+        };
+        let _ = dispatch_world_flag_action(&action, &fx.ctx());
     }
 }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod content;
+pub mod dispatch;
 pub mod flags;
 pub mod server;
 pub use server::WorldPlugin;

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -186,8 +186,8 @@ pub enum WorldLayerChange {
 ///
 /// Producer: `collect_world_events` (drains the `AiEventReaders` messages and
 /// `WorldContentRuntime::pending_world_events`, and synthesises the per-tick
-/// `TimerElapsed` event). Consumer: `tick_trigger_pipeline`, which seeds its
-/// comms-template evaluation and trigger-chaining loop from the buffer.
+/// `TimerElapsed` event). Consumers: `inject_comms_templates` (comms-template
+/// evaluation) and `tick_trigger_pipeline` (seeds its trigger-chaining loop).
 ///
 /// The chaining loop's internally-produced events (`FlagSet`, `FlagCleared`,
 /// `Destroyed` from a `DestroyEntity` action) stay LOCAL to the pipeline and
@@ -258,19 +258,22 @@ impl Plugin for WorldPlugin {
                 )
                     .chain(),
             )
-            // Explicit trigger-pipeline ordering (#718): `tick_pending_follow_ups`
-            // must observe `pending_world_events` BEFORE `collect_world_events`
-            // drains them into `WorldEventBuffer` (same-tick follow-up
-            // reaction), and `tick_trigger_pipeline` consumes the buffer.
-            // `.chain()` rather than separate `.before()`s: all three take
-            // `ResMut<WorldContentRuntime>` so they would serialise anyway;
-            // chaining documents the pipeline. (Comms injection joins this
-            // chain in #719.)
+            // Explicit trigger-pipeline ordering (#718/#719):
+            // `tick_pending_follow_ups` must observe `pending_world_events`
+            // BEFORE `collect_world_events` drains them into
+            // `WorldEventBuffer` (same-tick follow-up reaction);
+            // `inject_comms_templates` reads the buffer and must run before
+            // `tick_trigger_pipeline`'s dispatch can mutate
+            // `runtime.name_to_uuid` (`SpawnEntity`); the pipeline consumes
+            // the buffer last. `.chain()` rather than separate `.before()`s:
+            // all four take `ResMut<WorldContentRuntime>` so they would
+            // serialise anyway; chaining documents the pipeline.
             .add_systems(
                 Update,
                 (
                     tick_pending_follow_ups,
                     collect_world_events,
+                    inject_comms_templates,
                     tick_trigger_pipeline,
                 )
                     .chain()
@@ -1258,8 +1261,8 @@ fn broadcast_objective_summary(
 ///
 /// Ordering: chained after `tick_pending_follow_ups` (which snapshots
 /// `pending_world_events` before this system drains them) and before
-/// `tick_trigger_pipeline` (which consumes the buffer for both comms-template
-/// injection and trigger evaluation).
+/// `inject_comms_templates` and `tick_trigger_pipeline` (which consume the
+/// buffer for comms-template injection and trigger evaluation respectively).
 ///
 /// Change detection: `runtime` is only mutably dereferenced when
 /// `pending_world_events` has entries to drain, and the buffer is only
@@ -1317,6 +1320,117 @@ fn collect_world_events(
     buffer.0 = world_events;
 }
 
+/// Auto-fire comms templates that match this tick's external `WorldEvent`s
+/// (e.g. `on_attacked` distress calls) and inject the resulting messages onto
+/// channel-2. These are broadcast messages — no player hailing involved.
+///
+/// Reads `WorldEventBuffer` directly: only EXTERNAL events reach comms
+/// templates — `tick_trigger_pipeline`'s internally-produced chaining events
+/// (`FlagSet`, `FlagCleared`, `Destroyed` from a `DestroyEntity` action)
+/// never do.
+///
+/// Ordering (#719): chained after `collect_world_events` (which fills the
+/// buffer) and before `tick_trigger_pipeline`. Running before the pipeline
+/// means `runtime.name_to_uuid` read here is identical to the tick-level
+/// clone the pipeline takes — no `SpawnEntity` dispatch has mutated the map
+/// yet this tick — so reading the live map directly matches the pre-#719
+/// inline behaviour exactly.
+///
+/// Change detection (#716/#718 discipline): early-out on an empty buffer
+/// WITHOUT mutably dereferencing `runtime`. This is behaviour-preserving
+/// even on the tick where the buffer is empty but the pipeline still runs
+/// for pending delayed actions: `evaluate_comms_templates` over an empty
+/// events slice is a guaranteed no-op (`events.iter().any(..)` is `false`
+/// for every template, so no `fired` flag flips and nothing is returned).
+fn inject_comms_templates(
+    mut runtime: ResMut<WorldContentRuntime>,
+    buffer: Res<WorldEventBuffer>,
+    mut channel2_writer: MessageWriter<CommsChannel2Event>,
+) {
+    if buffer.0.is_empty() {
+        return;
+    }
+
+    // Reborrow the `ResMut` as a plain `&mut` so disjoint field borrows can
+    // be split (`&mut runtime.comms_template_states` while
+    // `&runtime.name_to_uuid` is read). Placed after the early return so an
+    // event-free tick never marks the resource changed; a tick with events
+    // marks it exactly as the pre-#719 inline pipeline did.
+    let runtime = &mut *runtime;
+
+    let fired_comms = evaluate_comms_templates(
+        &mut runtime.comms_template_states,
+        &buffer.0,
+        &runtime.name_to_uuid,
+    );
+    for fc in fired_comms {
+        let thread_id = fc
+            .thread_id
+            .clone()
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        // `_self` is the reserved synthetic internal-sender name; render it as
+        // "Internal Report" in the comms UI so the crew sees a ship-generated
+        // intelligence summary rather than a literal "_self" sender label.
+        let channel_name = if fc.from == "_self" {
+            "Internal Report".to_string()
+        } else {
+            fc.from.clone()
+        };
+        let sender_name = fc.node.speaker.clone().unwrap_or(channel_name);
+        // Keyed on the RAW `fc.from` (not the mapped display name): a
+        // synthetic sender like `_self` deliberately falls through to the
+        // name itself, which `current_sender_in_range` treats as
+        // always-in-range via its non-UUID escape hatch.
+        let sender_uuid = runtime
+            .name_to_uuid
+            .get(&fc.from)
+            .cloned()
+            .unwrap_or_else(|| fc.from.clone());
+
+        // Root templates inject immediately when their template-level
+        // `trigger` fires. Per-node triggers are reserved for follow-ups.
+        let msg_id = uuid::Uuid::new_v4().to_string();
+        let responses: Vec<String> = fc.node.responses.iter().map(|r| r.text.clone()).collect();
+        let msg = crate::messages::CommsMessage {
+            id: msg_id.clone(),
+            sender_uuid: sender_uuid.clone(),
+            sender_name: sender_name.clone(),
+            subject: fc.node.body.chars().take(40).collect(),
+            body: fc.node.body.clone(),
+            responses,
+            selected_response: None,
+            is_read: false,
+            is_orphaned: false,
+            sender_in_range: current_sender_in_range(runtime, &sender_uuid),
+            thread_id: thread_id.clone(),
+            is_urgent: fc.urgent,
+        };
+        channel2_writer.write(CommsChannel2Event { message: msg });
+        runtime.active_dialogues.insert(
+            msg_id,
+            ActiveDialogue {
+                current_node: fc.node.clone(),
+                thread_id: thread_id.clone(),
+            },
+        );
+
+        // Schedule the chained root follow_up, if any. See the
+        // matching block in `handle_hail` for the rationale.
+        if let Some(ref fu) = fc.root_follow_up {
+            let fu_sender_name = fu.speaker.clone().unwrap_or(sender_name.clone());
+            runtime.pending_follow_ups.push(PendingFollowUp {
+                node: fu.clone(),
+                sender_uuid: sender_uuid.clone(),
+                sender_name: fu_sender_name,
+                thread_id: thread_id.clone(),
+                elapsed_secs: 0.0,
+                placeholder_id: None,
+                urgent: fc.urgent,
+            });
+        }
+    }
+}
+
 /// Upper bound on `tick_trigger_pipeline`'s within-tick trigger-chaining passes.
 ///
 /// A `set_flag` action emits a `FlagSet` event that a downstream `on_flag_set`
@@ -1332,7 +1446,6 @@ const MAX_CHAIN_PASSES: i32 = 16;
 fn tick_trigger_pipeline(
     mut runtime: ResMut<WorldContentRuntime>,
     mut objectives: ResMut<ObjectiveManagerRes>,
-    mut channel2_writer: MessageWriter<CommsChannel2Event>,
     mut commands: Commands,
     buffer: Res<WorldEventBuffer>,
     mut ai_query: Query<
@@ -1398,73 +1511,8 @@ fn tick_trigger_pipeline(
         .map(|(ent, uuid_comp)| (uuid_comp.0.clone(), ent))
         .collect();
 
-    // Auto-fire comms templates that match the world events (e.g. on_attacked distress calls).
-    // These are injected without any player hailing ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â they are broadcast messages.
-    // Reads the buffer directly: only EXTERNAL events reach comms templates —
-    // the chaining loop's internally-produced events below never do.
-    let fired_comms =
-        evaluate_comms_templates(&mut runtime.comms_template_states, &buffer.0, &name_to_uuid);
-    for fc in fired_comms {
-        let thread_id = fc
-            .thread_id
-            .clone()
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-        // `_self` is the reserved synthetic internal-sender name; render it as
-        // "Internal Report" in the comms UI so the crew sees a ship-generated
-        // intelligence summary rather than a literal "_self" sender label.
-        let channel_name = if fc.from == "_self" {
-            "Internal Report".to_string()
-        } else {
-            fc.from.clone()
-        };
-        let sender_name = fc.node.speaker.clone().unwrap_or(channel_name);
-        let sender_uuid = name_to_uuid
-            .get(&fc.from)
-            .cloned()
-            .unwrap_or_else(|| fc.from.clone());
-
-        // Root templates inject immediately when their template-level
-        // `trigger` fires. Per-node triggers are reserved for follow-ups.
-        let msg_id = uuid::Uuid::new_v4().to_string();
-        let responses: Vec<String> = fc.node.responses.iter().map(|r| r.text.clone()).collect();
-        let msg = crate::messages::CommsMessage {
-            id: msg_id.clone(),
-            sender_uuid: sender_uuid.clone(),
-            sender_name: sender_name.clone(),
-            subject: fc.node.body.chars().take(40).collect(),
-            body: fc.node.body.clone(),
-            responses,
-            selected_response: None,
-            is_read: false,
-            is_orphaned: false,
-            sender_in_range: current_sender_in_range(runtime, &sender_uuid),
-            thread_id: thread_id.clone(),
-            is_urgent: fc.urgent,
-        };
-        channel2_writer.write(CommsChannel2Event { message: msg });
-        runtime.active_dialogues.insert(
-            msg_id,
-            ActiveDialogue {
-                current_node: fc.node.clone(),
-                thread_id: thread_id.clone(),
-            },
-        );
-
-        // Schedule the chained root follow_up, if any. See the
-        // matching block in `handle_hail` for the rationale.
-        if let Some(ref fu) = fc.root_follow_up {
-            let fu_sender_name = fu.speaker.clone().unwrap_or(sender_name.clone());
-            runtime.pending_follow_ups.push(PendingFollowUp {
-                node: fu.clone(),
-                sender_uuid: sender_uuid.clone(),
-                sender_name: fu_sender_name,
-                thread_id: thread_id.clone(),
-                elapsed_secs: 0.0,
-                placeholder_id: None,
-                urgent: fc.urgent,
-            });
-        }
-    }
+    // Comms-template injection happens in `inject_comms_templates`, chained
+    // immediately before this system (#719).
 
     // Loop to support within-tick chaining: a trigger that fires a
     // `set_flag` action emits a `FlagSet` event which a downstream
@@ -3026,7 +3074,7 @@ pub(crate) mod tests {
         assert!(messages[0].is_urgent);
     }
 
-    /// `tick_trigger_pipeline` (auto-fire path: `on_world_loaded`,
+    /// `inject_comms_templates` (auto-fire path: `on_world_loaded`,
     /// `on_attacked`, `on_destroyed`, `on_flag_set`) also schedules the
     /// chained `root_follow_up`. Verified by emitting `WorldLoaded` on a
     /// template with a chained node.
@@ -3114,6 +3162,7 @@ pub(crate) mod tests {
                 (
                     tick_pending_follow_ups,
                     collect_world_events,
+                    inject_comms_templates,
                     tick_trigger_pipeline,
                     handle_comms_channel2,
                 )
@@ -6834,6 +6883,7 @@ condition = "on_world_loaded"
                 Update,
                 (
                     collect_world_events,
+                    inject_comms_templates,
                     tick_trigger_pipeline,
                     handle_comms_channel2,
                 )
@@ -8721,7 +8771,7 @@ size_max = 2.0
 
     // -- Issue #506: channel-2 routing tests ------------------------------------
 
-    /// Scenario hail arrives in CommsInboxRes via channel-2 (tick_trigger_pipeline
+    /// Scenario hail arrives in CommsInboxRes via channel-2 (inject_comms_templates
     /// writes to CommsChannel2Event; handle_comms_channel2 injects into inbox).
     #[test]
     fn scenario_hail_arrives_in_inbox_via_channel2() {
@@ -8749,7 +8799,7 @@ size_max = 2.0
                 },
                 fired: false,
             });
-            // Queue a WorldLoaded event so tick_trigger_pipeline fires the template.
+            // Queue a WorldLoaded event so inject_comms_templates fires the template.
             runtime.pending_world_events.push(WorldEvent::WorldLoaded);
         }
 

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -20,6 +20,10 @@ use crate::world::content::{
     ActiveDialogue, CommsTemplateState, PendingFollowUp, TriggerAction, TriggerCondition,
     TriggerState, WorldEvent,
 };
+use crate::world::dispatch::{
+    dispatch_action, ActionCmd, DispatchContext, DispatchResult, LayerView,
+    WORLD_MODIFIER_SOURCE_ID,
+};
 
 /// An action queued for deferred dispatch via the `action_delays` trigger field.
 #[derive(Clone, Debug)]
@@ -1208,6 +1212,13 @@ fn broadcast_objective_summary(
 
 // -- AI-event trigger system -------------------------------------------------
 
+/// Upper bound on `handle_ai_events`' within-tick trigger-chaining passes.
+///
+/// A `set_flag` action emits a `FlagSet` event that a downstream `on_flag_set`
+/// trigger can react to in the same Bevy frame, which can in turn set another
+/// flag. The cap stops a pathological feedback loop from hanging the frame.
+const MAX_CHAIN_PASSES: i32 = 16;
+
 /// Read `AiEntityAttacked` and `AiEntityDestroyed` messages, translate them
 /// into `WorldEvent`s, evaluate the scenario trigger table, and execute the
 /// resulting actions (including `SetAiState`, `ApplyModifier`, `RemoveModifier`,
@@ -1236,6 +1247,7 @@ fn handle_ai_events(
     mut faction_dispatch: FactionDispatchParams,
     time: Option<Res<bevy::time::Time>>,
 ) {
+    let empty_anchors: HashMap<String, [f32; 3]> = HashMap::new();
     let mut world_events: Vec<WorldEvent> = Vec::new();
     for ev in ai_events.attacked.read() {
         world_events.push(WorldEvent::Attacked {
@@ -1382,7 +1394,6 @@ fn handle_ai_events(
     // and are observed on the next pass).
     let mut current_events = world_events.clone();
     let mut pass = 0;
-    let max_passes = 16;
     loop {
         pass += 1;
         // Compute current_elapsed from TimerElapsed events in current_events.
@@ -1426,6 +1437,18 @@ fn handle_ai_events(
             .map(|s| s.origin_layer.clone())
             .collect();
         let entity_groups = runtime.entity_groups.clone();
+        // Issue #710: ONE name -> uuid map for *action dispatch*, rebuilt at
+        // the top of every chaining pass — the same per-pass freshness rule
+        // `entity_groups` above already follows. Previously the six modifier
+        // arms read the tick-level `name_to_uuid` clone while `DestroyEntity`
+        // read the live `runtime.name_to_uuid`; unifying on per-pass makes the
+        // modifier arms slightly fresher and `DestroyEntity` slightly staler,
+        // and lets an action resolve a name that a `SpawnEntity` in an earlier
+        // pass of this same tick registered.
+        //
+        // Trigger *condition* evaluation deliberately keeps using the
+        // tick-level `name_to_uuid` clone above: only the dispatch arms change.
+        let dispatch_names = runtime.name_to_uuid.clone();
         for (idx, origin) in trigger_origins.iter().enumerate() {
             // Build the flag-store and layer-path chains for this trigger.
             let mut flag_chain_owned: Vec<&crate::world::flags::FlagStore> = Vec::new();
@@ -1486,604 +1509,67 @@ fn handle_ai_events(
                     }
                     continue;
                 }
-                match action {
-                    TriggerAction::AddObjective {
-                        id,
-                        text,
-                        mandatory,
-                        targets,
-                        directive,
-                        utility,
-                        source,
-                    } => {
-                        // Explicit targets win; otherwise fall back to the
-                        // trigger condition's entity (legacy behaviour).
-                        let resolved = if targets.is_empty() {
-                            ft.entity_name.clone().into_iter().collect()
-                        } else {
-                            targets.clone()
-                        };
-                        objectives.0.add_full(
-                            id.clone(),
-                            text.clone(),
-                            *mandatory,
-                            resolved,
-                            directive.clone(),
-                            utility.clone(),
-                            source.clone(),
-                        );
-                    }
-                    TriggerAction::CompleteObjective { id } => {
-                        objectives.0.complete(id);
-                    }
-                    TriggerAction::FailObjective { id } => {
-                        objectives.0.fail(id);
-                    }
-                    TriggerAction::SetAiState {
-                        entity,
-                        state,
-                        target: _,
-                    } => {
-                        // No-op in doctrine-based AI (issue #572). FSM state slots are
-                        // gone; NPC behaviour is now driven by the scored doctrine pool.
-                        bevy::log::warn!(
-                            "handle_ai_events: SetAiState(â€˜{entity}â€™ \u{2192} â€˜{state}â€™) ignored \u{2014} doctrine-based AI"
-                        );
-                    }
-                    TriggerAction::ApplyModifier {
-                        entity,
-                        tag,
-                        slot,
-                        bonus,
-                    } => {
-                        let Some(uuid) = name_to_uuid.get(entity) else {
-                            bevy::log::warn!(
-                                "handle_ai_events: ApplyModifier: unknown entity name '{entity}'"
-                            );
-                            continue;
-                        };
-                        let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                            bevy::log::warn!(
-                                "handle_ai_events: ApplyModifier: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                            );
-                            continue;
-                        };
-                        let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                            bevy::log::warn!(
-                                "handle_ai_events: ApplyModifier: entity '{entity}' has no ShipModifiers component"
-                            );
-                            continue;
-                        };
-                        mods.add_or_update(crate::modifiers::Modifier {
-                            source: crate::messages::ModifierSource::World {
-                                id: "world".to_string(),
-                                tag: tag.clone(),
-                            },
-                            slot: slot.clone(),
-                            bonus: *bonus,
-                        });
-                    }
-                    TriggerAction::RemoveModifier { entity, tag, slot } => {
-                        let Some(uuid) = name_to_uuid.get(entity) else {
-                            bevy::log::warn!(
-                                "handle_ai_events: RemoveModifier: unknown entity name '{entity}'"
-                            );
-                            continue;
-                        };
-                        let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                            bevy::log::warn!(
-                                "handle_ai_events: RemoveModifier: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                            );
-                            continue;
-                        };
-                        let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                            bevy::log::warn!(
-                                "handle_ai_events: RemoveModifier: entity '{entity}' has no ShipModifiers component"
-                            );
-                            continue;
-                        };
-                        mods.remove(
-                            &crate::messages::ModifierSource::World {
-                                id: "world".to_string(),
-                                tag: tag.clone(),
-                            },
-                            slot,
-                        );
-                    }
-                    TriggerAction::ApplyFlag { entity, tag, kind } => {
-                        let Some(uuid) = name_to_uuid.get(entity) else {
-                            bevy::log::warn!(
-                                "handle_ai_events: ApplyFlag: unknown entity name '{entity}'"
-                            );
-                            continue;
-                        };
-                        let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                            bevy::log::warn!(
-                                "handle_ai_events: ApplyFlag: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                            );
-                            continue;
-                        };
-                        let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                            bevy::log::warn!(
-                                "handle_ai_events: ApplyFlag: entity '{entity}' has no ShipModifiers component"
-                            );
-                            continue;
-                        };
-                        mods.add_flag(
-                            crate::messages::ModifierSource::World {
-                                id: "world".to_string(),
-                                tag: tag.clone(),
-                            },
-                            kind.clone(),
-                        );
-                    }
-                    TriggerAction::RemoveFlag { entity, tag, kind } => {
-                        let Some(uuid) = name_to_uuid.get(entity) else {
-                            bevy::log::warn!(
-                                "handle_ai_events: RemoveFlag: unknown entity name '{entity}'"
-                            );
-                            continue;
-                        };
-                        let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                            bevy::log::warn!(
-                                "handle_ai_events: RemoveFlag: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                            );
-                            continue;
-                        };
-                        let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                            bevy::log::warn!(
-                                "handle_ai_events: RemoveFlag: entity '{entity}' has no ShipModifiers component"
-                            );
-                            continue;
-                        };
-                        mods.remove_flag(
-                            crate::messages::ModifierSource::World {
-                                id: "world".to_string(),
-                                tag: tag.clone(),
-                            },
-                            kind.clone(),
-                        );
-                    }
-                    TriggerAction::ApplyIntModifier {
-                        entity,
-                        tag,
-                        slot,
-                        bonus,
-                    } => {
-                        let Some(uuid) = name_to_uuid.get(entity) else {
-                            bevy::log::warn!(
-                                "handle_ai_events: ApplyIntModifier: unknown entity name '{entity}'"
-                            );
-                            continue;
-                        };
-                        let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                            bevy::log::warn!(
-                                "handle_ai_events: ApplyIntModifier: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                            );
-                            continue;
-                        };
-                        let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                            bevy::log::warn!(
-                                "handle_ai_events: ApplyIntModifier: entity '{entity}' has no ShipModifiers component"
-                            );
-                            continue;
-                        };
-                        mods.add_or_update_int(crate::modifiers::IntModifier {
-                            source: crate::messages::ModifierSource::World {
-                                id: "world".to_string(),
-                                tag: tag.clone(),
-                            },
-                            slot: slot.clone(),
-                            bonus: *bonus,
-                        });
-                    }
-                    TriggerAction::RemoveIntModifier { entity, tag, slot } => {
-                        let Some(uuid) = name_to_uuid.get(entity) else {
-                            bevy::log::warn!(
-                                "handle_ai_events: RemoveIntModifier: unknown entity name '{entity}'"
-                            );
-                            continue;
-                        };
-                        let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                            bevy::log::warn!(
-                                "handle_ai_events: RemoveIntModifier: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                            );
-                            continue;
-                        };
-                        let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                            bevy::log::warn!(
-                                "handle_ai_events: RemoveIntModifier: entity '{entity}' has no ShipModifiers component"
-                            );
-                            continue;
-                        };
-                        mods.remove_int(
-                            &crate::messages::ModifierSource::World {
-                                id: "world".to_string(),
-                                tag: tag.clone(),
-                            },
-                            slot,
-                        );
-                    }
-                    TriggerAction::GameOver { message } => {
-                        let reason = message.clone().unwrap_or_default();
-                        if let Some(ref mut gr) = game_over_reason {
-                            gr.0 = Some(reason);
-                        }
-                        if let Some(ref mut ns) = next_state {
-                            ns.set(GamePhase::GameOver);
-                        }
-                    }
-                    TriggerAction::LoadWorld { path } => {
-                        if let Some(ref mut lc) = pending_layers {
-                            // PRD #397 fix 1: record the layer that issued
-                            // this LoadWorld so `parent:` from the new
-                            // sub-world resolves up to it.
-                            lc.0.push(WorldLayerChange::Load {
-                                path: path.clone(),
-                                loader_path: ft.origin_layer.clone(),
-                            });
-                        }
-                    }
-                    TriggerAction::UnloadWorld { path } => {
-                        if let Some(ref mut lc) = pending_layers {
-                            lc.0.push(WorldLayerChange::Unload(path.clone()));
-                        }
-                    }
-                    TriggerAction::SetWorldFlag { name } => {
-                        if let Some((target_layer, stripped, before, after)) = mutate_world_flag(
-                            &mut runtime.flags,
-                            layer_map.as_deref_mut().map(|lm| &mut lm.0),
-                            &ft.origin_layer,
-                            name,
-                            FlagMutation::Set,
-                        ) {
-                            emit_flag_transition(
-                                &mut next_events,
-                                &stripped,
-                                &target_layer,
-                                before,
-                                after,
-                            );
-                        }
-                    }
-                    TriggerAction::ClearWorldFlag { name } => {
-                        if let Some((target_layer, stripped, before, after)) = mutate_world_flag(
-                            &mut runtime.flags,
-                            layer_map.as_deref_mut().map(|lm| &mut lm.0),
-                            &ft.origin_layer,
-                            name,
-                            FlagMutation::Clear,
-                        ) {
-                            emit_flag_transition(
-                                &mut next_events,
-                                &stripped,
-                                &target_layer,
-                                before,
-                                after,
-                            );
-                        }
-                    }
-                    TriggerAction::IncrementWorldFlag { name, by } => {
-                        if let Some((target_layer, stripped, before, after)) = mutate_world_flag(
-                            &mut runtime.flags,
-                            layer_map.as_deref_mut().map(|lm| &mut lm.0),
-                            &ft.origin_layer,
-                            name,
-                            FlagMutation::Increment(*by),
-                        ) {
-                            emit_flag_transition(
-                                &mut next_events,
-                                &stripped,
-                                &target_layer,
-                                before,
-                                after,
-                            );
-                        }
-                    }
-                    TriggerAction::SetWorldFlagValue { name, value } => {
-                        if let Some((target_layer, stripped, before, after)) = mutate_world_flag(
-                            &mut runtime.flags,
-                            layer_map.as_deref_mut().map(|lm| &mut lm.0),
-                            &ft.origin_layer,
-                            name,
-                            FlagMutation::SetValue(*value),
-                        ) {
-                            emit_flag_transition(
-                                &mut next_events,
-                                &stripped,
-                                &target_layer,
-                                before,
-                                after,
-                            );
-                        }
-                    }
-                    TriggerAction::SpawnEntity {
-                        template_path,
-                        name,
-                        anchor,
-                        position,
-                        rotation,
-                        scale,
-                        groups,
-                    } => {
-                        // Resolve spawn position. `anchor` looks up in the
-                        // origin layer's anchors (or the base world's anchors
-                        // for `None` origin). `position` is used directly.
-                        let pos_arr: [f32; 3] = if let Some(pos) = position {
-                            *pos
-                        } else if let Some(anchor_name) = anchor {
-                            let lookup = match &ft.origin_layer {
-                                Some(layer_path) => layer_map
-                                    .as_ref()
-                                    .and_then(|lm| lm.0.get(layer_path))
-                                    .map(|wr| wr.anchors.get(anchor_name).copied())
-                                    .unwrap_or(None),
-                                None => base_world_config
-                                    .as_ref()
-                                    .and_then(|wc| wc.anchors.get(anchor_name).copied()),
-                            };
-                            match lookup {
-                                Some(p) => p,
-                                None => {
-                                    bevy::log::warn!(
-                                        "handle_ai_events: SpawnEntity '{name}' anchor '{anchor_name}' not found"
-                                    );
-                                    continue;
-                                }
-                            }
-                        } else {
-                            bevy::log::warn!(
-                                "handle_ai_events: SpawnEntity '{name}' has neither anchor nor position"
-                            );
-                            continue;
-                        };
+                // Issue #710: the action-dispatch table lives in the pure
+                // `world::dispatch` module. Decide first, then apply.
+                //
+                // The flag stores handed to the context MUST be the LIVE ones
+                // — `runtime.flags` plus `layer_map`'s per-layer stores,
+                // re-projected for every action — never the per-pass
+                // `base_flags_snapshot` / `layer_flags_snapshot` above. Those
+                // exist for condition evaluation only (deciding which triggers
+                // fire). `dispatch_action` computes each flag mutation's
+                // before/after against these stores to decide whether a
+                // transition event fires at all, so two triggers that both
+                // `set_flag` the same flag must see 0 -> 1 and then 1 -> 1
+                // (one `FlagSet` total), not 0 -> 1 twice.
+                let layers = project_layer_views(layer_map.as_deref());
+                let result = {
+                    let ctx = DispatchContext {
+                        origin_layer: ft.origin_layer.clone(),
+                        entity_name: ft.entity_name.clone(),
+                        name_to_uuid: &dispatch_names,
+                        base_flags: &runtime.flags,
+                        layers: &layers,
+                        base_anchors: base_world_config
+                            .as_ref()
+                            .map(|wc| &wc.anchors)
+                            .unwrap_or(&empty_anchors),
+                        factions: faction_dispatch.registry.as_deref().map(|r| &r.0),
+                        uuid_source: &crate::entity_loader::assign_uuid,
+                    };
+                    dispatch_action(action, &ctx)
+                };
 
-                        // Resolve template via config cache.
-                        let config_cache = crate::config_cache::get_config_cache();
-                        let template_inst = crate::world::config::WorldEntity {
-                            template_path: template_path.clone(),
-                            ..Default::default()
-                        };
-                        let entity_config = match crate::entity_loader::resolve_entity(
-                            &template_inst,
-                            &config_cache,
-                        ) {
-                            Ok(c) => c,
-                            Err(e) => {
-                                // Native fallback: try reading from disk.
-                                #[cfg(not(target_arch = "wasm32"))]
-                                {
-                                    match std::fs::read_to_string(template_path) {
-                                        Ok(toml_str) => {
-                                            match crate::entity_config::EntityConfig::from_toml(
-                                                &toml_str,
-                                            ) {
-                                                Ok(c) => c,
-                                                Err(err) => {
-                                                    bevy::log::warn!(
-                                                        "handle_ai_events: SpawnEntity '{name}' template '{template_path}' parse error: {err:?}"
-                                                    );
-                                                    continue;
-                                                }
-                                            }
-                                        }
-                                        Err(_) => {
-                                            bevy::log::warn!(
-                                                "handle_ai_events: SpawnEntity '{name}' template '{template_path}' not in cache nor on disk: {e}"
-                                            );
-                                            continue;
-                                        }
-                                    }
-                                }
-                                #[cfg(target_arch = "wasm32")]
-                                {
-                                    bevy::log::warn!(
-                                        "handle_ai_events: SpawnEntity '{name}' template '{template_path}' not in cache: {e}"
-                                    );
-                                    continue;
-                                }
-                            }
-                        };
-
-                        let uuid = crate::entity_loader::assign_uuid();
-                        let pos_vec = Vec3::new(pos_arr[0], pos_arr[1], pos_arr[2]);
-                        // Patch the entity name with the trigger's `name` field so that the
-                        // spawned ECS entity gets EntityName("wave_1") (not the template's
-                        // display name like "Harrow Destroyer"). This mirrors what
-                        // `spawn_world_entities` does for static `[[entity]]` entries and is
-                        // required for `resolve_objective_target` to match Destroy directives
-                        // by the scenario name (e.g. `target = "wave_1"`).
-                        let mut entity_config = entity_config;
-                        if !name.is_empty() {
-                            entity_config.name = Some(name.clone());
-                        }
-                        let spawned = crate::entity_spawner::spawn_entity(
-                            &mut commands,
-                            &entity_config,
-                            pos_vec,
-                            uuid.clone(),
-                            None,
-                        );
-
-                        // Apply optional rotation (XYZ Euler radians) and
-                        // scale (per-axis), mirroring `TransformConfig`
-                        // semantics from the static `[[entity]]` schema.
-                        // `spawn_entity` only set translation; we overwrite
-                        // the Transform with translation + rotation + scale
-                        // when either is supplied.
-                        if rotation.is_some() || scale.is_some() {
-                            let [rx, ry, rz] = rotation.unwrap_or([0.0, 0.0, 0.0]);
-                            let quat = Quat::from_euler(EulerRot::XYZ, rx, ry, rz);
-                            let [sx, sy, sz] = scale.unwrap_or([1.0, 1.0, 1.0]);
-                            let scale_vec = Vec3::new(sx, sy, sz);
-                            commands.entity(spawned).insert(Transform {
-                                translation: pos_vec,
-                                rotation: quat,
-                                scale: scale_vec,
-                            });
-                        }
-
-                        // Register name ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ uuid for subsequent triggers.
-                        runtime.name_to_uuid.insert(name.clone(), uuid);
-
-                        // Register entity in groups for OnAllDestroyed tracking.
-                        for g in groups {
-                            runtime
-                                .entity_groups
-                                .entry(g.clone())
-                                .or_default()
-                                .insert(name.clone());
-                        }
-
-                        // Attach to the parent layer's spawned_entities so
-                        // `UnloadWorld` despawns the entity (base-world
-                        // origin: entity just persists for the session).
-                        if let (Some(layer_path), Some(ref mut lm)) =
-                            (&ft.origin_layer, &mut layer_map)
-                        {
-                            if let Some(layer) = lm.0.get_mut(layer_path) {
-                                layer.spawned_entities.push(spawned);
-                            }
-                        }
-                    }
-                    TriggerAction::DestroyEntity { entity } => {
-                        let uuid = match runtime.name_to_uuid.get(entity) {
-                            Some(u) => u.clone(),
-                            None => {
-                                bevy::log::warn!(
-                                    "handle_ai_events: DestroyEntity: unknown entity name '{entity}'"
-                                );
-                                continue;
-                            }
-                        };
-                        // Find the Bevy entity with that UUID.
-                        let mut target_entity: Option<Entity> = None;
-                        for (ent, uuid_comp) in entity_uuid_query.iter() {
-                            if uuid_comp.0 == uuid {
-                                target_entity = Some(ent);
-                                break;
-                            }
-                        }
-                        // Push into our local pipeline so chained
-                        // on_destroyed triggers in the same frame fire.
-                        // We deliberately do NOT use
-                        // MessageWriter<AiEntityDestroyed> directly here
-                        // because this system already holds the matching
-                        // reader, which would trigger Bevy's B0002 access
-                        // check. Instead, defer the message write via a
-                        // command so it runs after this system exits and
-                        // external consumers (telemetry, save/load,
-                        // achievements) observe script-killed entities the
-                        // same as combat-killed ones.
-                        next_events.push(WorldEvent::Destroyed { uuid: uuid.clone() });
-                        let msg_uuid = uuid.clone();
-                        commands.queue(move |world: &mut World| {
-                            if let Some(mut msgs) = world
-                                .get_resource_mut::<Messages<crate::ai_plugin::AiEntityDestroyed>>()
-                            {
-                                msgs.write(crate::ai_plugin::AiEntityDestroyed {
-                                    entity_uuid: msg_uuid,
-                                });
-                            }
-                        });
-                        // Despawn the underlying entity if we found it.
-                        if let Some(ent) = target_entity {
-                            commands.entity(ent).try_despawn();
-                        }
-                    }
-                    TriggerAction::AddFactionEnemy { faction, enemy } => {
-                        let Some(registry) = faction_dispatch.registry.as_deref_mut() else {
-                            bevy::log::warn!(
-                                "handle_ai_events: AddFactionEnemy skipped: FactionRegistryResource not present"
-                            );
-                            continue;
-                        };
-                        let faction_uuid = match registry.0.uuid_by_name(faction) {
-                            Some(u) => u,
-                            None => {
-                                bevy::log::warn!(
-                                    "handle_ai_events: AddFactionEnemy: unknown faction name '{faction}'"
-                                );
-                                continue;
-                            }
-                        };
-                        let enemy_uuid = match registry.0.uuid_by_name(enemy) {
-                            Some(u) => u,
-                            None => {
-                                bevy::log::warn!(
-                                    "handle_ai_events: AddFactionEnemy: unknown enemy faction name '{enemy}'"
-                                );
-                                continue;
-                            }
-                        };
-                        // Idempotent: returns false if `enemy_uuid` is
-                        // already listed. Either way no target re-validation
-                        // is needed because adding a new hostility cannot
-                        // invalidate an existing engagement Ã¢â‚¬â€ the next
-                        // `enemy_in_range` tick organically picks up the
-                        // new relationship.
-                        registry.0.add_enemy(faction_uuid, enemy_uuid);
-                    }
-                    TriggerAction::RemoveFactionEnemy { faction, enemy } => {
-                        let Some(registry) = faction_dispatch.registry.as_deref_mut() else {
-                            bevy::log::warn!(
-                                "handle_ai_events: RemoveFactionEnemy skipped: FactionRegistryResource not present"
-                            );
-                            continue;
-                        };
-                        let faction_uuid = match registry.0.uuid_by_name(faction) {
-                            Some(u) => u,
-                            None => {
-                                bevy::log::warn!(
-                                    "handle_ai_events: RemoveFactionEnemy: unknown faction name '{faction}'"
-                                );
-                                continue;
-                            }
-                        };
-                        let enemy_uuid = match registry.0.uuid_by_name(enemy) {
-                            Some(u) => u,
-                            None => {
-                                bevy::log::warn!(
-                                    "handle_ai_events: RemoveFactionEnemy: unknown enemy faction name '{enemy}'"
-                                );
-                                continue;
-                            }
-                        };
-                        let removed = registry.0.remove_enemy(faction_uuid, enemy_uuid);
-                        if removed {
-                            // Snapshot every AI controller's own faction
-                            // BEFORE we take the &mut on the query for
-                            // re-validation. `iter()` on a `&mut Query`
-                            // yields immutable refs so no borrow conflict
-                            // with the subsequent `iter_mut()`.
-                            let ai_factions: Vec<(uuid::Uuid, uuid::Uuid)> = ai_query
-                                .iter()
-                                .filter_map(|(uid, _, fc)| {
-                                    let self_uuid = uuid::Uuid::parse_str(&uid.0).ok()?;
-                                    fc.map(|fc| (self_uuid, fc.0))
-                                })
-                                .collect();
-                            let uuid_to_faction = build_uuid_to_faction(
-                                &faction_dispatch.non_ai_factions,
-                                &ai_factions,
-                            );
-                            revalidate_ai_targets_after_faction_change(
-                                &mut ai_query,
-                                &registry.0,
-                                &uuid_to_faction,
-                            );
-                        }
-                    }
-                }
+                // Applied before the next action is dispatched, so the next
+                // `DispatchContext` observes this action's writes. `new_events`
+                // route into this pass's `next_events` — i.e. the next chaining
+                // pass of the SAME tick (`tick_delayed_actions` instead queues
+                // them onto `runtime.pending_world_events` for the next tick).
+                apply_dispatch_result(
+                    result,
+                    "handle_ai_events",
+                    &mut next_events,
+                    &uuid_to_entity,
+                    &mut runtime,
+                    &mut objectives,
+                    &mut commands,
+                    &mut ship_modifiers,
+                    pending_layers.as_deref_mut(),
+                    layer_map.as_deref_mut(),
+                    next_state.as_deref_mut(),
+                    game_over_reason.as_deref_mut(),
+                    &mut faction_dispatch,
+                    &mut ai_query,
+                );
             }
         }
 
         if next_events.is_empty() {
             break;
         }
-        if pass >= max_passes {
+        if pass >= MAX_CHAIN_PASSES {
             bevy::log::warn!(
-                "handle_ai_events: trigger chain exceeded {max_passes} passes; \
+                "handle_ai_events: trigger chain exceeded {MAX_CHAIN_PASSES} passes; \
                  stopping to prevent infinite loop"
             );
             break;
@@ -2092,538 +1578,503 @@ fn handle_ai_events(
     }
 }
 
-/// Dispatch a single `TriggerAction` using the provided execution context.
+/// Project the live `WorldLayerMap` into the read-only `LayerView`s that
+/// `dispatch_action` reads.
 ///
-/// This is the shared action-dispatch path used by both `handle_ai_events` (for
-/// immediate actions) and `tick_delayed_actions` (for `action_delays` queue).
+/// Called once per action rather than once per pass: `LayerView::flags` must be
+/// the *live* per-layer store so that a flag mutation applied earlier in this
+/// same pass is visible to the next action's before/after preview. See
+/// `DispatchContext::base_flags` for why that matters.
+fn project_layer_views(layer_map: Option<&WorldLayerMap>) -> HashMap<String, LayerView> {
+    layer_map
+        .map(|lm| {
+            lm.0.iter()
+                .map(|(path, wr)| {
+                    (
+                        path.clone(),
+                        LayerView {
+                            flags: wr.flags.clone(),
+                            loader_path: wr.loader_path.clone(),
+                            anchors: wr.anchors.clone(),
+                        },
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Resolve a dispatched UUID to its target entity's `ShipModifiers` component.
 ///
-/// All parameters are consumed/borrowed directly to avoid lifetime issues when
-/// called from `tick_delayed_actions`, which re-builds `uuid_to_entity` each tick
-/// rather than capturing a handle-ai-events-local binding.
+/// The pure layer resolves entity *name* -> *UUID* and stops there (writing a
+/// component is irreducibly impure), so the last two hops — UUID -> `Entity` ->
+/// component — land here. `what` names the calling action for the warn text.
+fn world_modifiers<'a>(
+    ship_modifiers: &'a mut ShipModifiersParams,
+    uuid_to_entity: &HashMap<String, Entity>,
+    uuid: &str,
+    log_ctx: &str,
+    what: &str,
+) -> Option<Mut<'a, crate::modifiers::ShipModifiers>> {
+    let Some(target) = uuid_to_entity.get(uuid).copied() else {
+        bevy::log::warn!("{log_ctx}: {what}: no ECS entity with UUID '{uuid}'");
+        return None;
+    };
+    match ship_modifiers.components.get_mut(target) {
+        Ok(mods) => Some(mods),
+        Err(_) => {
+            bevy::log::warn!(
+                "{log_ctx}: {what}: entity with UUID '{uuid}' has no ShipModifiers component"
+            );
+            None
+        }
+    }
+}
+
+/// Rebuild the `ModifierSource::World` that identifies a world-applied modifier.
+///
+/// Not a tunable value: this identity is what lets a later `RemoveModifier`
+/// find what an earlier `ApplyModifier` added.
+fn world_modifier_source(tag: String) -> crate::messages::ModifierSource {
+    crate::messages::ModifierSource::World {
+        id: WORLD_MODIFIER_SOURCE_ID.to_string(),
+        tag,
+    }
+}
+
+/// Perform everything one `DispatchResult` decided.
+///
+/// The impure half of the dispatch table (issue #710): `world::dispatch` decides
+/// *what* should happen from read-only data, and this turns that into ECS
+/// mutations. It is the shared apply path for both `handle_ai_events` (immediate
+/// actions) and `tick_delayed_actions` (delayed ones).
+///
+/// The one thing callers must decide for themselves is where `new_events` go, so
+/// they are written to the caller's `events_out`: `handle_ai_events` points that
+/// at the current pass's `next_events` (same tick, next chaining pass), whereas
+/// `tick_delayed_actions` drains it into `runtime.pending_world_events` (next
+/// tick). Same events, different destination.
+///
+/// `log_ctx` prefixes the pure layer's `warnings` so each message still names
+/// the system it came from.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn dispatch_single_action(
-    action: &TriggerAction,
-    origin_layer: &Option<String>,
-    entity_name: &Option<String>,
-    name_to_uuid: &HashMap<String, String>,
-    uuid_to_entity: &std::collections::HashMap<String, Entity>,
+fn apply_dispatch_result(
+    result: DispatchResult,
+    log_ctx: &str,
+    events_out: &mut Vec<WorldEvent>,
+    uuid_to_entity: &HashMap<String, Entity>,
     runtime: &mut WorldContentRuntime,
     objectives: &mut ObjectiveManagerRes,
-    mut pending_layers: Option<&mut PendingWorldLayerChanges>,
-    mut layer_map: Option<&mut WorldLayerMap>,
-    base_world_config: Option<&crate::world::config::WorldConfig>,
-    entity_uuid_query: &Query<(Entity, &EntityUuid)>,
     commands: &mut Commands,
     ship_modifiers: &mut ShipModifiersParams,
+    mut pending_layers: Option<&mut PendingWorldLayerChanges>,
+    mut layer_map: Option<&mut WorldLayerMap>,
     mut next_state: Option<&mut NextState<GamePhase>>,
     mut game_over_reason: Option<&mut crate::simulation::GameOverReason>,
     faction_dispatch: &mut FactionDispatchParams,
+    ai_query: &mut Query<
+        (
+            &EntityUuid,
+            Option<&mut crate::ai_plugin::ShipAiMemory>,
+            Option<&crate::entities::spawner::FactionComponent>,
+        ),
+        With<AiControllerComponent>,
+    >,
 ) {
-    match action {
-        TriggerAction::AddObjective {
-            id,
-            text,
-            mandatory,
-            targets,
-            directive,
-            utility,
-            source,
-        } => {
-            let resolved = if targets.is_empty() {
-                entity_name.clone().into_iter().collect()
-            } else {
-                targets.clone()
-            };
-            objectives.0.add_full(
-                id.clone(),
-                text.clone(),
-                *mandatory,
-                resolved,
-                directive.clone(),
-                utility.clone(),
-                source.clone(),
-            );
-        }
-        TriggerAction::CompleteObjective { id } => {
-            objectives.0.complete(id);
-        }
-        TriggerAction::FailObjective { id } => {
-            objectives.0.fail(id);
-        }
-        TriggerAction::SetAiState {
-            entity,
-            state,
-            target: _,
-        } => {
-            bevy::log::warn!(
-                "dispatch_single_action: SetAiState('{entity}' → '{state}') ignored — doctrine-based AI"
-            );
-        }
-        TriggerAction::ApplyModifier {
-            entity,
-            tag,
-            slot,
-            bonus,
-        } => {
-            let Some(uuid) = name_to_uuid.get(entity) else {
-                bevy::log::warn!(
-                    "dispatch_single_action: ApplyModifier: unknown entity name '{entity}'"
-                );
-                return;
-            };
-            let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                bevy::log::warn!(
-                    "dispatch_single_action: ApplyModifier: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                );
-                return;
-            };
-            let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                bevy::log::warn!(
-                    "dispatch_single_action: ApplyModifier: entity '{entity}' has no ShipModifiers component"
-                );
-                return;
-            };
-            mods.add_or_update(crate::modifiers::Modifier {
-                source: crate::messages::ModifierSource::World {
-                    id: "world".to_string(),
-                    tag: tag.clone(),
-                },
-                slot: slot.clone(),
-                bonus: *bonus,
-            });
-        }
-        TriggerAction::RemoveModifier { entity, tag, slot } => {
-            let Some(uuid) = name_to_uuid.get(entity) else {
-                bevy::log::warn!(
-                    "dispatch_single_action: RemoveModifier: unknown entity name '{entity}'"
-                );
-                return;
-            };
-            let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                bevy::log::warn!(
-                    "dispatch_single_action: RemoveModifier: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                );
-                return;
-            };
-            let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                bevy::log::warn!(
-                    "dispatch_single_action: RemoveModifier: entity '{entity}' has no ShipModifiers component"
-                );
-                return;
-            };
-            mods.remove(
-                &crate::messages::ModifierSource::World {
-                    id: "world".to_string(),
-                    tag: tag.clone(),
-                },
-                slot,
-            );
-        }
-        TriggerAction::ApplyFlag { entity, tag, kind } => {
-            let Some(uuid) = name_to_uuid.get(entity) else {
-                bevy::log::warn!(
-                    "dispatch_single_action: ApplyFlag: unknown entity name '{entity}'"
-                );
-                return;
-            };
-            let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                bevy::log::warn!(
-                    "dispatch_single_action: ApplyFlag: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                );
-                return;
-            };
-            let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                bevy::log::warn!(
-                    "dispatch_single_action: ApplyFlag: entity '{entity}' has no ShipModifiers component"
-                );
-                return;
-            };
-            mods.add_flag(
-                crate::messages::ModifierSource::World {
-                    id: "world".to_string(),
-                    tag: tag.clone(),
-                },
-                kind.clone(),
-            );
-        }
-        TriggerAction::RemoveFlag { entity, tag, kind } => {
-            let Some(uuid) = name_to_uuid.get(entity) else {
-                bevy::log::warn!(
-                    "dispatch_single_action: RemoveFlag: unknown entity name '{entity}'"
-                );
-                return;
-            };
-            let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                bevy::log::warn!(
-                    "dispatch_single_action: RemoveFlag: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                );
-                return;
-            };
-            let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                bevy::log::warn!(
-                    "dispatch_single_action: RemoveFlag: entity '{entity}' has no ShipModifiers component"
-                );
-                return;
-            };
-            mods.remove_flag(
-                crate::messages::ModifierSource::World {
-                    id: "world".to_string(),
-                    tag: tag.clone(),
-                },
-                kind.clone(),
-            );
-        }
-        TriggerAction::ApplyIntModifier {
-            entity,
-            tag,
-            slot,
-            bonus,
-        } => {
-            let Some(uuid) = name_to_uuid.get(entity) else {
-                bevy::log::warn!(
-                    "dispatch_single_action: ApplyIntModifier: unknown entity name '{entity}'"
-                );
-                return;
-            };
-            let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                bevy::log::warn!(
-                    "dispatch_single_action: ApplyIntModifier: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                );
-                return;
-            };
-            let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                bevy::log::warn!(
-                    "dispatch_single_action: ApplyIntModifier: entity '{entity}' has no ShipModifiers component"
-                );
-                return;
-            };
-            mods.add_or_update_int(crate::modifiers::IntModifier {
-                source: crate::messages::ModifierSource::World {
-                    id: "world".to_string(),
-                    tag: tag.clone(),
-                },
-                slot: slot.clone(),
-                bonus: *bonus,
-            });
-        }
-        TriggerAction::RemoveIntModifier { entity, tag, slot } => {
-            let Some(uuid) = name_to_uuid.get(entity) else {
-                bevy::log::warn!(
-                    "dispatch_single_action: RemoveIntModifier: unknown entity name '{entity}'"
-                );
-                return;
-            };
-            let Some(target) = uuid_to_entity.get(uuid).copied() else {
-                bevy::log::warn!(
-                    "dispatch_single_action: RemoveIntModifier: no ECS entity with UUID '{uuid}' for name '{entity}'"
-                );
-                return;
-            };
-            let Ok(mut mods) = ship_modifiers.components.get_mut(target) else {
-                bevy::log::warn!(
-                    "dispatch_single_action: RemoveIntModifier: entity '{entity}' has no ShipModifiers component"
-                );
-                return;
-            };
-            mods.remove_int(
-                &crate::messages::ModifierSource::World {
-                    id: "world".to_string(),
-                    tag: tag.clone(),
-                },
-                slot,
-            );
-        }
-        TriggerAction::GameOver { message } => {
-            let reason = message.clone().unwrap_or_default();
-            if let Some(ref mut gr) = game_over_reason {
-                gr.0 = Some(reason);
+    let DispatchResult {
+        commands: action_cmds,
+        new_events,
+        name_to_uuid_inserts,
+        entity_group_inserts,
+        warnings,
+    } = result;
+
+    for warning in warnings {
+        bevy::log::warn!("{log_ctx}: {warning}");
+    }
+
+    events_out.extend(new_events);
+
+    // `name_to_uuid_inserts` / `entity_group_inserts` are contingent on the
+    // accompanying `SpawnEntity` command actually spawning — template loading is
+    // still the applier's job (issue #715 moves it into the pure layer), so the
+    // pure layer cannot know whether the spawn resolved. Registering a name for
+    // an entity that never spawned would leave a phantom name -> uuid entry, and
+    // a later `DestroyEntity` would then emit `WorldEvent::Destroyed` for a
+    // ghost, firing `on_destroyed` triggers for an entity that never existed.
+    let mut spawn_failed = false;
+
+    for cmd in action_cmds {
+        match cmd {
+            ActionCmd::AddObjective {
+                id,
+                text,
+                mandatory,
+                targets,
+                directive,
+                utility,
+                source,
+            } => {
+                objectives
+                    .0
+                    .add_full(id, text, mandatory, targets, directive, utility, source);
             }
-            if let Some(ref mut ns) = next_state {
-                ns.set(GamePhase::GameOver);
+
+            ActionCmd::CompleteObjective { id } => {
+                objectives.0.complete(&id);
             }
-        }
-        TriggerAction::LoadWorld { path } => {
-            if let Some(ref mut lc) = pending_layers {
-                lc.0.push(WorldLayerChange::Load {
-                    path: path.clone(),
-                    loader_path: origin_layer.clone(),
+
+            ActionCmd::FailObjective { id } => {
+                objectives.0.fail(&id);
+            }
+
+            ActionCmd::ApplyModifier {
+                uuid,
+                tag,
+                slot,
+                bonus,
+            } => {
+                let Some(mut mods) = world_modifiers(
+                    ship_modifiers,
+                    uuid_to_entity,
+                    &uuid,
+                    log_ctx,
+                    "ApplyModifier",
+                ) else {
+                    continue;
+                };
+                mods.add_or_update(crate::modifiers::Modifier {
+                    source: world_modifier_source(tag),
+                    slot,
+                    bonus,
                 });
             }
-        }
-        TriggerAction::UnloadWorld { path } => {
-            if let Some(ref mut lc) = pending_layers {
-                lc.0.push(WorldLayerChange::Unload(path.clone()));
-            }
-        }
-        TriggerAction::SetWorldFlag { name } => {
-            if let Some((target_layer, stripped, before, after)) = mutate_world_flag(
-                &mut runtime.flags,
-                layer_map.as_deref_mut().map(|lm| &mut lm.0),
-                origin_layer,
-                name,
-                FlagMutation::Set,
-            ) {
-                let mut next_events: Vec<WorldEvent> = Vec::new();
-                emit_flag_transition(&mut next_events, &stripped, &target_layer, before, after);
-                runtime.pending_world_events.extend(next_events);
-            }
-        }
-        TriggerAction::ClearWorldFlag { name } => {
-            if let Some((target_layer, stripped, before, after)) = mutate_world_flag(
-                &mut runtime.flags,
-                layer_map.as_deref_mut().map(|lm| &mut lm.0),
-                origin_layer,
-                name,
-                FlagMutation::Clear,
-            ) {
-                let mut next_events: Vec<WorldEvent> = Vec::new();
-                emit_flag_transition(&mut next_events, &stripped, &target_layer, before, after);
-                runtime.pending_world_events.extend(next_events);
-            }
-        }
-        TriggerAction::IncrementWorldFlag { name, by } => {
-            if let Some((target_layer, stripped, before, after)) = mutate_world_flag(
-                &mut runtime.flags,
-                layer_map.as_deref_mut().map(|lm| &mut lm.0),
-                origin_layer,
-                name,
-                FlagMutation::Increment(*by),
-            ) {
-                let mut next_events: Vec<WorldEvent> = Vec::new();
-                emit_flag_transition(&mut next_events, &stripped, &target_layer, before, after);
-                runtime.pending_world_events.extend(next_events);
-            }
-        }
-        TriggerAction::SetWorldFlagValue { name, value } => {
-            if let Some((target_layer, stripped, before, after)) = mutate_world_flag(
-                &mut runtime.flags,
-                layer_map.as_deref_mut().map(|lm| &mut lm.0),
-                origin_layer,
-                name,
-                FlagMutation::SetValue(*value),
-            ) {
-                let mut next_events: Vec<WorldEvent> = Vec::new();
-                emit_flag_transition(&mut next_events, &stripped, &target_layer, before, after);
-                runtime.pending_world_events.extend(next_events);
-            }
-        }
-        TriggerAction::SpawnEntity {
-            template_path,
-            name,
-            anchor,
-            position,
-            rotation,
-            scale,
-            groups,
-        } => {
-            let pos_arr: [f32; 3] = if let Some(pos) = position {
-                *pos
-            } else if let Some(anchor_name) = anchor {
-                let lookup = match origin_layer {
-                    Some(layer_path) => layer_map
-                        .as_ref()
-                        .and_then(|lm| lm.0.get(layer_path))
-                        .map(|wr| wr.anchors.get(anchor_name).copied())
-                        .unwrap_or(None),
-                    None => base_world_config.and_then(|wc| wc.anchors.get(anchor_name).copied()),
-                };
-                match lookup {
-                    Some(p) => p,
-                    None => {
-                        bevy::log::warn!(
-                            "dispatch_single_action: SpawnEntity '{name}' anchor '{anchor_name}' not found"
-                        );
-                        return;
-                    }
-                }
-            } else {
-                bevy::log::warn!(
-                    "dispatch_single_action: SpawnEntity '{name}' has neither anchor nor position"
-                );
-                return;
-            };
 
-            let config_cache = crate::config_cache::get_config_cache();
-            let template_inst = crate::world::config::WorldEntity {
-                template_path: template_path.clone(),
-                ..Default::default()
-            };
-            let entity_config = match crate::entity_loader::resolve_entity(
-                &template_inst,
-                &config_cache,
-            ) {
-                Ok(c) => c,
-                Err(e) => {
-                    #[cfg(not(target_arch = "wasm32"))]
-                    {
-                        match std::fs::read_to_string(template_path) {
-                            Ok(toml_str) => {
-                                match crate::entity_config::EntityConfig::from_toml(&toml_str) {
-                                    Ok(c) => c,
-                                    Err(err) => {
-                                        bevy::log::warn!(
-                                            "dispatch_single_action: SpawnEntity '{name}' template '{template_path}' parse error: {err:?}"
-                                        );
-                                        return;
+            ActionCmd::RemoveModifier { uuid, tag, slot } => {
+                let Some(mut mods) = world_modifiers(
+                    ship_modifiers,
+                    uuid_to_entity,
+                    &uuid,
+                    log_ctx,
+                    "RemoveModifier",
+                ) else {
+                    continue;
+                };
+                mods.remove(&world_modifier_source(tag), &slot);
+            }
+
+            ActionCmd::ApplyFlag { uuid, tag, kind } => {
+                let Some(mut mods) =
+                    world_modifiers(ship_modifiers, uuid_to_entity, &uuid, log_ctx, "ApplyFlag")
+                else {
+                    continue;
+                };
+                mods.add_flag(world_modifier_source(tag), kind);
+            }
+
+            ActionCmd::RemoveFlag { uuid, tag, kind } => {
+                let Some(mut mods) =
+                    world_modifiers(ship_modifiers, uuid_to_entity, &uuid, log_ctx, "RemoveFlag")
+                else {
+                    continue;
+                };
+                mods.remove_flag(world_modifier_source(tag), kind);
+            }
+
+            ActionCmd::ApplyIntModifier {
+                uuid,
+                tag,
+                slot,
+                bonus,
+            } => {
+                let Some(mut mods) = world_modifiers(
+                    ship_modifiers,
+                    uuid_to_entity,
+                    &uuid,
+                    log_ctx,
+                    "ApplyIntModifier",
+                ) else {
+                    continue;
+                };
+                mods.add_or_update_int(crate::modifiers::IntModifier {
+                    source: world_modifier_source(tag),
+                    slot,
+                    bonus,
+                });
+            }
+
+            ActionCmd::RemoveIntModifier { uuid, tag, slot } => {
+                let Some(mut mods) = world_modifiers(
+                    ship_modifiers,
+                    uuid_to_entity,
+                    &uuid,
+                    log_ctx,
+                    "RemoveIntModifier",
+                ) else {
+                    continue;
+                };
+                mods.remove_int(&world_modifier_source(tag), &slot);
+            }
+
+            // Always applied before `SetNextState` below —
+            // `OnEnter(GamePhase::GameOver)` reads the reason resource.
+            ActionCmd::SetGameOverReason { reason } => {
+                if let Some(gr) = game_over_reason.as_deref_mut() {
+                    gr.0 = Some(reason);
+                }
+            }
+
+            ActionCmd::SetNextState { phase } => {
+                if let Some(ns) = next_state.as_deref_mut() {
+                    ns.set(phase);
+                }
+            }
+
+            ActionCmd::LoadWorld { path, loader_path } => {
+                if let Some(lc) = pending_layers.as_deref_mut() {
+                    lc.0.push(WorldLayerChange::Load { path, loader_path });
+                }
+            }
+
+            ActionCmd::UnloadWorld { path } => {
+                if let Some(lc) = pending_layers.as_deref_mut() {
+                    lc.0.push(WorldLayerChange::Unload(path));
+                }
+            }
+
+            // `target_layer` and `name` arrive already resolved: `parent:`
+            // prefixes are stripped and walked, and the layer was proved to
+            // exist against the same projection this applier writes to. The
+            // transition event (if any) is already in `events_out`.
+            ActionCmd::MutateFlag {
+                target_layer,
+                name,
+                mutation,
+            } => {
+                let store = match &target_layer {
+                    None => Some(&mut runtime.flags),
+                    Some(path) => layer_map
+                        .as_deref_mut()
+                        .and_then(|lm| lm.0.get_mut(path))
+                        .map(|wr| &mut wr.flags),
+                };
+                let Some(store) = store else {
+                    bevy::log::warn!(
+                        "{log_ctx}: MutateFlag: target layer {target_layer:?} missing from \
+                         WorldLayerMap — ignoring '{name}'"
+                    );
+                    continue;
+                };
+                match mutation {
+                    crate::world::dispatch::FlagMutation::Set => store.set_flag(&name),
+                    crate::world::dispatch::FlagMutation::Clear => store.clear_flag(&name),
+                    crate::world::dispatch::FlagMutation::Increment(by) => {
+                        store.increment_flag(&name, by)
+                    }
+                    crate::world::dispatch::FlagMutation::SetValue(v) => {
+                        store.set_flag_value(&name, v)
+                    }
+                };
+            }
+
+            ActionCmd::SpawnEntity {
+                template_path,
+                name,
+                uuid,
+                position,
+                rotation,
+                scale,
+                groups: _,
+                layer_path,
+            } => {
+                // Template loading stays here for now (issue #715 moves it into
+                // the pure layer behind a `TemplateLoader`). A failure here is
+                // what makes the name / group registrations contingent.
+                let config_cache = crate::config_cache::get_config_cache();
+                let template_inst = crate::world::config::WorldEntity {
+                    template_path: template_path.clone(),
+                    ..Default::default()
+                };
+                let entity_config = match crate::entity_loader::resolve_entity(
+                    &template_inst,
+                    &config_cache,
+                ) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        // Native fallback: try reading from disk.
+                        #[cfg(not(target_arch = "wasm32"))]
+                        {
+                            match std::fs::read_to_string(&template_path) {
+                                Ok(toml_str) => {
+                                    match crate::entity_config::EntityConfig::from_toml(&toml_str) {
+                                        Ok(c) => c,
+                                        Err(err) => {
+                                            bevy::log::warn!(
+                                                    "{log_ctx}: SpawnEntity '{name}' template '{template_path}' parse error: {err:?}"
+                                                );
+                                            spawn_failed = true;
+                                            continue;
+                                        }
                                     }
                                 }
-                            }
-                            Err(_) => {
-                                bevy::log::warn!(
-                                    "dispatch_single_action: SpawnEntity '{name}' template '{template_path}' not in cache nor on disk: {e}"
-                                );
-                                return;
+                                Err(_) => {
+                                    bevy::log::warn!(
+                                            "{log_ctx}: SpawnEntity '{name}' template '{template_path}' not in cache nor on disk: {e}"
+                                        );
+                                    spawn_failed = true;
+                                    continue;
+                                }
                             }
                         }
+                        #[cfg(target_arch = "wasm32")]
+                        {
+                            bevy::log::warn!(
+                                    "{log_ctx}: SpawnEntity '{name}' template '{template_path}' not in cache: {e}"
+                                );
+                            spawn_failed = true;
+                            continue;
+                        }
                     }
-                    #[cfg(target_arch = "wasm32")]
-                    {
-                        bevy::log::warn!(
-                            "dispatch_single_action: SpawnEntity '{name}' template '{template_path}' not in cache: {e}"
-                        );
-                        return;
-                    }
+                };
+
+                let pos_vec = Vec3::new(position[0], position[1], position[2]);
+                // Patch the entity name with the trigger's `name` field so the
+                // spawned ECS entity gets EntityName("wave_1") (not the
+                // template's display name like "Harrow Destroyer"). This mirrors
+                // what `spawn_world_entities` does for static `[[entity]]`
+                // entries and is required for `resolve_objective_target` to
+                // match Destroy directives by the scenario name.
+                let mut entity_config = entity_config;
+                if !name.is_empty() {
+                    entity_config.name = Some(name.clone());
                 }
-            };
+                let spawned = crate::entity_spawner::spawn_entity(
+                    commands,
+                    &entity_config,
+                    pos_vec,
+                    uuid,
+                    None,
+                );
 
-            let uuid = crate::entity_loader::assign_uuid();
-            let pos_vec = Vec3::new(pos_arr[0], pos_arr[1], pos_arr[2]);
-            let mut entity_config = entity_config;
-            if !name.is_empty() {
-                entity_config.name = Some(name.clone());
-            }
-            let spawned = crate::entity_spawner::spawn_entity(
-                commands,
-                &entity_config,
-                pos_vec,
-                uuid.clone(),
-                None,
-            );
-
-            if rotation.is_some() || scale.is_some() {
-                let [rx, ry, rz] = rotation.unwrap_or([0.0, 0.0, 0.0]);
-                let quat = Quat::from_euler(EulerRot::XYZ, rx, ry, rz);
-                let [sx, sy, sz] = scale.unwrap_or([1.0, 1.0, 1.0]);
-                let scale_vec = Vec3::new(sx, sy, sz);
-                commands.entity(spawned).insert(Transform {
-                    translation: pos_vec,
-                    rotation: quat,
-                    scale: scale_vec,
-                });
-            }
-
-            runtime.name_to_uuid.insert(name.clone(), uuid);
-
-            for g in groups {
-                runtime
-                    .entity_groups
-                    .entry(g.clone())
-                    .or_default()
-                    .insert(name.clone());
-            }
-
-            if let (Some(layer_path), Some(ref mut lm)) = (origin_layer, &mut layer_map) {
-                if let Some(layer) = lm.0.get_mut(layer_path) {
-                    layer.spawned_entities.push(spawned);
-                }
-            }
-        }
-        TriggerAction::DestroyEntity { entity } => {
-            let uuid = match runtime.name_to_uuid.get(entity) {
-                Some(u) => u.clone(),
-                None => {
-                    bevy::log::warn!(
-                        "dispatch_single_action: DestroyEntity: unknown entity name '{entity}'"
-                    );
-                    return;
-                }
-            };
-            let mut target_entity: Option<Entity> = None;
-            for (ent, uuid_comp) in entity_uuid_query.iter() {
-                if uuid_comp.0 == uuid {
-                    target_entity = Some(ent);
-                    break;
-                }
-            }
-            runtime
-                .pending_world_events
-                .push(WorldEvent::Destroyed { uuid: uuid.clone() });
-            let msg_uuid = uuid.clone();
-            commands.queue(move |world: &mut World| {
-                if let Some(mut msgs) =
-                    world.get_resource_mut::<Messages<crate::ai_plugin::AiEntityDestroyed>>()
-                {
-                    msgs.write(crate::ai_plugin::AiEntityDestroyed {
-                        entity_uuid: msg_uuid,
+                // Apply optional rotation (XYZ Euler radians) and scale
+                // (per-axis), mirroring `TransformConfig` semantics from the
+                // static `[[entity]]` schema. `spawn_entity` only set
+                // translation; overwrite the whole Transform when either is
+                // supplied.
+                if rotation.is_some() || scale.is_some() {
+                    let [rx, ry, rz] = rotation.unwrap_or([0.0, 0.0, 0.0]);
+                    let quat = Quat::from_euler(EulerRot::XYZ, rx, ry, rz);
+                    let [sx, sy, sz] = scale.unwrap_or([1.0, 1.0, 1.0]);
+                    commands.entity(spawned).insert(Transform {
+                        translation: pos_vec,
+                        rotation: quat,
+                        scale: Vec3::new(sx, sy, sz),
                     });
                 }
-            });
-            if let Some(ent) = target_entity {
-                commands.entity(ent).try_despawn();
+
+                // Attach to the authoring layer's spawned_entities so
+                // `UnloadWorld` despawns the entity (base-world origin: the
+                // entity just persists for the session).
+                if let (Some(path), Some(lm)) = (&layer_path, layer_map.as_deref_mut()) {
+                    if let Some(layer) = lm.0.get_mut(path) {
+                        layer.spawned_entities.push(spawned);
+                    }
+                }
+            }
+
+            ActionCmd::DestroyEntity { uuid } => {
+                let target_entity = uuid_to_entity.get(&uuid).copied();
+                // The matching `WorldEvent::Destroyed` is already in
+                // `events_out` so chained `on_destroyed` triggers fire.
+                //
+                // We deliberately do NOT use `MessageWriter<AiEntityDestroyed>`
+                // directly: `handle_ai_events` already holds the matching
+                // reader, which would trip Bevy's B0002 access check. Deferring
+                // the write via a command runs it after the system exits, so
+                // external consumers (telemetry, save/load, achievements)
+                // observe script-killed entities the same as combat-killed ones.
+                commands.queue(move |world: &mut World| {
+                    if let Some(mut msgs) =
+                        world.get_resource_mut::<Messages<crate::ai_plugin::AiEntityDestroyed>>()
+                    {
+                        msgs.write(crate::ai_plugin::AiEntityDestroyed { entity_uuid: uuid });
+                    }
+                });
+                if let Some(ent) = target_entity {
+                    commands.entity(ent).try_despawn();
+                }
+            }
+
+            ActionCmd::AddFactionEnemy {
+                faction_uuid,
+                enemy_uuid,
+            } => {
+                let Some(registry) = faction_dispatch.registry.as_deref_mut() else {
+                    bevy::log::warn!(
+                        "{log_ctx}: AddFactionEnemy skipped: FactionRegistryResource not present"
+                    );
+                    continue;
+                };
+                // Idempotent: returns false if `enemy_uuid` is already listed.
+                // Either way no target re-validation is needed, because adding a
+                // hostility cannot invalidate an existing engagement — the next
+                // `enemy_in_range` tick organically picks the new relationship
+                // up. `RemoveFactionEnemy` below is deliberately asymmetric.
+                registry.0.add_enemy(faction_uuid, enemy_uuid);
+            }
+
+            ActionCmd::RemoveFactionEnemy {
+                faction_uuid,
+                enemy_uuid,
+            } => {
+                let Some(registry) = faction_dispatch.registry.as_deref_mut() else {
+                    bevy::log::warn!(
+                        "{log_ctx}: RemoveFactionEnemy skipped: FactionRegistryResource not present"
+                    );
+                    continue;
+                };
+                let removed = registry.0.remove_enemy(faction_uuid, enemy_uuid);
+                if removed {
+                    // Snapshot every AI controller's own faction BEFORE taking
+                    // the &mut on the query for re-validation. `iter()` on a
+                    // `&mut Query` yields immutable refs, so there is no borrow
+                    // conflict with the subsequent `iter_mut()`.
+                    let ai_factions: Vec<(uuid::Uuid, uuid::Uuid)> = ai_query
+                        .iter()
+                        .filter_map(|(uid, _, fc)| {
+                            let self_uuid = uuid::Uuid::parse_str(&uid.0).ok()?;
+                            fc.map(|fc| (self_uuid, fc.0))
+                        })
+                        .collect();
+                    let uuid_to_faction =
+                        build_uuid_to_faction(&faction_dispatch.non_ai_factions, &ai_factions);
+                    revalidate_ai_targets_after_faction_change(
+                        ai_query,
+                        &registry.0,
+                        &uuid_to_faction,
+                    );
+                }
             }
         }
-        TriggerAction::AddFactionEnemy { faction, enemy } => {
-            let Some(registry) = faction_dispatch.registry.as_deref_mut() else {
-                bevy::log::warn!(
-                    "dispatch_single_action: AddFactionEnemy skipped: FactionRegistryResource not present"
-                );
-                return;
-            };
-            let faction_uuid = match registry.0.uuid_by_name(faction) {
-                Some(u) => u,
-                None => {
-                    bevy::log::warn!(
-                        "dispatch_single_action: AddFactionEnemy: unknown faction name '{faction}'"
-                    );
-                    return;
-                }
-            };
-            let enemy_uuid = match registry.0.uuid_by_name(enemy) {
-                Some(u) => u,
-                None => {
-                    bevy::log::warn!(
-                        "dispatch_single_action: AddFactionEnemy: unknown enemy faction name '{enemy}'"
-                    );
-                    return;
-                }
-            };
-            registry.0.add_enemy(faction_uuid, enemy_uuid);
+    }
+
+    if !spawn_failed {
+        for (name, uuid) in name_to_uuid_inserts {
+            runtime.name_to_uuid.insert(name, uuid);
         }
-        TriggerAction::RemoveFactionEnemy { faction, enemy } => {
-            let Some(registry) = faction_dispatch.registry.as_deref_mut() else {
-                bevy::log::warn!(
-                    "dispatch_single_action: RemoveFactionEnemy skipped: FactionRegistryResource not present"
-                );
-                return;
-            };
-            let faction_uuid = match registry.0.uuid_by_name(faction) {
-                Some(u) => u,
-                None => {
-                    bevy::log::warn!(
-                        "dispatch_single_action: RemoveFactionEnemy: unknown faction name '{faction}'"
-                    );
-                    return;
-                }
-            };
-            let enemy_uuid = match registry.0.uuid_by_name(enemy) {
-                Some(u) => u,
-                None => {
-                    bevy::log::warn!(
-                        "dispatch_single_action: RemoveFactionEnemy: unknown enemy faction name '{enemy}'"
-                    );
-                    return;
-                }
-            };
-            registry.0.remove_enemy(faction_uuid, enemy_uuid);
+        for (group, name) in entity_group_inserts {
+            runtime.entity_groups.entry(group).or_default().insert(name);
         }
     }
 }
 
 /// Drain actions from `pending_delayed_actions` whose `fire_at_elapsed` has
-/// elapsed and dispatch them via `dispatch_single_action`.
+/// elapsed and dispatch them through the same `world::dispatch` table
+/// `handle_ai_events` uses.
 ///
 /// Registered after `handle_ai_events` in `SimSet::Physics` so that it sees
 /// the same tick's `world_loaded_at_secs` anchor.
+#[allow(clippy::too_many_arguments)]
 fn tick_delayed_actions(
     mut runtime: ResMut<WorldContentRuntime>,
     time: Option<Res<bevy::time::Time>>,
@@ -2637,6 +2088,20 @@ fn tick_delayed_actions(
     base_world_config: Option<Res<crate::world::config::WorldConfig>>,
     entity_uuid_query: Query<(Entity, &EntityUuid)>,
     mut faction_dispatch: FactionDispatchParams,
+    // Issue #710: `RemoveFactionEnemy` re-validates AI targets after a
+    // successful removal. The immediate path always did; the delayed path did
+    // not, because the old duplicated dispatch table it called had no
+    // `ai_query` — a latent bug that let a delayed `remove_faction_enemy` leave
+    // an in-progress engagement stuck on a now-friendly target. Both paths now
+    // share one table, so both re-validate.
+    mut ai_query: Query<
+        (
+            &EntityUuid,
+            Option<&mut crate::ai_plugin::ShipAiMemory>,
+            Option<&crate::entities::spawner::FactionComponent>,
+        ),
+        With<AiControllerComponent>,
+    >,
 ) {
     let Some(elapsed) = time.as_ref().and_then(|t| {
         runtime
@@ -2655,7 +2120,7 @@ fn tick_delayed_actions(
         .map(|(ent, uuid_comp)| (uuid_comp.0.clone(), ent))
         .collect();
 
-    let name_to_uuid = runtime.name_to_uuid.clone();
+    let empty_anchors: HashMap<String, [f32; 3]> = HashMap::new();
 
     let mut ready: Vec<DelayedAction> = Vec::new();
     let mut still_pending: Vec<DelayedAction> = Vec::new();
@@ -2669,24 +2134,48 @@ fn tick_delayed_actions(
     runtime.pending_delayed_actions = still_pending;
 
     for pda in ready {
-        dispatch_single_action(
-            &pda.action,
-            &pda.origin_layer,
-            &pda.entity_name,
-            &name_to_uuid,
+        // Same live-store rule as `handle_ai_events`: re-project per action so
+        // each dispatch sees the previous one's writes.
+        let name_to_uuid = runtime.name_to_uuid.clone();
+        let layers = project_layer_views(layer_map.as_deref());
+        let result = {
+            let ctx = DispatchContext {
+                origin_layer: pda.origin_layer.clone(),
+                entity_name: pda.entity_name.clone(),
+                name_to_uuid: &name_to_uuid,
+                base_flags: &runtime.flags,
+                layers: &layers,
+                base_anchors: base_world_config
+                    .as_ref()
+                    .map(|wc| &wc.anchors)
+                    .unwrap_or(&empty_anchors),
+                factions: faction_dispatch.registry.as_deref().map(|r| &r.0),
+                uuid_source: &crate::entity_loader::assign_uuid,
+            };
+            dispatch_action(&pda.action, &ctx)
+        };
+
+        // Unlike `handle_ai_events`, a delayed action's `new_events` are queued
+        // for the NEXT tick: this system runs after `handle_ai_events` has
+        // already drained `pending_world_events` for this one.
+        let mut out_events: Vec<WorldEvent> = Vec::new();
+        apply_dispatch_result(
+            result,
+            "tick_delayed_actions",
+            &mut out_events,
             &uuid_to_entity,
             &mut runtime,
             &mut objectives,
-            pending_layers.as_deref_mut(),
-            layer_map.as_deref_mut(),
-            base_world_config.as_deref(),
-            &entity_uuid_query,
             &mut commands,
             &mut ship_modifiers,
+            pending_layers.as_deref_mut(),
+            layer_map.as_deref_mut(),
             next_state.as_deref_mut(),
             game_over_reason.as_deref_mut(),
             &mut faction_dispatch,
+            &mut ai_query,
         );
+        runtime.pending_world_events.extend(out_events);
     }
 }
 
@@ -3615,6 +3104,134 @@ pub(crate) mod tests {
         app.world_mut()
             .insert_resource(State::new(GamePhase::InProgress));
         app
+    }
+
+    /// Issue #710: the `DispatchContext` flag stores must be the LIVE ones, not
+    /// `handle_ai_events`' per-pass `base_flags_snapshot` (which exists for
+    /// condition evaluation only). `dispatch_action` computes before/after
+    /// against them to decide whether a transition event fires at all, so a
+    /// snapshot silently drops transitions.
+    ///
+    /// Set-then-clear in a single pass is the discriminating case: against the
+    /// live store the clear reads before = 1 and emits `FlagCleared`; against a
+    /// snapshot it reads before = 0, sees no change, and emits nothing. The
+    /// sibling case — two triggers both `set_flag` the same flag
+    /// (`assets/worlds/before_the_fire.toml:276`) — is not observable here,
+    /// because a duplicated `FlagSet` is masked by single-shot trigger firing.
+    #[test]
+    fn flag_stores_handed_to_dispatch_are_live_within_a_pass() {
+        let mut app = ai_trigger_test_app();
+        let npc_uuid = "src-uuid-001";
+        {
+            let mut runtime = app.world_mut().resource_mut::<WorldContentRuntime>();
+            runtime
+                .name_to_uuid
+                .insert("source".into(), npc_uuid.into());
+            let mk = |condition, actions| TriggerState {
+                trigger: crate::world::content::Trigger {
+                    condition,
+                    actions,
+                    when: None,
+                    action_predicates: vec![],
+                    action_delays: vec![],
+                },
+                fired: false,
+                origin_layer: None,
+                seen_destroyed: HashSet::new(),
+            };
+            runtime.trigger_states = vec![
+                mk(
+                    TriggerCondition::OnDestroyed {
+                        entity_name: "source".into(),
+                    },
+                    vec![TriggerAction::SetWorldFlag { name: "a".into() }],
+                ),
+                mk(
+                    TriggerCondition::OnDestroyed {
+                        entity_name: "source".into(),
+                    },
+                    vec![TriggerAction::ClearWorldFlag { name: "a".into() }],
+                ),
+                mk(
+                    TriggerCondition::OnFlagCleared { name: "a".into() },
+                    vec![TriggerAction::AddObjective {
+                        id: "obj-cleared".into(),
+                        text: "Reacted to flag cleared".into(),
+                        mandatory: false,
+                        targets: vec![],
+                        directive: crate::messages::AiDirective::None,
+                        utility: crate::objectives::UtilityConfig::default(),
+                        source: crate::messages::ObjectiveSource::default(),
+                    }],
+                ),
+            ];
+        }
+        app.world_mut()
+            .resource_mut::<Messages<AiEntityDestroyed>>()
+            .write(AiEntityDestroyed {
+                entity_uuid: npc_uuid.into(),
+            });
+        app.update();
+
+        // Both setter and clearer fire in the same pass. Against the LIVE store
+        // the clear sees before = 1 and emits FlagCleared, so the downstream
+        // on_flag_cleared trigger fires. Against a per-pass snapshot the clear
+        // would see before = 0, emit nothing, and this objective would never
+        // appear.
+        let objectives = app.world().resource::<ObjectiveManagerRes>();
+        assert!(
+            objectives
+                .0
+                .sorted_snapshots()
+                .iter()
+                .any(|o| o.id == "obj-cleared"),
+            "clear_flag must emit FlagCleared against the live store"
+        );
+    }
+
+    /// Issue #710: `tick_delayed_actions` now shares the `world::dispatch`
+    /// table with `handle_ai_events`. The routing of `new_events` is the one
+    /// thing that must stay different: a delayed action's events queue onto
+    /// `pending_world_events` for the NEXT tick, because this system runs after
+    /// `handle_ai_events` has already drained that queue for this one.
+    #[test]
+    fn delayed_action_dispatches_and_queues_event_for_next_tick() {
+        let mut app = ai_trigger_test_app();
+        app.add_systems(Update, tick_delayed_actions.after(handle_ai_events));
+
+        {
+            let mut runtime = app.world_mut().resource_mut::<WorldContentRuntime>();
+            runtime.world_loaded_at_secs = Some(0.0);
+            runtime.pending_delayed_actions.push(DelayedAction {
+                action: TriggerAction::SetWorldFlag {
+                    name: "aphelion_armed".to_string(),
+                },
+                origin_layer: None,
+                entity_name: None,
+                fire_at_elapsed: 0.0,
+            });
+        }
+
+        app.update();
+
+        let runtime = app.world().resource::<WorldContentRuntime>();
+        assert_eq!(
+            runtime.flags.counter("aphelion_armed"),
+            1,
+            "delayed set_flag must mutate the live base flag store"
+        );
+        assert!(
+            runtime.pending_delayed_actions.is_empty(),
+            "the fired delayed action must be drained"
+        );
+        assert_eq!(
+            runtime.pending_world_events,
+            vec![WorldEvent::FlagSet {
+                name: "aphelion_armed".to_string(),
+                origin_layer: None,
+            }],
+            "a delayed action's new_events must queue for the NEXT tick"
+        );
     }
 
     /// A scenario trigger fires when the named ship reaches the named

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -75,17 +75,17 @@ pub struct WorldContentRuntime {
     /// World flag / counter store consumed by predicate-gated triggers
     /// (`when = "..."`) and mutated by `set_flag` / `clear_flag` /
     /// `increment_flag` / `set_flag_value` trigger actions. Mutations are
-    /// observed inside `handle_ai_events`, which emits `FlagSet` /
+    /// observed inside `tick_trigger_pipeline`, which emits `FlagSet` /
     /// `FlagCleared` `WorldEvent`s on transitions and re-evaluates the
     /// trigger table in the same tick so chained `on_flag_set` /
     /// `on_flag_cleared` triggers fire as part of the same Bevy frame.
     pub flags: crate::world::flags::FlagStore,
-    /// Queue of synthesised `WorldEvent`s to be drained by `handle_ai_events`
+    /// Queue of synthesised `WorldEvent`s to be drained by `tick_trigger_pipeline`
     /// on the next Update tick. Used by `init_world_runtime` (base-world
     /// Startup) and `apply_world_layer_changes` (sub-world Load) to inject
     /// `WorldEvent::WorldLoaded` into the trigger evaluation pipeline
     /// without duplicating the dispatch logic that lives inside
-    /// `handle_ai_events`.
+    /// `tick_trigger_pipeline`.
     pub pending_world_events: Vec<WorldEvent>,
     /// Comms follow-ups awaiting their trigger condition before injection.
     /// Response follow-ups carry a `placeholder_id` so the inbox shows a
@@ -95,7 +95,7 @@ pub struct WorldContentRuntime {
     /// (set by `init_world_runtime`). `on_timer` triggers fire when
     /// `time.elapsed_secs() - world_loaded_at_secs >= after_secs`.
     /// `None` while no world is loaded (lobby, fallback bootstrap), in
-    /// which case `handle_ai_events` skips emitting `TimerElapsed` events.
+    /// which case `tick_trigger_pipeline` skips emitting `TimerElapsed` events.
     /// (#475)
     pub world_loaded_at_secs: Option<f32>,
     /// Maps named groups to the set of entity names currently in that group.
@@ -161,7 +161,7 @@ pub struct WorldLayerMap(pub HashMap<String, WorldRuntime>);
 
 /// Queue of `LoadWorld` / `UnloadWorld` actions to execute on the next frame.
 ///
-/// `handle_ai_events` pushes path-keyed commands here; `apply_world_layer_changes`
+/// `tick_trigger_pipeline` pushes path-keyed commands here; `apply_world_layer_changes`
 /// drains it and mutates `WorldLayerMap` + `WorldContentRuntime` accordingly.
 #[derive(Resource, Default)]
 pub struct PendingWorldLayerChanges(pub Vec<WorldLayerChange>);
@@ -242,12 +242,12 @@ impl Plugin for WorldPlugin {
             )
             .add_systems(
                 Update,
-                handle_ai_events.in_set(crate::sim_sets::SimSet::Physics),
+                tick_trigger_pipeline.in_set(crate::sim_sets::SimSet::Physics),
             )
             // Cursor advancement is a `Modifiers` evaluator: `Physics` has
             // finished moving every ship by then, so waypoint arrival is
             // judged against this tick's final positions. It emits
-            // `AiWaypointReached`, which `handle_ai_events` turns into a
+            // `AiWaypointReached`, which `tick_trigger_pipeline` turns into a
             // `WorldEvent::WaypointReached` on the next tick (the same
             // one-tick event bridge `AiEntityAttacked` already uses).
             .add_systems(
@@ -259,13 +259,13 @@ impl Plugin for WorldPlugin {
                 Update,
                 tick_delayed_actions
                     .in_set(crate::sim_sets::SimSet::Physics)
-                    .after(handle_ai_events),
+                    .after(tick_trigger_pipeline),
             )
             .add_systems(
                 Update,
                 tick_pending_follow_ups
                     .in_set(crate::sim_sets::SimSet::Physics)
-                    .before(handle_ai_events),
+                    .before(tick_trigger_pipeline),
             )
             .add_systems(
                 Update,
@@ -281,7 +281,7 @@ impl Plugin for WorldPlugin {
 }
 
 /// Observer: bridge `RegionEntered` (player ship boundary crossing into a
-/// region) into a queued `WorldEvent::EnteredRegion` so `handle_ai_events`
+/// region) into a queued `WorldEvent::EnteredRegion` so `tick_trigger_pipeline`
 /// can fan it out to matching triggers on the next tick.
 ///
 /// Looks up the region entity's UUID via `RegionMembership.region_uuids`
@@ -630,7 +630,7 @@ fn init_world_runtime(
     };
 
     // (#475) Stamp the load-time anchor for `on_timer` triggers. All
-    // `after_secs` values are measured relative to this; `handle_ai_events`
+    // `after_secs` values are measured relative to this; `tick_trigger_pipeline`
     // emits `WorldEvent::TimerElapsed { elapsed_secs }` each tick using
     // `time.elapsed_secs() - world_loaded_at_secs`. `Time` is wrapped in
     // `Option` so older test apps that don't install `TimePlugin` continue
@@ -683,7 +683,7 @@ fn init_world_runtime(
     // Issue #415: emit a WorldLoaded event so `on_world_loaded` triggers
     // declared in the base world fire on the first Update tick. Pushed onto
     // the pending queue (rather than evaluated here) so the dispatch logic
-    // inside `handle_ai_events` is the single owner of trigger action
+    // inside `tick_trigger_pipeline` is the single owner of trigger action
     // execution.
     runtime.pending_world_events.push(WorldEvent::WorldLoaded);
 
@@ -737,8 +737,8 @@ fn mark_comms_dirty_on_game_start(
 /// trigger conditions against current world state plus this tick's pending
 /// events, and inject any follow-ups whose conditions are now met.
 ///
-/// Ordering: scheduled `.before(handle_ai_events)` so this system observes
-/// `pending_world_events` BEFORE `handle_ai_events` drains them. This lets
+/// Ordering: scheduled `.before(tick_trigger_pipeline)` so this system observes
+/// `pending_world_events` BEFORE `tick_trigger_pipeline` drains them. This lets
 /// follow-ups react to events on the same tick they fire.
 ///
 /// "Fire immediately if already true" semantics applies to state-based
@@ -1212,7 +1212,7 @@ fn broadcast_objective_summary(
 
 // -- AI-event trigger system -------------------------------------------------
 
-/// Upper bound on `handle_ai_events`' within-tick trigger-chaining passes.
+/// Upper bound on `tick_trigger_pipeline`'s within-tick trigger-chaining passes.
 ///
 /// A `set_flag` action emits a `FlagSet` event that a downstream `on_flag_set`
 /// trigger can react to in the same Bevy frame, which can in turn set another
@@ -1223,7 +1223,7 @@ const MAX_CHAIN_PASSES: i32 = 16;
 /// into `WorldEvent`s, evaluate the scenario trigger table, and execute the
 /// resulting actions (including `SetAiState`, `ApplyModifier`, `RemoveModifier`,
 /// `ApplyFlag`, and `RemoveFlag`).
-fn handle_ai_events(
+fn tick_trigger_pipeline(
     mut runtime: ResMut<WorldContentRuntime>,
     mut objectives: ResMut<ObjectiveManagerRes>,
     mut channel2_writer: MessageWriter<CommsChannel2Event>,
@@ -1240,9 +1240,7 @@ fn handle_ai_events(
     mut ship_modifiers: ShipModifiersParams,
     mut next_state: Option<ResMut<NextState<GamePhase>>>,
     mut game_over_reason: Option<ResMut<crate::simulation::GameOverReason>>,
-    mut pending_layers: Option<ResMut<PendingWorldLayerChanges>>,
-    mut layer_map: Option<ResMut<WorldLayerMap>>,
-    base_world_config: Option<Res<crate::world::config::WorldConfig>>,
+    mut world_layers: WorldLayerParams,
     entity_uuid_query: Query<(Entity, &EntityUuid)>,
     mut faction_dispatch: FactionDispatchParams,
     time: Option<Res<bevy::time::Time>>,
@@ -1302,6 +1300,15 @@ fn handle_ai_events(
         return;
     }
 
+    // Reborrow the `ResMut` as a plain `&mut` so the evaluation loop below can
+    // split disjoint field borrows (`&runtime.flags` for condition chains while
+    // `&mut runtime.trigger_states[idx]` is handed to the evaluator) — a smart
+    // pointer cannot split, a plain reference can. Placed after the early
+    // return so change detection still only marks the resource on ticks that
+    // actually process events (the pre-existing behaviour: every path past
+    // this point mutated through the `ResMut` anyway).
+    let runtime = &mut *runtime;
+
     let name_to_uuid = runtime.name_to_uuid.clone();
 
     // Build UUID â†’ ECS Entity map once per tick so the six per-entity
@@ -1355,7 +1362,7 @@ fn handle_ai_events(
             selected_response: None,
             is_read: false,
             is_orphaned: false,
-            sender_in_range: current_sender_in_range(&runtime, &sender_uuid),
+            sender_in_range: current_sender_in_range(runtime, &sender_uuid),
             thread_id: thread_id.clone(),
             is_urgent: fc.urgent,
         };
@@ -1392,12 +1399,14 @@ fn handle_ai_events(
     // PRD #397 fix 1: each trigger is evaluated with its OWN flag chain
     // and layer chain, computed from its `origin_layer` by walking
     // `loader_path` pointers up via `WorldLayerMap` until reaching the
-    // base world (whose store is `runtime.flags`). The chains are
-    // snapshotted once per pass so trigger ordering within a pass is
-    // deterministic (later triggers in the same pass see the same
-    // flag values as earlier ones; their mutations land in `next_events`
-    // and are observed on the next pass).
-    let mut current_events = world_events.clone();
+    // base world (whose store is `runtime.flags`). Trigger ordering within
+    // a pass is deterministic because each pass is two-phase: ALL
+    // conditions are evaluated (reading the live stores, which nothing
+    // mutates during evaluation) before ANY fired action is dispatched, so
+    // later triggers in the same pass see the same flag values as earlier
+    // ones; their mutations land in `next_events` and are observed on the
+    // next pass.
+    let mut current_events = world_events;
     let mut pass = 0;
     loop {
         pass += 1;
@@ -1412,30 +1421,16 @@ fn handle_ai_events(
                 }
             })
             .fold(0.0_f32, |max_e, e| e.max(max_e));
-        // Snapshot per-layer flag stores and loader pointers once per pass.
-        let base_flags_snapshot = runtime.flags.clone();
-        let layer_flags_snapshot: HashMap<String, crate::world::flags::FlagStore> = layer_map
-            .as_ref()
-            .map(|lm| {
-                lm.0.iter()
-                    .map(|(p, wr)| (p.clone(), wr.flags.clone()))
-                    .collect()
-            })
-            .unwrap_or_default();
-        let layer_loaders_snapshot: HashMap<String, Option<String>> = layer_map
-            .as_ref()
-            .map(|lm| {
-                lm.0.iter()
-                    .map(|(p, wr)| (p.clone(), wr.loader_path.clone()))
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        // Per-trigger evaluation: build chain from origin_layer up.
+        // Per-trigger evaluation: build chain from origin_layer up. The
+        // chains borrow the LIVE stores (`runtime.flags` and `layer_map`'s
+        // per-layer stores) rather than per-pass clones: evaluation is safe
+        // against them because the pass is two-phase — every condition is
+        // evaluated before any fired action is dispatched, so no store
+        // mutates while these borrows are alive.
         let mut fired: Vec<crate::world::content::FiredTrigger> = Vec::new();
-        // We have to clone the origin_layer slice up front to avoid
-        // holding a borrow on `runtime.trigger_states` across the chain
-        // build (chain references the snapshot, not the live store).
+        // We have to clone the origin_layer slice up front: the evaluator
+        // below takes `&mut runtime.trigger_states[idx]`, so nothing may
+        // hold a borrow on `runtime.trigger_states` across the loop.
         let trigger_origins: Vec<Option<String>> = runtime
             .trigger_states
             .iter()
@@ -1456,25 +1451,26 @@ fn handle_ai_events(
         let dispatch_names = runtime.name_to_uuid.clone();
         for (idx, origin) in trigger_origins.iter().enumerate() {
             // Build the flag-store and layer-path chains for this trigger.
-            let mut flag_chain_owned: Vec<&crate::world::flags::FlagStore> = Vec::new();
+            let mut flag_chain: Vec<&crate::world::flags::FlagStore> = Vec::new();
             let mut layer_chain: Vec<Option<String>> = Vec::new();
             let mut cur = origin.clone();
             loop {
                 layer_chain.push(cur.clone());
                 match &cur {
                     Some(p) => {
-                        if let Some(fs) = layer_flags_snapshot.get(p) {
-                            flag_chain_owned.push(fs);
+                        if let Some(wr) = world_layers.layer_map.as_ref().and_then(|lm| lm.0.get(p))
+                        {
+                            flag_chain.push(&wr.flags);
+                            cur = wr.loader_path.clone();
                         } else {
-                            // Layer missing from snapshot Ã¢â‚¬â€ treat as empty.
+                            // Layer missing from the map Ã¢â‚¬â€ treat as empty.
                             // (Shouldn't happen in normal flow.)
-                            flag_chain_owned.push(&base_flags_snapshot);
+                            flag_chain.push(&runtime.flags);
                             break;
                         }
-                        cur = layer_loaders_snapshot.get(p).cloned().flatten();
                     }
                     None => {
-                        flag_chain_owned.push(&base_flags_snapshot);
+                        flag_chain.push(&runtime.flags);
                         break;
                     }
                 }
@@ -1485,7 +1481,7 @@ fn handle_ai_events(
                 &mut runtime.trigger_states[idx],
                 &current_events,
                 &name_to_uuid,
-                &flag_chain_owned,
+                &flag_chain,
                 &layer_chain,
                 &entity_groups,
                 current_elapsed,
@@ -1519,15 +1515,13 @@ fn handle_ai_events(
                 //
                 // The flag stores handed to the context MUST be the LIVE ones
                 // — `runtime.flags` plus `layer_map`'s per-layer stores,
-                // re-projected for every action — never the per-pass
-                // `base_flags_snapshot` / `layer_flags_snapshot` above. Those
-                // exist for condition evaluation only (deciding which triggers
-                // fire). `dispatch_action` computes each flag mutation's
+                // re-projected for every action, never a stale copy.
+                // `dispatch_action` computes each flag mutation's
                 // before/after against these stores to decide whether a
                 // transition event fires at all, so two triggers that both
                 // `set_flag` the same flag must see 0 -> 1 and then 1 -> 1
                 // (one `FlagSet` total), not 0 -> 1 twice.
-                let layers = project_layer_views(layer_map.as_deref());
+                let layers = project_layer_views(world_layers.layer_map.as_deref());
                 let result = {
                     let ctx = DispatchContext {
                         origin_layer: ft.origin_layer.clone(),
@@ -1535,7 +1529,8 @@ fn handle_ai_events(
                         name_to_uuid: &dispatch_names,
                         base_flags: &runtime.flags,
                         layers: &layers,
-                        base_anchors: base_world_config
+                        base_anchors: world_layers
+                            .base_world_config
                             .as_ref()
                             .map(|wc| &wc.anchors)
                             .unwrap_or(&empty_anchors),
@@ -1553,15 +1548,15 @@ fn handle_ai_events(
                 // them onto `runtime.pending_world_events` for the next tick).
                 apply_dispatch_result(
                     result,
-                    "handle_ai_events",
+                    "tick_trigger_pipeline",
                     &mut next_events,
                     &uuid_to_entity,
-                    &mut runtime,
+                    runtime,
                     &mut objectives,
                     &mut commands,
                     &mut ship_modifiers,
-                    pending_layers.as_deref_mut(),
-                    layer_map.as_deref_mut(),
+                    world_layers.pending_layers.as_deref_mut(),
+                    world_layers.layer_map.as_deref_mut(),
                     next_state.as_deref_mut(),
                     game_over_reason.as_deref_mut(),
                     &mut faction_dispatch,
@@ -1575,7 +1570,7 @@ fn handle_ai_events(
         }
         if pass >= MAX_CHAIN_PASSES {
             bevy::log::warn!(
-                "handle_ai_events: trigger chain exceeded {MAX_CHAIN_PASSES} passes; \
+                "tick_trigger_pipeline: trigger chain exceeded {MAX_CHAIN_PASSES} passes; \
                  stopping to prevent infinite loop"
             );
             break;
@@ -1652,11 +1647,11 @@ fn world_modifier_source(tag: String) -> crate::messages::ModifierSource {
 ///
 /// The impure half of the dispatch table (issue #710): `world::dispatch` decides
 /// *what* should happen from read-only data, and this turns that into ECS
-/// mutations. It is the shared apply path for both `handle_ai_events` (immediate
+/// mutations. It is the shared apply path for both `tick_trigger_pipeline` (immediate
 /// actions) and `tick_delayed_actions` (delayed ones).
 ///
 /// The one thing callers must decide for themselves is where `new_events` go, so
-/// they are written to the caller's `events_out`: `handle_ai_events` points that
+/// they are written to the caller's `events_out`: `tick_trigger_pipeline` points that
 /// at the current pass's `next_events` (same tick, next chaining pass), whereas
 /// `tick_delayed_actions` drains it into `runtime.pending_world_events` (next
 /// tick). Same events, different destination.
@@ -1925,7 +1920,7 @@ fn apply_dispatch_result(
                 // `events_out` so chained `on_destroyed` triggers fire.
                 //
                 // We deliberately do NOT use `MessageWriter<AiEntityDestroyed>`
-                // directly: `handle_ai_events` already holds the matching
+                // directly: `tick_trigger_pipeline` already holds the matching
                 // reader, which would trip Bevy's B0002 access check. Deferring
                 // the write via a command runs it after the system exits, so
                 // external consumers (telemetry, save/load, achievements)
@@ -2009,9 +2004,9 @@ fn apply_dispatch_result(
 
 /// Drain actions from `pending_delayed_actions` whose `fire_at_elapsed` has
 /// elapsed and dispatch them through the same `world::dispatch` table
-/// `handle_ai_events` uses.
+/// `tick_trigger_pipeline` uses.
 ///
-/// Registered after `handle_ai_events` in `SimSet::Physics` so that it sees
+/// Registered after `tick_trigger_pipeline` in `SimSet::Physics` so that it sees
 /// the same tick's `world_loaded_at_secs` anchor.
 #[allow(clippy::too_many_arguments)]
 fn tick_delayed_actions(
@@ -2060,7 +2055,7 @@ fn tick_delayed_actions(
         .collect();
 
     let empty_anchors: HashMap<String, [f32; 3]> = HashMap::new();
-    // Same template source as `handle_ai_events` (issue #715): one
+    // Same template source as `tick_trigger_pipeline` (issue #715): one
     // `WasmTemplateLoader` per system run, both targets.
     let template_loader = crate::entity_loader::WasmTemplateLoader;
 
@@ -2076,7 +2071,7 @@ fn tick_delayed_actions(
     runtime.pending_delayed_actions = still_pending;
 
     for pda in ready {
-        // Same live-store rule as `handle_ai_events`: re-project per action so
+        // Same live-store rule as `tick_trigger_pipeline`: re-project per action so
         // each dispatch sees the previous one's writes.
         let name_to_uuid = runtime.name_to_uuid.clone();
         let layers = project_layer_views(layer_map.as_deref());
@@ -2098,8 +2093,8 @@ fn tick_delayed_actions(
             dispatch_action(&pda.action, &ctx)
         };
 
-        // Unlike `handle_ai_events`, a delayed action's `new_events` are queued
-        // for the NEXT tick: this system runs after `handle_ai_events` has
+        // Unlike `tick_trigger_pipeline`, a delayed action's `new_events` are queued
+        // for the NEXT tick: this system runs after `tick_trigger_pipeline` has
         // already drained `pending_world_events` for this one.
         let mut out_events: Vec<WorldEvent> = Vec::new();
         apply_dispatch_result(
@@ -2152,14 +2147,14 @@ pub(crate) fn build_uuid_to_faction(
 
 /// Bundle of system params used by the two trigger-dispatch sites for
 /// the `add_faction_enemy` / `remove_faction_enemy` actions. Grouping
-/// these keeps both `handle_ai_events` and `handle_respond_to_message`
+/// these keeps both `tick_trigger_pipeline` and `handle_respond_to_message`
 /// under Bevy's per-system parameter cap (16).
 ///
 /// `registry` is `Option<ResMut<_>>` so test apps that don't insert
 /// `FactionRegistryResource` (most of `world::server::tests`) still load
 /// the systems without a "resource does not exist" panic. Production
 /// Bundles the optional world-layer mutation resources used by
-/// `handle_respond_to_message` and `handle_ai_events` into a single
+/// `handle_respond_to_message` and `tick_trigger_pipeline` into a single
 /// `SystemParam` so both functions stay within Bevy's 16-parameter limit.
 #[derive(bevy::ecs::system::SystemParam)]
 pub struct WorldLayerParams<'w> {
@@ -2169,7 +2164,7 @@ pub struct WorldLayerParams<'w> {
 }
 
 /// Bundle of per-entity `ShipModifiers` writers used by
-/// `handle_respond_to_message` and `handle_ai_events` to route
+/// `handle_respond_to_message` and `tick_trigger_pipeline` to route
 /// `TriggerAction::{Apply,Remove}{Modifier,Flag,IntModifier}` actions to
 /// the named target entity's Component (not the legacy global Resource).
 ///
@@ -2184,11 +2179,11 @@ pub struct ShipModifiersParams<'w, 's> {
     pub components: Query<'w, 's, &'static mut crate::modifiers::ShipModifiers>,
 }
 
-/// The AI-plugin messages `handle_ai_events` bridges into `WorldEvent`s.
+/// The AI-plugin messages `tick_trigger_pipeline` bridges into `WorldEvent`s.
 ///
 /// Grouped into a `SystemParam` for the same reason as `ShipModifiersParams`:
-/// `handle_ai_events` is at Bevy's 16-parameter limit, and each new AI event
-/// source would otherwise push it over.
+/// it keeps `tick_trigger_pipeline` clear of Bevy's 16-parameter limit, and
+/// each new AI event source would otherwise eat one slot of that budget.
 #[derive(bevy::ecs::system::SystemParam)]
 pub struct AiEventReaders<'w, 's> {
     pub attacked: MessageReader<'w, 's, crate::ai_plugin::AiEntityAttacked>,
@@ -2620,7 +2615,7 @@ fn apply_world_layer_changes(
                                 // `on_world_loaded` triggers declared inside
                                 // this sub-world (and merged into the live
                                 // runtime above) fire on the next Update
-                                // tick via `handle_ai_events`.
+                                // tick via `tick_trigger_pipeline`.
                                 runtime.pending_world_events.push(WorldEvent::WorldLoaded);
 
                                 layer_map.0.insert(
@@ -2952,7 +2947,7 @@ pub(crate) mod tests {
         assert!(messages[0].is_urgent);
     }
 
-    /// `handle_ai_events` (auto-fire path: `on_world_loaded`,
+    /// `tick_trigger_pipeline` (auto-fire path: `on_world_loaded`,
     /// `on_attacked`, `on_destroyed`, `on_flag_set`) also schedules the
     /// chained `root_follow_up`. Verified by emitting `WorldLoaded` on a
     /// template with a chained node.
@@ -3020,7 +3015,7 @@ pub(crate) mod tests {
 
     // -- AI-event trigger tests -----------------------------------------------
 
-    /// Build a minimal test app that includes just what handle_ai_events needs.
+    /// Build a minimal test app that includes just what tick_trigger_pipeline needs.
     fn ai_trigger_test_app() -> App {
         let mut app = App::new();
         app.add_plugins(LobbyPlugin)
@@ -3038,7 +3033,7 @@ pub(crate) mod tests {
                 Update,
                 (
                     tick_pending_follow_ups,
-                    handle_ai_events,
+                    tick_trigger_pipeline,
                     handle_comms_channel2,
                 )
                     .chain(),
@@ -3049,9 +3044,10 @@ pub(crate) mod tests {
         app
     }
 
-    /// Issue #710: the `DispatchContext` flag stores must be the LIVE ones, not
-    /// `handle_ai_events`' per-pass `base_flags_snapshot` (which exists for
-    /// condition evaluation only). `dispatch_action` computes before/after
+    /// Issue #710: the `DispatchContext` flag stores must be the LIVE ones,
+    /// never a per-pass copy taken before dispatch began (condition
+    /// evaluation reads the stores before any dispatch, which is safe;
+    /// dispatch itself must not). `dispatch_action` computes before/after
     /// against them to decide whether a transition event fires at all, so a
     /// snapshot silently drops transitions.
     ///
@@ -3133,14 +3129,14 @@ pub(crate) mod tests {
     }
 
     /// Issue #710: `tick_delayed_actions` now shares the `world::dispatch`
-    /// table with `handle_ai_events`. The routing of `new_events` is the one
+    /// table with `tick_trigger_pipeline`. The routing of `new_events` is the one
     /// thing that must stay different: a delayed action's events queue onto
     /// `pending_world_events` for the NEXT tick, because this system runs after
-    /// `handle_ai_events` has already drained that queue for this one.
+    /// `tick_trigger_pipeline` has already drained that queue for this one.
     #[test]
     fn delayed_action_dispatches_and_queues_event_for_next_tick() {
         let mut app = ai_trigger_test_app();
-        app.add_systems(Update, tick_delayed_actions.after(handle_ai_events));
+        app.add_systems(Update, tick_delayed_actions.after(tick_trigger_pipeline));
 
         {
             let mut runtime = app.world_mut().resource_mut::<WorldContentRuntime>();
@@ -3452,7 +3448,7 @@ pub(crate) mod tests {
 
     // -- AI-event ApplyModifier / per-entity target regression tests -------
     //
-    // The following six tests exercise `handle_ai_events` dispatch of the
+    // The following six tests exercise `tick_trigger_pipeline` dispatch of the
     // per-entity trigger actions (`ApplyModifier`, `RemoveModifier`,
     // `ApplyFlag`, `RemoveFlag`, `ApplyIntModifier`, `RemoveIntModifier`)
     // and prove that the action lands on the target entity's per-entity
@@ -3492,7 +3488,7 @@ pub(crate) mod tests {
 
     /// Installs a single `OnDestroyed { raider_alpha }` trigger whose
     /// action list is `actions`, emits `AiEntityDestroyed { npc-target-uuid }`,
-    /// and ticks once so `handle_ai_events` dispatches the actions.
+    /// and ticks once so `tick_trigger_pipeline` dispatches the actions.
     fn fire_ai_event_trigger(app: &mut App, actions: Vec<TriggerAction>) {
         let mut runtime = app.world_mut().resource_mut::<WorldContentRuntime>();
         runtime.trigger_states = vec![TriggerState {
@@ -4515,7 +4511,7 @@ pub(crate) mod tests {
     // -- add_faction_enemy / remove_faction_enemy dispatch tests --------------
 
     /// Helper: fire a single trigger with the given action via
-    /// `handle_ai_events`. Uses `on_world_loaded` so we only need a
+    /// `tick_trigger_pipeline`. Uses `on_world_loaded` so we only need a
     /// `WorldLoaded` event to fire it. Returns the post-update App so
     /// tests can inspect mutated resources.
     fn fire_world_loaded_action(actions: Vec<TriggerAction>) -> App {
@@ -6403,7 +6399,7 @@ entity = "layer_npc"
 
     // -- on_world_loaded (issue #415) ----------------------------------------
 
-    /// `handle_ai_events` drains `pending_world_events` and dispatches their
+    /// `tick_trigger_pipeline` drains `pending_world_events` and dispatches their
     /// matching triggers' actions. Seeds a `WorldLoaded` event directly into
     /// the queue and asserts the `add_objective` action fires.
     #[test]
@@ -6448,7 +6444,7 @@ entity = "layer_npc"
         let runtime = app.world().resource::<WorldContentRuntime>();
         assert!(
             runtime.pending_world_events.is_empty(),
-            "pending_world_events must be drained by handle_ai_events"
+            "pending_world_events must be drained by tick_trigger_pipeline"
         );
         assert!(
             runtime.trigger_states[0].fired,
@@ -6559,7 +6555,7 @@ entity = "layer_npc"
                 loader_path: None,
             });
         app.update(); // applies load + queues WorldLoaded
-        app.update(); // handle_ai_events drains pending event + fires trigger
+        app.update(); // tick_trigger_pipeline drains pending event + fires trigger
 
         {
             let objectives = &app.world().resource::<ObjectiveManagerRes>().0;
@@ -6654,7 +6650,7 @@ condition = "on_world_loaded"
     use crate::regions::server::RegionPlugin;
 
     /// Build a minimal app that wires `RegionPlugin` + the issue-#416
-    /// observers + `handle_ai_events` into the same world. Skips the
+    /// observers + `tick_trigger_pipeline` into the same world. Skips the
     /// heavyweight `WorldPlugin`/`AiPlugin`/`LobbyPlugin` bootstrap so the
     /// test focuses on the region-event ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ trigger-fire path.
     fn region_trigger_test_app() -> App {
@@ -6669,7 +6665,10 @@ condition = "on_world_loaded"
             .add_message::<crate::ai::server::AiEntityDestroyed>()
             .add_message::<crate::ai::server::AiWaypointReached>()
             .add_message::<CommsChannel2Event>()
-            .add_systems(Update, (handle_ai_events, handle_comms_channel2).chain())
+            .add_systems(
+                Update,
+                (tick_trigger_pipeline, handle_comms_channel2).chain(),
+            )
             .add_observer(handle_region_entered_event)
             .add_observer(handle_region_exited_event);
         // Spawn the player ship (with a Transform so RegionPlugin's
@@ -6810,12 +6809,12 @@ condition = "on_world_loaded"
         );
 
         // Move ship inside. The membership system runs in Physics and
-        // queues a WorldEvent via the observer; `handle_ai_events` (also
+        // queues a WorldEvent via the observer; `tick_trigger_pipeline` (also
         // in Physics) drains the queue on the NEXT tick ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â matching the
         // documented `WorldLoaded` two-tick pattern.
         set_ship_pos(&mut app, 110.0, 0.0);
         app.update(); // queues EnteredRegion
-        app.update(); // handle_ai_events drains + fires
+        app.update(); // tick_trigger_pipeline drains + fires
         assert!(
             objective_present(&app, "obj-entered"),
             "trigger must fire on entry"
@@ -7780,7 +7779,7 @@ size_max = 2.0
 
     /// (#475) `on_timer` triggers fire when `time.elapsed_secs() -
     /// runtime.world_loaded_at_secs >= after_secs`. Verify the producer
-    /// in `handle_ai_events` emits `TimerElapsed` events using the
+    /// in `tick_trigger_pipeline` emits `TimerElapsed` events using the
     /// load-time anchor, and that an `on_timer` trigger correctly fires
     /// a `spawn_entity` action.
     #[test]
@@ -7817,7 +7816,7 @@ size_max = 2.0
             }];
         }
 
-        // Tick twice: first runs handle_ai_events which fires the trigger
+        // Tick twice: first runs tick_trigger_pipeline which fires the trigger
         // and queues the spawn via Commands; second flushes Commands.
         app.update();
         app.update();
@@ -7831,7 +7830,7 @@ size_max = 2.0
         assert!(
             uuid.is_some(),
             "on_timer after_secs=0 must have fired its SpawnEntity action Ã¢â‚¬â€ \
-             handle_ai_events must emit TimerElapsed events when \
+             tick_trigger_pipeline must emit TimerElapsed events when \
              world_loaded_at_secs is set"
         );
 
@@ -8552,7 +8551,7 @@ size_max = 2.0
 
     // -- Issue #506: channel-2 routing tests ------------------------------------
 
-    /// Scenario hail arrives in CommsInboxRes via channel-2 (handle_ai_events
+    /// Scenario hail arrives in CommsInboxRes via channel-2 (tick_trigger_pipeline
     /// writes to CommsChannel2Event; handle_comms_channel2 injects into inbox).
     #[test]
     fn scenario_hail_arrives_in_inbox_via_channel2() {
@@ -8580,7 +8579,7 @@ size_max = 2.0
                 },
                 fired: false,
             });
-            // Queue a WorldLoaded event so handle_ai_events fires the template.
+            // Queue a WorldLoaded event so tick_trigger_pipeline fires the template.
             runtime.pending_world_events.push(WorldEvent::WorldLoaded);
         }
 

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -1451,7 +1451,7 @@ fn tick_trigger_pipeline(
     mut ai_query: Query<
         (
             &EntityUuid,
-            Option<&mut crate::ai_plugin::ShipAiMemory>,
+            Option<&mut crate::weapons_plugin::WeaponsTarget>,
             Option<&crate::entities::spawner::FactionComponent>,
         ),
         With<AiControllerComponent>,
@@ -1807,7 +1807,7 @@ pub(crate) fn apply_dispatch_result(
     ai_query: &mut Query<
         (
             &EntityUuid,
-            Option<&mut crate::ai_plugin::ShipAiMemory>,
+            Option<&mut crate::weapons_plugin::WeaponsTarget>,
             Option<&crate::entities::spawner::FactionComponent>,
         ),
         With<AiControllerComponent>,
@@ -2162,7 +2162,7 @@ fn tick_delayed_actions(
     mut ai_query: Query<
         (
             &EntityUuid,
-            Option<&mut crate::ai_plugin::ShipAiMemory>,
+            Option<&mut crate::weapons_plugin::WeaponsTarget>,
             Option<&crate::entities::spawner::FactionComponent>,
         ),
         With<AiControllerComponent>,

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -80,9 +80,10 @@ pub struct WorldContentRuntime {
     /// trigger table in the same tick so chained `on_flag_set` /
     /// `on_flag_cleared` triggers fire as part of the same Bevy frame.
     pub flags: crate::world::flags::FlagStore,
-    /// Queue of synthesised `WorldEvent`s to be drained by `tick_trigger_pipeline`
-    /// on the next Update tick. Used by `init_world_runtime` (base-world
-    /// Startup) and `apply_world_layer_changes` (sub-world Load) to inject
+    /// Queue of synthesised `WorldEvent`s to be drained by `collect_world_events`
+    /// into `WorldEventBuffer` on the next Update tick. Used by
+    /// `init_world_runtime` (base-world Startup) and
+    /// `apply_world_layer_changes` (sub-world Load) to inject
     /// `WorldEvent::WorldLoaded` into the trigger evaluation pipeline
     /// without duplicating the dispatch logic that lives inside
     /// `tick_trigger_pipeline`.
@@ -95,7 +96,7 @@ pub struct WorldContentRuntime {
     /// (set by `init_world_runtime`). `on_timer` triggers fire when
     /// `time.elapsed_secs() - world_loaded_at_secs >= after_secs`.
     /// `None` while no world is loaded (lobby, fallback bootstrap), in
-    /// which case `tick_trigger_pipeline` skips emitting `TimerElapsed` events.
+    /// which case `collect_world_events` skips emitting `TimerElapsed` events.
     /// (#475)
     pub world_loaded_at_secs: Option<f32>,
     /// Maps named groups to the set of entity names currently in that group.
@@ -181,6 +182,22 @@ pub enum WorldLayerChange {
     Unload(String),
 }
 
+/// Per-tick buffer of the externally-sourced `WorldEvent`s observed this tick.
+///
+/// Producer: `collect_world_events` (drains the `AiEventReaders` messages and
+/// `WorldContentRuntime::pending_world_events`, and synthesises the per-tick
+/// `TimerElapsed` event). Consumer: `tick_trigger_pipeline`, which seeds its
+/// comms-template evaluation and trigger-chaining loop from the buffer.
+///
+/// The chaining loop's internally-produced events (`FlagSet`, `FlagCleared`,
+/// `Destroyed` from a `DestroyEntity` action) stay LOCAL to the pipeline and
+/// are never written here, preserving the contract that comms templates fire
+/// only from external events. Contents are valid for one tick:
+/// `collect_world_events` rebuilds the buffer every run, so stale events
+/// never leak into the next tick.
+#[derive(Resource, Default)]
+pub struct WorldEventBuffer(pub Vec<WorldEvent>);
+
 /// The comms message currently being displayed on the viewscreen.
 ///
 /// Set when a Comms officer sends `ShowOnScreen { message_id }`.
@@ -209,6 +226,7 @@ impl Plugin for WorldPlugin {
             .init_resource::<PendingScenarioLoad>()
             .init_resource::<WorldLayerMap>()
             .init_resource::<PendingWorldLayerChanges>()
+            .init_resource::<WorldEventBuffer>()
             .init_resource::<OnScreenMessage>()
             .add_message::<CommsChannel2Event>()
             .add_systems(
@@ -240,14 +258,28 @@ impl Plugin for WorldPlugin {
                 )
                     .chain(),
             )
+            // Explicit trigger-pipeline ordering (#718): `tick_pending_follow_ups`
+            // must observe `pending_world_events` BEFORE `collect_world_events`
+            // drains them into `WorldEventBuffer` (same-tick follow-up
+            // reaction), and `tick_trigger_pipeline` consumes the buffer.
+            // `.chain()` rather than separate `.before()`s: all three take
+            // `ResMut<WorldContentRuntime>` so they would serialise anyway;
+            // chaining documents the pipeline. (Comms injection joins this
+            // chain in #719.)
             .add_systems(
                 Update,
-                tick_trigger_pipeline.in_set(crate::sim_sets::SimSet::Physics),
+                (
+                    tick_pending_follow_ups,
+                    collect_world_events,
+                    tick_trigger_pipeline,
+                )
+                    .chain()
+                    .in_set(crate::sim_sets::SimSet::Physics),
             )
             // Cursor advancement is a `Modifiers` evaluator: `Physics` has
             // finished moving every ship by then, so waypoint arrival is
             // judged against this tick's final positions. It emits
-            // `AiWaypointReached`, which `tick_trigger_pipeline` turns into a
+            // `AiWaypointReached`, which `collect_world_events` turns into a
             // `WorldEvent::WaypointReached` on the next tick (the same
             // one-tick event bridge `AiEntityAttacked` already uses).
             .add_systems(
@@ -263,12 +295,6 @@ impl Plugin for WorldPlugin {
             )
             .add_systems(
                 Update,
-                tick_pending_follow_ups
-                    .in_set(crate::sim_sets::SimSet::Physics)
-                    .before(tick_trigger_pipeline),
-            )
-            .add_systems(
-                Update,
                 apply_pending_scenario_loads.in_set(crate::sim_sets::SimSet::Physics),
             )
             .add_systems(
@@ -281,8 +307,8 @@ impl Plugin for WorldPlugin {
 }
 
 /// Observer: bridge `RegionEntered` (player ship boundary crossing into a
-/// region) into a queued `WorldEvent::EnteredRegion` so `tick_trigger_pipeline`
-/// can fan it out to matching triggers on the next tick.
+/// region) into a queued `WorldEvent::EnteredRegion` so `collect_world_events`
+/// can buffer it for the trigger pipeline on the next tick.
 ///
 /// Looks up the region entity's UUID via `RegionMembership.region_uuids`
 /// (populated each tick by `update_region_membership`, and persisted after
@@ -630,7 +656,7 @@ fn init_world_runtime(
     };
 
     // (#475) Stamp the load-time anchor for `on_timer` triggers. All
-    // `after_secs` values are measured relative to this; `tick_trigger_pipeline`
+    // `after_secs` values are measured relative to this; `collect_world_events`
     // emits `WorldEvent::TimerElapsed { elapsed_secs }` each tick using
     // `time.elapsed_secs() - world_loaded_at_secs`. `Time` is wrapped in
     // `Option` so older test apps that don't install `TimePlugin` continue
@@ -737,9 +763,10 @@ fn mark_comms_dirty_on_game_start(
 /// trigger conditions against current world state plus this tick's pending
 /// events, and inject any follow-ups whose conditions are now met.
 ///
-/// Ordering: scheduled `.before(tick_trigger_pipeline)` so this system observes
-/// `pending_world_events` BEFORE `tick_trigger_pipeline` drains them. This lets
-/// follow-ups react to events on the same tick they fire.
+/// Ordering: chained BEFORE `collect_world_events` (see `WorldPlugin::build`)
+/// so this system observes `pending_world_events` BEFORE they are drained
+/// into `WorldEventBuffer`. This lets follow-ups react to events on the same
+/// tick they fire.
 ///
 /// "Fire immediately if already true" semantics applies to state-based
 /// triggers: `OnEnteredRegion` fires if the ship is currently inside the
@@ -1212,45 +1239,38 @@ fn broadcast_objective_summary(
 
 // -- AI-event trigger system -------------------------------------------------
 
-/// Upper bound on `tick_trigger_pipeline`'s within-tick trigger-chaining passes.
+/// Collect this tick's externally-sourced `WorldEvent`s into `WorldEventBuffer`.
 ///
-/// A `set_flag` action emits a `FlagSet` event that a downstream `on_flag_set`
-/// trigger can react to in the same Bevy frame, which can in turn set another
-/// flag. The cap stops a pathological feedback loop from hanging the frame.
-const MAX_CHAIN_PASSES: i32 = 16;
-
-/// Read `AiEntityAttacked` and `AiEntityDestroyed` messages, translate them
-/// into `WorldEvent`s, evaluate the scenario trigger table, and execute the
-/// resulting actions (including `SetAiState`, `ApplyModifier`, `RemoveModifier`,
-/// `ApplyFlag`, and `RemoveFlag`).
-fn tick_trigger_pipeline(
-    mut runtime: ResMut<WorldContentRuntime>,
-    mut objectives: ResMut<ObjectiveManagerRes>,
-    mut channel2_writer: MessageWriter<CommsChannel2Event>,
-    mut commands: Commands,
+/// Three sources, in order:
+/// 1. AI-plugin messages (`AiEntityAttacked` / `AiEntityDestroyed` /
+///    `AiWaypointReached`) bridged into `WorldEvent`s via `AiEventReaders`.
+/// 2. `runtime.pending_world_events` (`WorldLoaded`, `EnteredRegion`, ...
+///    queued by `init_world_runtime`, `apply_world_layer_changes`, the region
+///    observers, and `tick_delayed_actions` on the previous tick).
+/// 3. (#475) A synthesised `TimerElapsed` event once the world has loaded.
+///    `on_timer` triggers fire when `elapsed_secs >= after_secs`, measured
+///    from `world_loaded_at_secs` (so `after_secs = 0` fires on the first
+///    post-load tick, and `after_secs = 300` fires 300s into the scenario
+///    regardless of how long the lobby was up beforehand). Single-shot
+///    semantics on `TriggerState.fired` prevent re-firing. `Time` is optional
+///    so test apps without `TimePlugin` continue to work (they just never see
+///    `TimerElapsed`).
+///
+/// Ordering: chained after `tick_pending_follow_ups` (which snapshots
+/// `pending_world_events` before this system drains them) and before
+/// `tick_trigger_pipeline` (which consumes the buffer for both comms-template
+/// injection and trigger evaluation).
+///
+/// Change detection: `runtime` is only mutably dereferenced when
+/// `pending_world_events` has entries to drain, and the buffer is only
+/// mutably dereferenced when its contents change, so an event-free tick
+/// (minimal test apps without `TimePlugin`) marks neither resource changed.
+fn collect_world_events(
     mut ai_events: AiEventReaders,
-    mut ai_query: Query<
-        (
-            &EntityUuid,
-            Option<&mut crate::weapons_plugin::WeaponsTarget>,
-            Option<&crate::entities::spawner::FactionComponent>,
-        ),
-        With<AiControllerComponent>,
-    >,
-    mut ship_modifiers: ShipModifiersParams,
-    mut next_state: Option<ResMut<NextState<GamePhase>>>,
-    mut game_over_reason: Option<ResMut<crate::simulation::GameOverReason>>,
-    mut world_layers: WorldLayerParams,
-    entity_uuid_query: Query<(Entity, &EntityUuid)>,
-    mut faction_dispatch: FactionDispatchParams,
+    mut runtime: ResMut<WorldContentRuntime>,
+    mut buffer: ResMut<WorldEventBuffer>,
     time: Option<Res<bevy::time::Time>>,
 ) {
-    let empty_anchors: HashMap<String, [f32; 3]> = HashMap::new();
-    // Template source for `SpawnEntity` dispatch (issue #715), built once per
-    // system run. `WasmTemplateLoader` unconditionally: it serves the
-    // preloaded config cache first and, on native, falls back to the
-    // filesystem — reproducing the old cfg-split inline block on both targets.
-    let template_loader = crate::entity_loader::WasmTemplateLoader;
     let mut world_events: Vec<WorldEvent> = Vec::new();
     for ev in ai_events.attacked.read() {
         world_events.push(WorldEvent::Attacked {
@@ -1273,21 +1293,12 @@ fn tick_trigger_pipeline(
         });
     }
     // Drain any externally-queued world events (e.g. WorldLoaded pushed by
-    // init_world_runtime or apply_world_layer_changes). This lets those
-    // emission sites participate in the existing evaluate+dispatch+chain
-    // loop below without duplicating the action dispatch table.
+    // init_world_runtime or apply_world_layer_changes). The emptiness check
+    // is a read: it keeps event-free ticks from marking WorldContentRuntime
+    // changed via a no-op DerefMut.
     if !runtime.pending_world_events.is_empty() {
-        let drained: Vec<WorldEvent> = runtime.pending_world_events.drain(..).collect();
-        world_events.extend(drained);
+        world_events.append(&mut runtime.pending_world_events);
     }
-    // (#475) Emit a `TimerElapsed` event each tick once the world has
-    // loaded. `on_timer` triggers fire when `elapsed_secs >= after_secs`,
-    // measured from `world_loaded_at_secs` (so `after_secs = 0` fires on
-    // the first post-load tick, and `after_secs = 300` fires 300s into
-    // the scenario regardless of how long the lobby was up beforehand).
-    // Single-shot semantics on `TriggerState.fired` prevent re-firing.
-    // `Time` is optional so test apps without `TimePlugin` continue to
-    // work (they just never see `TimerElapsed`).
     let elapsed_secs = time.as_ref().and_then(|t| {
         runtime
             .world_loaded_at_secs
@@ -1296,9 +1307,74 @@ fn tick_trigger_pipeline(
     if let Some(es) = elapsed_secs {
         world_events.push(WorldEvent::TimerElapsed { elapsed_secs: es });
     }
-    if world_events.is_empty() && runtime.pending_delayed_actions.is_empty() {
+    // Leave the buffer holding exactly THIS tick's events. Skip the mutable
+    // deref when both the old and new contents are empty — replacing an
+    // empty Vec with an empty Vec is a no-op that would otherwise mark the
+    // buffer changed every tick.
+    if world_events.is_empty() && buffer.0.is_empty() {
         return;
     }
+    buffer.0 = world_events;
+}
+
+/// Upper bound on `tick_trigger_pipeline`'s within-tick trigger-chaining passes.
+///
+/// A `set_flag` action emits a `FlagSet` event that a downstream `on_flag_set`
+/// trigger can react to in the same Bevy frame, which can in turn set another
+/// flag. The cap stops a pathological feedback loop from hanging the frame.
+const MAX_CHAIN_PASSES: i32 = 16;
+
+/// Read this tick's externally-sourced `WorldEvent`s from `WorldEventBuffer`
+/// (filled by `collect_world_events` earlier in the Physics chain), evaluate
+/// the scenario trigger table, and execute the resulting actions (including
+/// `SetAiState`, `ApplyModifier`, `RemoveModifier`, `ApplyFlag`, and
+/// `RemoveFlag`).
+fn tick_trigger_pipeline(
+    mut runtime: ResMut<WorldContentRuntime>,
+    mut objectives: ResMut<ObjectiveManagerRes>,
+    mut channel2_writer: MessageWriter<CommsChannel2Event>,
+    mut commands: Commands,
+    buffer: Res<WorldEventBuffer>,
+    mut ai_query: Query<
+        (
+            &EntityUuid,
+            Option<&mut crate::ai_plugin::ShipAiMemory>,
+            Option<&crate::entities::spawner::FactionComponent>,
+        ),
+        With<AiControllerComponent>,
+    >,
+    mut ship_modifiers: ShipModifiersParams,
+    mut next_state: Option<ResMut<NextState<GamePhase>>>,
+    mut game_over_reason: Option<ResMut<crate::simulation::GameOverReason>>,
+    mut world_layers: WorldLayerParams,
+    entity_uuid_query: Query<(Entity, &EntityUuid)>,
+    mut faction_dispatch: FactionDispatchParams,
+    time: Option<Res<bevy::time::Time>>,
+) {
+    let empty_anchors: HashMap<String, [f32; 3]> = HashMap::new();
+    // Template source for `SpawnEntity` dispatch (issue #715), built once per
+    // system run. `WasmTemplateLoader` unconditionally: it serves the
+    // preloaded config cache first and, on native, falls back to the
+    // filesystem — reproducing the old cfg-split inline block on both targets.
+    let template_loader = crate::entity_loader::WasmTemplateLoader;
+    if buffer.0.is_empty() && runtime.pending_delayed_actions.is_empty() {
+        return;
+    }
+
+    // (#475/#718) `elapsed_secs` anchors delayed-action scheduling below
+    // (`fire_at_elapsed = elapsed_secs + delay`). Recomputed from `Time`
+    // rather than derived from the buffer's `TimerElapsed` event because the
+    // delay check distinguishes `None` (no `Time` resource or no world-load
+    // anchor — delayed actions are silently dropped) from `Some`, and tests
+    // push `TimerElapsed` events into `pending_world_events` without a
+    // world-load anchor; deriving from the buffer would flip `None` to
+    // `Some` there. `Time` is updated once per frame, so this reads the same
+    // value `collect_world_events` used earlier in the chain.
+    let elapsed_secs = time.as_ref().and_then(|t| {
+        runtime
+            .world_loaded_at_secs
+            .map(|loaded_at| (t.elapsed_secs() - loaded_at).max(0.0))
+    });
 
     // Reborrow the `ResMut` as a plain `&mut` so the evaluation loop below can
     // split disjoint field borrows (`&runtime.flags` for condition chains while
@@ -1324,11 +1400,10 @@ fn tick_trigger_pipeline(
 
     // Auto-fire comms templates that match the world events (e.g. on_attacked distress calls).
     // These are injected without any player hailing ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â they are broadcast messages.
-    let fired_comms = evaluate_comms_templates(
-        &mut runtime.comms_template_states,
-        &world_events,
-        &name_to_uuid,
-    );
+    // Reads the buffer directly: only EXTERNAL events reach comms templates —
+    // the chaining loop's internally-produced events below never do.
+    let fired_comms =
+        evaluate_comms_templates(&mut runtime.comms_template_states, &buffer.0, &name_to_uuid);
     for fc in fired_comms {
         let thread_id = fc
             .thread_id
@@ -1406,7 +1481,11 @@ fn tick_trigger_pipeline(
     // later triggers in the same pass see the same flag values as earlier
     // ones; their mutations land in `next_events` and are observed on the
     // next pass.
-    let mut current_events = world_events;
+    // Seed the chain from the buffer's contents. The buffer stays borrowed
+    // (`collect_world_events` owns refilling it next tick), so clone rather
+    // than move — one Vec clone per non-empty tick, the same cost the
+    // pre-#716 local `world_events.clone()` paid.
+    let mut current_events = buffer.0.clone();
     let mut pass = 0;
     loop {
         pass += 1;
@@ -2179,10 +2258,10 @@ pub struct ShipModifiersParams<'w, 's> {
     pub components: Query<'w, 's, &'static mut crate::modifiers::ShipModifiers>,
 }
 
-/// The AI-plugin messages `tick_trigger_pipeline` bridges into `WorldEvent`s.
+/// The AI-plugin messages `collect_world_events` bridges into `WorldEvent`s.
 ///
 /// Grouped into a `SystemParam` for the same reason as `ShipModifiersParams`:
-/// it keeps `tick_trigger_pipeline` clear of Bevy's 16-parameter limit, and
+/// it keeps `collect_world_events` clear of Bevy's 16-parameter limit, and
 /// each new AI event source would otherwise eat one slot of that budget.
 #[derive(bevy::ecs::system::SystemParam)]
 pub struct AiEventReaders<'w, 's> {
@@ -3028,11 +3107,13 @@ pub(crate) mod tests {
             .init_resource::<CommsInboxRes>()
             .init_resource::<ObjectiveManagerRes>()
             .init_resource::<SimOutbox>()
+            .init_resource::<WorldEventBuffer>()
             .add_message::<CommsChannel2Event>()
             .add_systems(
                 Update,
                 (
                     tick_pending_follow_ups,
+                    collect_world_events,
                     tick_trigger_pipeline,
                     handle_comms_channel2,
                 )
@@ -6444,11 +6525,94 @@ entity = "layer_npc"
         let runtime = app.world().resource::<WorldContentRuntime>();
         assert!(
             runtime.pending_world_events.is_empty(),
-            "pending_world_events must be drained by tick_trigger_pipeline"
+            "pending_world_events must be drained by collect_world_events"
         );
         assert!(
             runtime.trigger_states[0].fired,
             "trigger must be marked fired"
+        );
+    }
+
+    /// (#718) Pins the follow-ups -> collect -> pipeline chain ordering:
+    /// `tick_pending_follow_ups` must snapshot `pending_world_events` BEFORE
+    /// `collect_world_events` drains them into `WorldEventBuffer`. A
+    /// registration that ran collection first would leave the snapshot empty
+    /// and the event-only `OnAttacked` follow-up trigger used here would
+    /// never observe its event (it is consumed this tick, not requeued).
+    #[test]
+    fn pending_follow_up_reacts_to_event_queued_same_tick() {
+        let mut app = ai_trigger_test_app();
+
+        {
+            let mut runtime = app.world_mut().resource_mut::<WorldContentRuntime>();
+            runtime
+                .name_to_uuid
+                .insert("freighter".to_string(), "freighter-uuid".to_string());
+            runtime.pending_follow_ups.push(PendingFollowUp {
+                node: CommsDialogueNode {
+                    body: "Mayday! We are under attack!".to_string(),
+                    responses: vec![],
+                    speaker: Some("Freighter".to_string()),
+                    trigger: Some(TriggerCondition::OnAttacked {
+                        entity_name: "freighter".to_string(),
+                    }),
+                },
+                sender_uuid: "freighter-uuid".to_string(),
+                sender_name: "Freighter".to_string(),
+                thread_id: "convoy-thread".to_string(),
+                elapsed_secs: 0.0,
+                placeholder_id: None,
+                urgent: true,
+            });
+            // Queued before this tick's update, e.g. by `tick_delayed_actions`
+            // on the previous tick or by a region observer.
+            runtime.pending_world_events.push(WorldEvent::Attacked {
+                uuid: "freighter-uuid".to_string(),
+                attacker_uuid: "raider-uuid".to_string(),
+            });
+        }
+
+        app.update();
+
+        let messages = app.world().resource::<CommsInboxRes>().0.messages();
+        assert_eq!(
+            messages.len(),
+            1,
+            "an OnAttacked follow-up must fire on the SAME tick its event sits \
+             in pending_world_events — tick_pending_follow_ups must run before \
+             collect_world_events drains the queue"
+        );
+        assert_eq!(messages[0].body, "Mayday! We are under attack!");
+    }
+
+    /// (#718) `WorldEventBuffer` is per-tick state: `collect_world_events`
+    /// rebuilds it every run. An event queued for tick N flows through the
+    /// buffer to the pipeline, and tick N+1 (with no new sources) must leave
+    /// the buffer empty — stale events must not leak into later ticks.
+    #[test]
+    fn world_event_buffer_holds_only_current_tick_events() {
+        let mut app = ai_trigger_test_app();
+
+        app.world_mut()
+            .resource_mut::<WorldContentRuntime>()
+            .pending_world_events
+            .push(WorldEvent::WorldLoaded);
+
+        app.update();
+        {
+            let buffer = app.world().resource::<WorldEventBuffer>();
+            assert_eq!(
+                buffer.0,
+                vec![WorldEvent::WorldLoaded],
+                "collect_world_events must publish this tick's external events"
+            );
+        }
+
+        app.update();
+        let buffer = app.world().resource::<WorldEventBuffer>();
+        assert!(
+            buffer.0.is_empty(),
+            "stale events must not leak into the next tick's buffer"
         );
     }
 
@@ -6555,7 +6719,7 @@ entity = "layer_npc"
                 loader_path: None,
             });
         app.update(); // applies load + queues WorldLoaded
-        app.update(); // tick_trigger_pipeline drains pending event + fires trigger
+        app.update(); // collect_world_events drains pending event; pipeline fires trigger
 
         {
             let objectives = &app.world().resource::<ObjectiveManagerRes>().0;
@@ -6661,13 +6825,19 @@ condition = "on_world_loaded"
             .init_resource::<CommsInboxRes>()
             .init_resource::<ObjectiveManagerRes>()
             .init_resource::<SimOutbox>()
+            .init_resource::<WorldEventBuffer>()
             .add_message::<crate::ai::server::AiEntityAttacked>()
             .add_message::<crate::ai::server::AiEntityDestroyed>()
             .add_message::<crate::ai::server::AiWaypointReached>()
             .add_message::<CommsChannel2Event>()
             .add_systems(
                 Update,
-                (tick_trigger_pipeline, handle_comms_channel2).chain(),
+                (
+                    collect_world_events,
+                    tick_trigger_pipeline,
+                    handle_comms_channel2,
+                )
+                    .chain(),
             )
             .add_observer(handle_region_entered_event)
             .add_observer(handle_region_exited_event);
@@ -6814,7 +6984,7 @@ condition = "on_world_loaded"
         // documented `WorldLoaded` two-tick pattern.
         set_ship_pos(&mut app, 110.0, 0.0);
         app.update(); // queues EnteredRegion
-        app.update(); // tick_trigger_pipeline drains + fires
+        app.update(); // collect_world_events drains; tick_trigger_pipeline fires
         assert!(
             objective_present(&app, "obj-entered"),
             "trigger must fire on entry"

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -1713,7 +1713,7 @@ fn tick_trigger_pipeline(
 /// the *live* per-layer store so that a flag mutation applied earlier in this
 /// same pass is visible to the next action's before/after preview. See
 /// `DispatchContext::base_flags` for why that matters.
-fn project_layer_views(layer_map: Option<&WorldLayerMap>) -> HashMap<String, LayerView> {
+pub(crate) fn project_layer_views(layer_map: Option<&WorldLayerMap>) -> HashMap<String, LayerView> {
     layer_map
         .map(|lm| {
             lm.0.iter()
@@ -1774,19 +1774,23 @@ fn world_modifier_source(tag: String) -> crate::messages::ModifierSource {
 ///
 /// The impure half of the dispatch table (issue #710): `world::dispatch` decides
 /// *what* should happen from read-only data, and this turns that into ECS
-/// mutations. It is the shared apply path for both `tick_trigger_pipeline` (immediate
-/// actions) and `tick_delayed_actions` (delayed ones).
+/// mutations. It is the shared apply path for `tick_trigger_pipeline` (immediate
+/// actions), `tick_delayed_actions` (delayed ones), and
+/// `console::comms::server::handle_respond_to_message` (comms-response actions,
+/// issue #722) — `pub(crate)` so the comms module can reach it.
 ///
 /// The one thing callers must decide for themselves is where `new_events` go, so
 /// they are written to the caller's `events_out`: `tick_trigger_pipeline` points that
 /// at the current pass's `next_events` (same tick, next chaining pass), whereas
-/// `tick_delayed_actions` drains it into `runtime.pending_world_events` (next
-/// tick). Same events, different destination.
+/// `tick_delayed_actions` and `handle_respond_to_message` both drain it into
+/// `runtime.pending_world_events` (next tick — there is no chaining loop in
+/// either of those two callers, only `tick_trigger_pipeline`'s). Same events,
+/// different destination.
 ///
 /// `log_ctx` prefixes the pure layer's `warnings` so each message still names
 /// the system it came from.
 #[allow(clippy::too_many_arguments)]
-fn apply_dispatch_result(
+pub(crate) fn apply_dispatch_result(
     result: DispatchResult,
     log_ctx: &str,
     events_out: &mut Vec<WorldEvent>,

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -2272,14 +2272,6 @@ pub(crate) fn build_uuid_to_faction(
     map
 }
 
-/// Bundle of system params used by the two trigger-dispatch sites for
-/// the `add_faction_enemy` / `remove_faction_enemy` actions. Grouping
-/// these keeps both `tick_trigger_pipeline` and `handle_respond_to_message`
-/// under Bevy's per-system parameter cap (16).
-///
-/// `registry` is `Option<ResMut<_>>` so test apps that don't insert
-/// `FactionRegistryResource` (most of `world::server::tests`) still load
-/// the systems without a "resource does not exist" panic. Production
 /// Bundles the optional world-layer mutation resources used by
 /// `handle_respond_to_message` and `tick_trigger_pipeline` into a single
 /// `SystemParam` so both functions stay within Bevy's 16-parameter limit.
@@ -2318,6 +2310,14 @@ pub struct AiEventReaders<'w, 's> {
     pub waypoint_reached: MessageReader<'w, 's, crate::ai_plugin::AiWaypointReached>,
 }
 
+/// Bundle of system params used by the two trigger-dispatch sites for
+/// the `add_faction_enemy` / `remove_faction_enemy` actions. Grouping
+/// these keeps both `tick_trigger_pipeline` and `handle_respond_to_message`
+/// under Bevy's per-system parameter cap (16).
+///
+/// `registry` is `Option<ResMut<_>>` so test apps that don't insert
+/// `FactionRegistryResource` (most of `world::server::tests`) still load
+/// the systems without a "resource does not exist" panic. Production
 /// builds always insert the registry via `init_world_runtime`, so the
 /// `None` branch is a test-only safety net that logs and skips the
 /// action.
@@ -6524,6 +6524,549 @@ entity = "layer_npc"
         assert!(
             runtime.contacts.iter().all(|c| !c.in_range),
             "all contacts must be out of range after ship despawn"
+        );
+    }
+
+    // -- Issue #717: trigger-pipeline edge cases ------------------------------
+
+    /// (#717) An empty world — no triggers, no entities, no queued events —
+    /// must flow through the collect → inject → pipeline chain as a pure
+    /// no-op: nothing panics, no state appears, and (pinning the #716/#718
+    /// change-detection discipline) neither `WorldContentRuntime` nor
+    /// `WorldEventBuffer` is marked changed on an event-free tick.
+    #[test]
+    fn tick_trigger_pipeline_is_a_noop_on_an_empty_world() {
+        #[derive(Resource, Default)]
+        struct ChangeProbe {
+            runtime_changed: bool,
+            buffer_changed: bool,
+        }
+
+        fn probe(
+            runtime: Res<WorldContentRuntime>,
+            buffer: Res<WorldEventBuffer>,
+            mut out: ResMut<ChangeProbe>,
+        ) {
+            out.runtime_changed = runtime.is_changed();
+            out.buffer_changed = buffer.is_changed();
+        }
+
+        // Deliberately bare — no TimePlugin (so no `TimerElapsed` synthesis)
+        // and no Lobby/Ai plugin systems that might touch the probed
+        // resources. This is the "minimal test apps without TimePlugin" shape
+        // the pipeline's docs promise keeps working.
+        let mut app = App::new();
+        app.init_resource::<WorldContentRuntime>()
+            .init_resource::<ObjectiveManagerRes>()
+            .init_resource::<WorldEventBuffer>()
+            .init_resource::<ChangeProbe>()
+            .add_message::<CommsChannel2Event>()
+            .add_message::<crate::ai_plugin::AiEntityAttacked>()
+            .add_message::<crate::ai_plugin::AiEntityDestroyed>()
+            .add_message::<crate::ai_plugin::AiWaypointReached>()
+            .add_systems(
+                Update,
+                (
+                    collect_world_events,
+                    inject_comms_templates,
+                    tick_trigger_pipeline,
+                    probe,
+                )
+                    .chain(),
+            );
+
+        // First tick: the probe sees everything "changed" because the
+        // resources were freshly inserted — it only proves nothing panics.
+        app.update();
+        // Second tick is the discriminating one: with no events and no
+        // triggers none of the three systems may mutably dereference the
+        // resources, so the probe must see them unchanged.
+        app.update();
+
+        let probe_out = app.world().resource::<ChangeProbe>();
+        assert!(
+            !probe_out.runtime_changed,
+            "an event-free tick must not mark WorldContentRuntime changed"
+        );
+        assert!(
+            !probe_out.buffer_changed,
+            "an event-free tick must not mark WorldEventBuffer changed"
+        );
+        let runtime = app.world().resource::<WorldContentRuntime>();
+        assert!(
+            runtime.trigger_states.is_empty(),
+            "no trigger state may appear"
+        );
+        assert!(
+            runtime.pending_world_events.is_empty(),
+            "no world events may be synthesised from nothing"
+        );
+        assert!(
+            app.world().resource::<WorldEventBuffer>().0.is_empty(),
+            "the buffer must stay empty"
+        );
+        assert!(
+            app.world()
+                .resource::<ObjectiveManagerRes>()
+                .0
+                .sorted_snapshots()
+                .is_empty(),
+            "no objectives may appear"
+        );
+    }
+
+    /// (#717) A trigger chain longer than `MAX_CHAIN_PASSES` must be cut off
+    /// at the cap (with a warning) instead of hanging the frame. Builds a
+    /// linear chain of `MAX_CHAIN_PASSES + 2` single-shot triggers: the seed
+    /// fires on the external `WorldLoaded` event and sets `chain_1`; link `i`
+    /// fires on `on_flag_set chain_i` and sets `chain_{i+1}`. Each pass of
+    /// the within-tick chaining loop advances the chain by exactly one link,
+    /// so the observable cut is: `chain_1..=chain_MAX` set (that much
+    /// dispatch work happened), `chain_{MAX+1}` never set (the cap broke the
+    /// loop before pass MAX+1), and the corresponding trigger never consumed.
+    #[test]
+    fn trigger_chain_exceeding_max_passes_stops_at_the_cap() {
+        let mut app = ai_trigger_test_app();
+        let chain_len = (MAX_CHAIN_PASSES + 2) as usize;
+        {
+            let mut runtime = app.world_mut().resource_mut::<WorldContentRuntime>();
+            let mk = |condition, flag_to_set: String| TriggerState {
+                trigger: crate::world::content::Trigger {
+                    condition,
+                    actions: vec![TriggerAction::SetWorldFlag { name: flag_to_set }],
+                    when: None,
+                    action_predicates: vec![],
+                    action_delays: vec![],
+                },
+                fired: false,
+                origin_layer: None,
+                seen_destroyed: HashSet::new(),
+            };
+            let mut states = vec![mk(TriggerCondition::OnWorldLoaded, "chain_1".to_string())];
+            for i in 1..chain_len {
+                states.push(mk(
+                    TriggerCondition::OnFlagSet {
+                        name: format!("chain_{i}"),
+                    },
+                    format!("chain_{}", i + 1),
+                ));
+            }
+            runtime.trigger_states = states;
+            runtime.pending_world_events.push(WorldEvent::WorldLoaded);
+        }
+
+        // A single update must terminate — the cap is what guarantees it.
+        app.update();
+
+        let runtime = app.world().resource::<WorldContentRuntime>();
+        let max = MAX_CHAIN_PASSES as usize;
+        for i in 1..=max {
+            assert_eq!(
+                runtime.flags.counter(&format!("chain_{i}")),
+                1,
+                "pass {i} of the chaining loop must set chain_{i}"
+            );
+        }
+        assert_eq!(
+            runtime.flags.counter(&format!("chain_{}", max + 1)),
+            0,
+            "the MAX_CHAIN_PASSES cap must stop the chain before pass {}",
+            max + 1
+        );
+        assert!(
+            !runtime.trigger_states[max].fired,
+            "the link past the cap must never fire (its flag never got set)"
+        );
+    }
+
+    /// (#717) The per-trigger flag-store chain that `tick_trigger_pipeline`
+    /// builds for condition evaluation must fall back to the BASE store when
+    /// the trigger's `origin_layer` is missing from `WorldLayerMap`. The
+    /// `when` predicate here only passes if the chain's first entry is the
+    /// base store — an empty stand-in store would read `armed` as unset and
+    /// suppress the trigger. The layer map is deliberately non-empty so the
+    /// fallback is proven per-entry, not merely "map absent".
+    ///
+    /// The pure dispatch-layer twins of this behaviour (the `parent:` walk
+    /// inside `dispatch_world_flag_action`) are
+    /// `dispatch::tests::flag_layer_missing_mid_walk_is_silent_and_treated_as_base`
+    /// / `world_flag_layer_missing_mid_walk_is_silent_and_treated_as_base_directly`,
+    /// and the final-lookup-missing abort is
+    /// `flag_target_layer_missing_from_map_warns_and_emits_nothing`. This
+    /// test drives the Bevy-side chain builder those tests cannot reach.
+    #[test]
+    fn trigger_from_layer_missing_in_layer_map_reads_base_flags() {
+        let mut app = ai_trigger_test_app();
+        app.init_resource::<WorldLayerMap>();
+        {
+            let mut layer_map = app.world_mut().resource_mut::<WorldLayerMap>();
+            layer_map.0.insert(
+                "assets/worlds/unrelated.toml".to_string(),
+                WorldRuntime::default(),
+            );
+        }
+        {
+            let mut runtime = app.world_mut().resource_mut::<WorldContentRuntime>();
+            runtime.flags.set_flag("armed"); // set in the BASE store only
+            runtime.trigger_states = vec![TriggerState {
+                trigger: crate::world::content::Trigger {
+                    condition: TriggerCondition::OnWorldLoaded,
+                    actions: vec![TriggerAction::AddObjective {
+                        id: "obj-ghost-layer".into(),
+                        text: "Fired despite the missing layer".into(),
+                        mandatory: false,
+                        targets: vec![],
+                        directive: crate::messages::AiDirective::None,
+                        utility: crate::objectives::UtilityConfig::default(),
+                        source: crate::messages::ObjectiveSource::default(),
+                    }],
+                    when: Some(crate::world::flags::parse_predicate("flag(armed)").unwrap()),
+                    action_predicates: vec![],
+                    action_delays: vec![],
+                },
+                fired: false,
+                // Not present in WorldLayerMap — e.g. state surviving an
+                // unload. The chain builder must treat it as the base world.
+                origin_layer: Some("assets/worlds/ghost.toml".to_string()),
+                seen_destroyed: HashSet::new(),
+            }];
+            runtime.pending_world_events.push(WorldEvent::WorldLoaded);
+        }
+
+        app.update();
+
+        let objectives = &app.world().resource::<ObjectiveManagerRes>().0;
+        assert!(
+            objectives
+                .sorted_snapshots()
+                .iter()
+                .any(|o| o.id == "obj-ghost-layer"),
+            "a missing origin layer must fall back to the base flag store, \
+             so the base-store `armed` flag must satisfy the when predicate"
+        );
+    }
+
+    /// (#717) One trigger whose action list carries every `TriggerAction`
+    /// variant (all 21) must dispatch them in LIST ORDER, each result applied
+    /// before the next action is dispatched. Order is observed through
+    /// order-sensitive pairs rather than instrumentation:
+    ///
+    /// * `AddObjective` → `CompleteObjective`/`FailObjective`: complete/fail
+    ///   only transition Active objectives, so the final statuses prove the
+    ///   adds ran first.
+    /// * `Apply*` → `Remove*` (float / int / flag modifiers): the removes
+    ///   only find what the applies wrote, so baseline end values prove
+    ///   apply-before-remove.
+    /// * `SetWorldFlag` → `ClearWorldFlag` on one flag: against the live
+    ///   store this emits `FlagSet` then `FlagCleared`; the chained
+    ///   `on_flag_cleared` trigger firing proves the order (a clear-first
+    ///   order would emit no `FlagCleared` transition at all).
+    /// * `SetWorldFlagValue(40)` → `IncrementWorldFlag(+2)`: final counter 42
+    ///   (the reverse order would end at 40).
+    /// * `AddFactionEnemy` → `RemoveFactionEnemy` of the same pair: final
+    ///   relationship is neutral (the reverse order would leave it hostile).
+    /// * `LoadWorld` → `UnloadWorld`: `PendingWorldLayerChanges` preserves
+    ///   push order positionally.
+    /// * `SpawnEntity` / `DestroyEntity` / `SetAiState` (warn no-op) and the
+    ///   trailing `GameOver` are asserted by their individual effects.
+    #[test]
+    fn single_trigger_dispatches_every_action_variant_in_list_order() {
+        let template_path = write_spawn_template_fixture();
+        let mut app = ai_trigger_test_app();
+        app.init_resource::<WorldLayerMap>()
+            .init_resource::<PendingWorldLayerChanges>()
+            .init_resource::<crate::simulation::GameOverReason>();
+
+        // Target for the six per-entity modifier actions.
+        let target = app
+            .world_mut()
+            .spawn((
+                EntityUuid("allvar-target-uuid".to_string()),
+                crate::modifiers::ShipModifiers::new(),
+            ))
+            .id();
+        // Victim for DestroyEntity.
+        let victim = app
+            .world_mut()
+            .spawn((
+                EntityUuid("allvar-victim-uuid".to_string()),
+                Transform::from_xyz(0.0, 0.0, 0.0),
+            ))
+            .id();
+
+        {
+            let mut runtime = app.world_mut().resource_mut::<WorldContentRuntime>();
+            runtime
+                .name_to_uuid
+                .insert("target_ship".into(), "allvar-target-uuid".into());
+            runtime
+                .name_to_uuid
+                .insert("victim".into(), "allvar-victim-uuid".into());
+            let all_variants = vec![
+                TriggerAction::AddObjective {
+                    id: "obj-alpha".into(),
+                    text: "Add then complete".into(),
+                    mandatory: false,
+                    targets: vec![],
+                    directive: crate::messages::AiDirective::None,
+                    utility: crate::objectives::UtilityConfig::default(),
+                    source: crate::messages::ObjectiveSource::default(),
+                },
+                TriggerAction::CompleteObjective {
+                    id: "obj-alpha".into(),
+                },
+                TriggerAction::AddObjective {
+                    id: "obj-beta".into(),
+                    text: "Add then fail".into(),
+                    mandatory: false,
+                    targets: vec![],
+                    directive: crate::messages::AiDirective::None,
+                    utility: crate::objectives::UtilityConfig::default(),
+                    source: crate::messages::ObjectiveSource::default(),
+                },
+                TriggerAction::FailObjective {
+                    id: "obj-beta".into(),
+                },
+                TriggerAction::SetAiState {
+                    entity: "target_ship".into(),
+                    state: "attack".into(),
+                    target: None,
+                },
+                TriggerAction::ApplyModifier {
+                    entity: "target_ship".into(),
+                    tag: "boost".into(),
+                    slot: crate::messages::ModifierSlot::MaxSpeed,
+                    bonus: 2.0,
+                },
+                TriggerAction::ApplyIntModifier {
+                    entity: "target_ship".into(),
+                    tag: "crew".into(),
+                    slot: crate::modifiers::IntModifierSlot::RepairTeams,
+                    bonus: 3,
+                },
+                TriggerAction::ApplyFlag {
+                    entity: "target_ship".into(),
+                    tag: "jammer".into(),
+                    kind: crate::flag_kind::FlagKind::CommsJammed,
+                },
+                TriggerAction::RemoveModifier {
+                    entity: "target_ship".into(),
+                    tag: "boost".into(),
+                    slot: crate::messages::ModifierSlot::MaxSpeed,
+                },
+                TriggerAction::RemoveIntModifier {
+                    entity: "target_ship".into(),
+                    tag: "crew".into(),
+                    slot: crate::modifiers::IntModifierSlot::RepairTeams,
+                },
+                TriggerAction::RemoveFlag {
+                    entity: "target_ship".into(),
+                    tag: "jammer".into(),
+                    kind: crate::flag_kind::FlagKind::CommsJammed,
+                },
+                TriggerAction::SetWorldFlag {
+                    name: "ordered".into(),
+                },
+                TriggerAction::ClearWorldFlag {
+                    name: "ordered".into(),
+                },
+                TriggerAction::SetWorldFlagValue {
+                    name: "counter".into(),
+                    value: 40,
+                },
+                TriggerAction::IncrementWorldFlag {
+                    name: "counter".into(),
+                    by: 2,
+                },
+                TriggerAction::SpawnEntity {
+                    template_path: template_path.clone(),
+                    name: "allvar_spawned".into(),
+                    anchor: None,
+                    position: Some([5.0, 0.0, 5.0]),
+                    rotation: None,
+                    scale: None,
+                    groups: vec![],
+                },
+                TriggerAction::DestroyEntity {
+                    entity: "victim".into(),
+                },
+                TriggerAction::AddFactionEnemy {
+                    faction: "Harrow".into(),
+                    enemy: "Federation".into(),
+                },
+                TriggerAction::RemoveFactionEnemy {
+                    faction: "Harrow".into(),
+                    enemy: "Federation".into(),
+                },
+                TriggerAction::LoadWorld {
+                    path: "assets/worlds/allvar_load.toml".into(),
+                },
+                TriggerAction::UnloadWorld {
+                    path: "assets/worlds/allvar_unload.toml".into(),
+                },
+                TriggerAction::GameOver {
+                    message: Some("all variants dispatched".into()),
+                },
+            ];
+            runtime.trigger_states = vec![
+                TriggerState {
+                    trigger: crate::world::content::Trigger {
+                        condition: TriggerCondition::OnWorldLoaded,
+                        actions: all_variants,
+                        when: None,
+                        action_predicates: vec![],
+                        action_delays: vec![],
+                    },
+                    fired: false,
+                    origin_layer: None,
+                    seen_destroyed: HashSet::new(),
+                },
+                // Chained witness: fires only if the pipeline emitted
+                // FlagSet("ordered") followed by FlagCleared("ordered").
+                TriggerState {
+                    trigger: crate::world::content::Trigger {
+                        condition: TriggerCondition::OnFlagCleared {
+                            name: "ordered".into(),
+                        },
+                        actions: vec![TriggerAction::AddObjective {
+                            id: "obj-chained-cleared".into(),
+                            text: "Observed set-then-clear".into(),
+                            mandatory: false,
+                            targets: vec![],
+                            directive: crate::messages::AiDirective::None,
+                            utility: crate::objectives::UtilityConfig::default(),
+                            source: crate::messages::ObjectiveSource::default(),
+                        }],
+                        when: None,
+                        action_predicates: vec![],
+                        action_delays: vec![],
+                    },
+                    fired: false,
+                    origin_layer: None,
+                    seen_destroyed: HashSet::new(),
+                },
+            ];
+            runtime.pending_world_events.push(WorldEvent::WorldLoaded);
+        }
+
+        app.update();
+        app.update();
+
+        // Objectives: add-before-complete / add-before-fail.
+        let objectives = &app.world().resource::<ObjectiveManagerRes>().0;
+        let snapshot_status = |id: &str| {
+            objectives
+                .sorted_snapshots()
+                .iter()
+                .find(|o| o.id == id)
+                .map(|o| o.status.clone())
+        };
+        assert_eq!(
+            snapshot_status("obj-alpha"),
+            Some(ObjectiveStatus::Completed),
+            "AddObjective must dispatch before CompleteObjective"
+        );
+        assert_eq!(
+            snapshot_status("obj-beta"),
+            Some(ObjectiveStatus::Failed),
+            "AddObjective must dispatch before FailObjective"
+        );
+        assert_eq!(
+            snapshot_status("obj-chained-cleared"),
+            Some(ObjectiveStatus::Active),
+            "SetWorldFlag must dispatch before ClearWorldFlag (chained \
+             on_flag_cleared trigger must observe the transition)"
+        );
+
+        // Per-entity modifiers: apply-before-remove nets out to baselines.
+        let mods = app
+            .world()
+            .entity(target)
+            .get::<crate::modifiers::ShipModifiers>()
+            .expect("target must keep its ShipModifiers component");
+        assert!(
+            (mods.get(&crate::messages::ModifierSlot::MaxSpeed) - 1.0).abs() < 1e-3,
+            "RemoveModifier must undo the earlier ApplyModifier"
+        );
+        assert_eq!(
+            mods.get_int(&crate::modifiers::IntModifierSlot::RepairTeams),
+            0,
+            "RemoveIntModifier must undo the earlier ApplyIntModifier"
+        );
+        assert!(
+            !mods.has_flag(&crate::flag_kind::FlagKind::CommsJammed),
+            "RemoveFlag must undo the earlier ApplyFlag"
+        );
+
+        // World flags: set-then-clear ends cleared; value-then-increment ends 42.
+        let runtime = app.world().resource::<WorldContentRuntime>();
+        assert_eq!(runtime.flags.counter("ordered"), 0);
+        assert_eq!(
+            runtime.flags.counter("counter"),
+            42,
+            "SetWorldFlagValue(40) must dispatch before IncrementWorldFlag(+2)"
+        );
+
+        // SpawnEntity: registered and present in the ECS.
+        let spawned_uuid = runtime
+            .name_to_uuid
+            .get("allvar_spawned")
+            .cloned()
+            .expect("SpawnEntity must register name_to_uuid");
+        let mut q = app.world_mut().query::<&EntityUuid>();
+        assert!(
+            q.iter(app.world()).any(|eu| eu.0 == spawned_uuid),
+            "SpawnEntity must spawn the templated entity"
+        );
+
+        // DestroyEntity: the victim is gone.
+        assert!(
+            app.world().get_entity(victim).is_err(),
+            "DestroyEntity must despawn the victim"
+        );
+
+        // Factions: add-before-remove nets out to neutral.
+        let registry = &app
+            .world()
+            .resource::<crate::config_cache::FactionRegistryResource>()
+            .0;
+        assert!(
+            !crate::faction::is_enemy(
+                Some(harrow_faction_uuid()),
+                Some(fed_faction_uuid()),
+                registry
+            ),
+            "RemoveFactionEnemy must undo the earlier AddFactionEnemy"
+        );
+
+        // Layer changes: pushed in list order.
+        let pending = app.world().resource::<PendingWorldLayerChanges>();
+        assert_eq!(pending.0.len(), 2, "exactly one Load and one Unload");
+        assert!(
+            matches!(&pending.0[0], WorldLayerChange::Load { path, .. } if path == "assets/worlds/allvar_load.toml"),
+            "LoadWorld must be queued before UnloadWorld, got {:?}",
+            pending.0
+        );
+        assert!(
+            matches!(&pending.0[1], WorldLayerChange::Unload(path) if path == "assets/worlds/allvar_unload.toml"),
+            "UnloadWorld must be queued after LoadWorld, got {:?}",
+            pending.0
+        );
+
+        // GameOver: reason recorded, phase transitioned (second update let
+        // the queued NextState take effect).
+        assert_eq!(
+            app.world()
+                .resource::<crate::simulation::GameOverReason>()
+                .0
+                .as_deref(),
+            Some("all variants dispatched"),
+            "GameOver must record its reason"
+        );
+        assert_eq!(
+            *app.world().resource::<State<GamePhase>>().get(),
+            GamePhase::GameOver,
+            "GameOver must queue the phase transition"
         );
     }
 

--- a/src/world/server.rs
+++ b/src/world/server.rs
@@ -1248,6 +1248,11 @@ fn handle_ai_events(
     time: Option<Res<bevy::time::Time>>,
 ) {
     let empty_anchors: HashMap<String, [f32; 3]> = HashMap::new();
+    // Template source for `SpawnEntity` dispatch (issue #715), built once per
+    // system run. `WasmTemplateLoader` unconditionally: it serves the
+    // preloaded config cache first and, on native, falls back to the
+    // filesystem — reproducing the old cfg-split inline block on both targets.
+    let template_loader = crate::entity_loader::WasmTemplateLoader;
     let mut world_events: Vec<WorldEvent> = Vec::new();
     for ev in ai_events.attacked.read() {
         world_events.push(WorldEvent::Attacked {
@@ -1536,6 +1541,7 @@ fn handle_ai_events(
                             .unwrap_or(&empty_anchors),
                         factions: faction_dispatch.registry.as_deref().map(|r| &r.0),
                         uuid_source: &crate::entity_loader::assign_uuid,
+                        template_loader: &template_loader,
                     };
                     dispatch_action(action, &ctx)
                 };
@@ -1694,15 +1700,6 @@ fn apply_dispatch_result(
     }
 
     events_out.extend(new_events);
-
-    // `name_to_uuid_inserts` / `entity_group_inserts` are contingent on the
-    // accompanying `SpawnEntity` command actually spawning — template loading is
-    // still the applier's job (issue #715 moves it into the pure layer), so the
-    // pure layer cannot know whether the spawn resolved. Registering a name for
-    // an entity that never spawned would leave a phantom name -> uuid entry, and
-    // a later `DestroyEntity` would then emit `WorldEvent::Destroyed` for a
-    // ghost, firing `on_destroyed` triggers for an entity that never existed.
-    let mut spawn_failed = false;
 
     for cmd in action_cmds {
         match cmd {
@@ -1878,97 +1875,37 @@ fn apply_dispatch_result(
             }
 
             ActionCmd::SpawnEntity {
-                template_path,
-                name,
+                config,
+                name: _,
                 uuid,
                 position,
                 rotation,
                 scale,
-                groups: _,
                 layer_path,
             } => {
-                // Template loading stays here for now (issue #715 moves it into
-                // the pure layer behind a `TemplateLoader`). A failure here is
-                // what makes the name / group registrations contingent.
-                let config_cache = crate::config_cache::get_config_cache();
-                let template_inst = crate::world::config::WorldEntity {
-                    template_path: template_path.clone(),
-                    ..Default::default()
-                };
-                let entity_config = match crate::entity_loader::resolve_entity(
-                    &template_inst,
-                    &config_cache,
-                ) {
-                    Ok(c) => c,
-                    Err(e) => {
-                        // Native fallback: try reading from disk.
-                        #[cfg(not(target_arch = "wasm32"))]
-                        {
-                            match std::fs::read_to_string(&template_path) {
-                                Ok(toml_str) => {
-                                    match crate::entity_config::EntityConfig::from_toml(&toml_str) {
-                                        Ok(c) => c,
-                                        Err(err) => {
-                                            bevy::log::warn!(
-                                                    "{log_ctx}: SpawnEntity '{name}' template '{template_path}' parse error: {err:?}"
-                                                );
-                                            spawn_failed = true;
-                                            continue;
-                                        }
-                                    }
-                                }
-                                Err(_) => {
-                                    bevy::log::warn!(
-                                            "{log_ctx}: SpawnEntity '{name}' template '{template_path}' not in cache nor on disk: {e}"
-                                        );
-                                    spawn_failed = true;
-                                    continue;
-                                }
-                            }
-                        }
-                        #[cfg(target_arch = "wasm32")]
-                        {
-                            bevy::log::warn!(
-                                    "{log_ctx}: SpawnEntity '{name}' template '{template_path}' not in cache: {e}"
-                                );
-                            spawn_failed = true;
-                            continue;
-                        }
-                    }
-                };
-
+                // The template arrives already resolved and name-patched: the
+                // pure layer loaded it via `DispatchContext::template_loader`
+                // and gated the failure path (issue #715), so a command here
+                // always spawns.
                 let pos_vec = Vec3::new(position[0], position[1], position[2]);
-                // Patch the entity name with the trigger's `name` field so the
-                // spawned ECS entity gets EntityName("wave_1") (not the
-                // template's display name like "Harrow Destroyer"). This mirrors
-                // what `spawn_world_entities` does for static `[[entity]]`
-                // entries and is required for `resolve_objective_target` to
-                // match Destroy directives by the scenario name.
-                let mut entity_config = entity_config;
-                if !name.is_empty() {
-                    entity_config.name = Some(name.clone());
-                }
-                let spawned = crate::entity_spawner::spawn_entity(
-                    commands,
-                    &entity_config,
-                    pos_vec,
-                    uuid,
-                    None,
-                );
+                let spawned =
+                    crate::entity_spawner::spawn_entity(commands, &config, pos_vec, uuid, None);
 
                 // Apply optional rotation (XYZ Euler radians) and scale
-                // (per-axis), mirroring `TransformConfig` semantics from the
-                // static `[[entity]]` schema. `spawn_entity` only set
-                // translation; overwrite the whole Transform when either is
-                // supplied.
+                // (per-axis) via the canonical `TransformConfig` conversions —
+                // the same parse-layer helpers the static `[[entity]]` schema
+                // uses. `spawn_entity` only set translation; overwrite the
+                // whole Transform when either is supplied.
                 if rotation.is_some() || scale.is_some() {
-                    let [rx, ry, rz] = rotation.unwrap_or([0.0, 0.0, 0.0]);
-                    let quat = Quat::from_euler(EulerRot::XYZ, rx, ry, rz);
-                    let [sx, sy, sz] = scale.unwrap_or([1.0, 1.0, 1.0]);
+                    let tc = crate::world::config::TransformConfig {
+                        rotation,
+                        scale,
+                        ..Default::default()
+                    };
                     commands.entity(spawned).insert(Transform {
                         translation: pos_vec,
-                        rotation: quat,
-                        scale: Vec3::new(sx, sy, sz),
+                        rotation: tc.quat(),
+                        scale: tc.scale_vec(),
                     });
                 }
 
@@ -2058,13 +1995,15 @@ fn apply_dispatch_result(
         }
     }
 
-    if !spawn_failed {
-        for (name, uuid) in name_to_uuid_inserts {
-            runtime.name_to_uuid.insert(name, uuid);
-        }
-        for (group, name) in entity_group_inserts {
-            runtime.entity_groups.entry(group).or_default().insert(name);
-        }
+    // Both maps arrive already gated: a `SpawnEntity` whose template failed
+    // to resolve returns a warning-only result with no inserts (issue #715
+    // moved that gate into `dispatch_spawn_entity`), so everything here
+    // applies unconditionally.
+    for (name, uuid) in name_to_uuid_inserts {
+        runtime.name_to_uuid.insert(name, uuid);
+    }
+    for (group, name) in entity_group_inserts {
+        runtime.entity_groups.entry(group).or_default().insert(name);
     }
 }
 
@@ -2121,6 +2060,9 @@ fn tick_delayed_actions(
         .collect();
 
     let empty_anchors: HashMap<String, [f32; 3]> = HashMap::new();
+    // Same template source as `handle_ai_events` (issue #715): one
+    // `WasmTemplateLoader` per system run, both targets.
+    let template_loader = crate::entity_loader::WasmTemplateLoader;
 
     let mut ready: Vec<DelayedAction> = Vec::new();
     let mut still_pending: Vec<DelayedAction> = Vec::new();
@@ -2151,6 +2093,7 @@ fn tick_delayed_actions(
                     .unwrap_or(&empty_anchors),
                 factions: faction_dispatch.registry.as_deref().map(|r| &r.0),
                 uuid_source: &crate::entity_loader::assign_uuid,
+                template_loader: &template_loader,
             };
             dispatch_action(&pda.action, &ctx)
         };

--- a/wiki/concepts/broadcaster-seam.md
+++ b/wiki/concepts/broadcaster-seam.md
@@ -28,7 +28,7 @@ Both plugins expose a builder-style `register()` method and implement `bevy::Plu
 
 ## Key types
 
-### Audience (`src/core/broadcast/audience.rs:7`)
+### Audience (`src/core/broadcast/audience.rs:8`)
 
 ```rust
 pub enum Audience {
@@ -94,27 +94,27 @@ The broadcaster implements `bevy::Plugin` with `is_unique() -> false`, so you ca
 
 ## Complete catalogue of registered producers
 
-All `ServerMessage` broadcasts are listed below. **Every** `OutboundMessage` write happens through a broadcaster-registered producer — either directly via the dispatch loop's `world.write_message(OutboundMessage { ... })` (`src/core/broadcast/sim.rs:183`, `src/core/broadcast/lobby.rs:174`) or inside a producer closure that is exclusively called by that dispatch.
+All `ServerMessage` broadcasts are listed below. **Every** `OutboundMessage` write happens through a broadcaster-registered producer — either directly via the dispatch loop's `world.write_message(OutboundMessage { ... })` (`src/core/broadcast/sim.rs:189`, `src/core/broadcast/lobby.rs:188`) or inside a producer closure that is exclusively called by that dispatch.
 
 ### SimBroadcaster (game phase = `InProgress`)
 
 | Producer | Message(s) | Audience | Cadence | Registered in | Delivers as |
 |---|---|---|---|---|---|
-| `power_state_broadcaster` | `PowerState` | `Holding(StationId("power"))` | `Hz(10.0)` | `src/ship/power.rs:144` | Snapshot (via `sim_outbox_broadcaster`) |
-| `weapons_update_broadcaster` | `WeaponsUpdate` | `Holding(StationId("tactical"))` | `Hz(10.0)` | `src/console/weapons/server.rs:2738` | Snapshot (via `sim_outbox_broadcaster`) |
-| `repair_state_broadcaster` | `RepairState` | `Holding(StationId("repair"))` | `Hz(10.0)` | `src/console/repair/server.rs:52` | Snapshot (via `sim_outbox_broadcaster`) |
-| `sim_state_broadcaster` | `SimState` + `SystemHullUpdate` | `All` | `Hz(10.0)` | `src/server_app.rs:362` | Snapshot |
-| `modifier_events_broadcaster` | `ModifierAdded` / `ModifierRemoved` | `All` | `OnEvent` | `src/server_app.rs:603` | Reliable |
-| `sim_outbox_broadcaster` | Drain of `SimOutbox` (see below) | `All` (placeholder) | `OnEvent` | `src/server_app.rs:642` | Per-message via `delivery_class_for_msg()` |
+| `power_state_broadcaster` | `PowerState` | `Holding(StationId("power"))` | `Hz(10.0)` | `src/ship/power.rs:216` | Snapshot (via `sim_outbox_broadcaster`) |
+| `weapons_update_broadcaster` | `WeaponsUpdate` | `Holding(StationId("tactical"))` | `Hz(10.0)` | `src/console/weapons/server.rs:4484` | Snapshot (via `sim_outbox_broadcaster`) |
+| `repair_state_broadcaster` | `RepairState` | `Holding(StationId("repair"))` | `Hz(10.0)` | `src/console/repair/server.rs:147` | Snapshot (via `sim_outbox_broadcaster`) |
+| `sim_state_broadcaster` | `SimState` + `SystemHullUpdate` | `All` | `Hz(10.0)` | `src/server_app.rs:381` | Snapshot |
+| `modifier_events_broadcaster` | `ModifierAdded` / `ModifierRemoved` | `All` | `OnEvent` | `src/server_app.rs:622` | Reliable |
+| `sim_outbox_broadcaster` | Drain of `SimOutbox` (see below) | `All` (placeholder) | `OnEvent` | `src/server_app.rs:661` | Per-message via `delivery_class_for_msg()` |
 
-The `SimOutbox` producer (`sim_outbox_broadcaster`, `src/server_app.rs:642`) is a special forwarding producer that drains `SimOutbox` — a `Vec<(Target, ServerMessage)>` resource written by simulation systems that need to emit arbitrary-target messages (entity spawn/despawn, torpedo events, shield status, world setup, comms state, objective summaries). It is the only producer that sets `delivery` per message via `delivery_class_for_msg()` (`src/server_app.rs:664`), which classifies high-frequency state pushes as `Snapshot` and everything else as `Reliable`. The producer writes each entry directly via `world.write_message(OutboundMessage { ... })` and returns an empty `Vec`. Messages currently routed through `SimOutbox`:
+The `SimOutbox` producer (`sim_outbox_broadcaster`, `src/server_app.rs:661`) is a special forwarding producer that drains `SimOutbox` — a `Vec<(Target, ServerMessage)>` resource written by simulation systems that need to emit arbitrary-target messages (entity spawn/despawn, torpedo events, shield status, world setup, comms state, objective summaries). It is the only producer that sets `delivery` per message via `delivery_class_for_msg()` (`src/server_app.rs:683`), which classifies high-frequency state pushes as `Snapshot` and everything else as `Reliable`. The producer writes each entry directly via `world.write_message(OutboundMessage { ... })` and returns an empty `Vec`. Messages currently routed through `SimOutbox`:
 
 | Source system | Message(s) | Target | Location | Delivers as |
 |---|---|---|---|---|
-| `broadcast_shield_status` | `ShieldStatus` | `All` | `src/server_app.rs:1055` | Snapshot |
-| `broadcast_world_setup_on_start` | `WorldSetup` | `All` | `src/server_app.rs:1390` | Reliable |
-| `broadcast_comms_state` | `CommsState` | `Holding(StationId("comms"))` | `src/world/server.rs:1016` | Reliable |
-| `broadcast_objective_summary` | `ObjectiveSummary` | `Holding(StationId("captain"))` | `src/world/server.rs:1075` | Reliable |
+| `broadcast_shield_status` | `ShieldStatus` | `All` | `src/server_app.rs:1094` | Snapshot |
+| `broadcast_world_setup_on_start` | `WorldSetup` | `All` | `src/server_app.rs:1443` | Reliable |
+| `broadcast_comms_state` | `CommsState` | `Holding(StationId("comms"))` | `src/world/server.rs:1164` | Reliable |
+| `broadcast_objective_summary` | `ObjectiveSummary` | `Holding(StationId("captain"))` | `src/world/server.rs:1223` | Reliable |
 | Torpedo systems | `TorpedoLaunched` | `All` via `SimOutbox` | `src/console/weapons/server.rs` | Reliable |
 | `asteroid_spawn` / `update_asteroid_window` | `EntitySpawned` / `EntityDespawned` | `All` via `SimOutbox` | `asteroids/lifecycle.rs` | Reliable |
 | Phaser / damage systems | `PhaserFired`, `AsteroidDestroyed`, etc. | `All` via `SimOutbox` | `src/console/weapons/server.rs` | Reliable |
@@ -123,9 +123,9 @@ The `SimOutbox` producer (`sim_outbox_broadcaster`, `src/server_app.rs:642`) is 
 
 | Producer | Message(s) | Audience | Cadence | Registered in |
 |---|---|---|---|---|
-| `lobby_outbox_broadcaster` | Drain of `LobbyOutbox` (see below) | `All` (placeholder) | `OnEvent` | `lobby/server.rs:179` |
+| `lobby_outbox_broadcaster` | Drain of `LobbyOutbox` (see below) | `All` (placeholder) | `OnEvent` | `lobby/server.rs:712` |
 
-The `LobbyOutbox` producer (`lobby_outbox_broadcaster`, `lobby/server.rs:179`) parallels the `SimOutbox` pattern. It drains `LobbyOutbox` — written by `lobby_handler::process_message()` and `handle_disconnect` systems. Messages routed through `LobbyOutbox`:
+The `LobbyOutbox` producer (`lobby_outbox_broadcaster`, `lobby/server.rs:712`) parallels the `SimOutbox` pattern. It drains `LobbyOutbox` — written by `lobby_handler::process_message()` and `handle_disconnect` systems. Messages routed through `LobbyOutbox`:
 
 | ServerMessage | Target | Notes |
 |---|---|---|
@@ -138,7 +138,7 @@ The `LobbyOutbox` producer (`lobby_outbox_broadcaster`, `lobby/server.rs:179`) p
 
 ## Contract: OutboundMessage is written ONLY through the broadcaster
 
-`OutboundMessage` (`src/lobby/server.rs:66`) is the Bevy `Message` that carries a `(Target, ServerMessage, DeliveryClass)` triple to the JS bridge:
+`OutboundMessage` (`src/lobby/server.rs:96`) is the Bevy `Message` that carries a `(Target, ServerMessage, DeliveryClass)` triple to the JS bridge:
 
 ```rust
 pub struct OutboundMessage {
@@ -155,7 +155,7 @@ The rule is:
 All outbound traffic flows through one of two paths:
 
 1. **Broadcaster dispatch loop** — `src/core/broadcast/sim.rs:189` and `src/core/broadcast/lobby.rs:188` write messages returned by registered producers. Each producer closure is called inside a pre-resolved audience context; the dispatch loop writes the `OutboundMessage` with `delivery: DeliveryClass::Reliable` (the producers themselves don't set delivery).
-2. **Forwarding producer closures** — `src/server_app.rs:642` (`sim_outbox_broadcaster`) calls `delivery_class_for_msg()` (`src/server_app.rs:664`) to set per-message delivery, and `src/lobby/server.rs:511` (`drain_lobby_outbox`) hardcodes `DeliveryClass::Reliable` for all lobby messages.
+2. **Forwarding producer closures** — `src/server_app.rs:661` (`sim_outbox_broadcaster`) calls `delivery_class_for_msg()` (`src/server_app.rs:683`) to set per-message delivery, and `src/lobby/server.rs:696` (`drain_lobby_outbox`) hardcodes `DeliveryClass::Reliable` for all lobby messages.
 
 This means a codebase grep for `write_message.*OutboundMessage` should only hit files under `src/core/broadcast/`, `src/server_app.rs`, and `src/lobby/server.rs`.
 
@@ -163,10 +163,10 @@ This means a codebase grep for `write_message.*OutboundMessage` should only hit 
 
 The following Bevy systems still write to `SimOutbox` (not `OutboundMessage` directly — the contract holds) but use the old hand-written pattern (own gating + timer + audience resolution). They are candidates for future migration to direct `SimBroadcaster` registrations:
 
-- `broadcast_shield_status` (`src/server_app.rs:1055`)
-- `broadcast_world_setup_on_start` (`src/server_app.rs:1390`)
-- `broadcast_comms_state` (`src/world/server.rs:1016`)
-- `broadcast_objective_summary` (`src/world/server.rs:1075`)
+- `broadcast_shield_status` (`src/server_app.rs:1094`)
+- `broadcast_world_setup_on_start` (`src/server_app.rs:1443`)
+- `broadcast_comms_state` (`src/world/server.rs:1164`)
+- `broadcast_objective_summary` (`src/world/server.rs:1223`)
 
 Each could be replaced by a `SimBroadcaster` registration that produces the same `ServerMessage` at the right cadence, eliminating the hand-written gating and timer.
 
@@ -204,5 +204,5 @@ A sixth cache, `LastWeaponsUpdate` (`src/console/weapons/server.rs`), stays defi
 ## Registration points
 
 - `src/bridge.rs` & `src/server/bridge.rs` — `LobbyBroadcaster` / `LobbyOutboxPlugin` registered alongside `LobbyPlugin`.
-- `src/server_app.rs:326-332` — registers all six `SimBroadcaster` producers (`add_simulation_plugins` function, `SimSet` scheduling).
-- `src/lobby/server.rs:507` — `LobbyOutboxPlugin::build` registers `drain_lobby_outbox` after `process_lobby`.
+- `src/server_app.rs:346`–`:351` — `add_simulation_plugins` registers `weapons_update_broadcaster`, `sim_state_broadcaster`, `modifier_events_broadcaster`, and `sim_outbox_broadcaster`; `power_state_broadcaster` and `repair_state_broadcaster` register inside their own plugins (`src/ship/power.rs:201`, `src/console/repair/server.rs:134`).
+- `src/lobby/server.rs:690` — `LobbyOutboxPlugin::build` registers `drain_lobby_outbox` after `process_lobby`.

--- a/wiki/concepts/comms-panel.md
+++ b/wiki/concepts/comms-panel.md
@@ -115,7 +115,7 @@ message   = "...Stand by — patching you through to Dr. Myst now."
 ```
 
 Implementation: scheduled in `handle_hail` (`src/world/server.rs:719`) and
-`handle_ai_events` (`src/world/server.rs:1786`) by pushing a
+`tick_trigger_pipeline` (`src/world/server.rs:1786`) by pushing a
 `PendingFollowUp` onto `runtime.pending_follow_ups` whose `placeholder_id =
 None`. The `tick_pending_follow_ups` system evaluates each pending
 follow-up's `trigger` each tick against current world state (region
@@ -178,7 +178,7 @@ text = "Understood, Axiom Station. We are proceeding to your location."
 Implementation: the pure evaluator `follow_up_trigger_holds` in
 `src/world/server.rs` returns true when the condition is met (or
 already-true at queue time). `tick_pending_follow_ups` runs in
-`SimSet::Physics` (ordered `.before(handle_ai_events)` so it observes
+`SimSet::Physics` (ordered `.before(tick_trigger_pipeline)` so it observes
 `pending_world_events` before they are drained) and snapshots region
 membership + live UUIDs + flag store for the evaluator.
 

--- a/wiki/concepts/comms-panel.md
+++ b/wiki/concepts/comms-panel.md
@@ -114,10 +114,10 @@ message   = "...Stand by — patching you through to Dr. Myst now."
       message    = "If it fires at full charge..."
 ```
 
-Implementation: scheduled in `handle_hail` (`src/world/server.rs:719`) and
-`tick_trigger_pipeline` (`src/world/server.rs:1786`) by pushing a
-`PendingFollowUp` onto `runtime.pending_follow_ups` whose `placeholder_id =
-None`. The `tick_pending_follow_ups` system evaluates each pending
+Implementation: scheduled in `handle_hail` (`src/console/comms/server.rs:113`)
+and `inject_comms_templates` (`src/world/server.rs:1345`, the trigger-pipeline
+system that fires `[[comms]]` templates) by pushing a `PendingFollowUp` onto
+`runtime.pending_follow_ups` whose `placeholder_id = None`. The `tick_pending_follow_ups` system evaluates each pending
 follow-up's `trigger` each tick against current world state (region
 membership, flag store, live entity UUIDs) plus this tick's pending events;
 ready follow-ups are injected and replace any `...` placeholder.
@@ -177,10 +177,12 @@ text = "Understood, Axiom Station. We are proceeding to your location."
 
 Implementation: the pure evaluator `follow_up_trigger_holds` in
 `src/world/server.rs` returns true when the condition is met (or
-already-true at queue time). `tick_pending_follow_ups` runs in
-`SimSet::Physics` (ordered `.before(tick_trigger_pipeline)` so it observes
-`pending_world_events` before they are drained) and snapshots region
-membership + live UUIDs + flag store for the evaluator.
+already-true at queue time). `tick_pending_follow_ups` runs first in the
+chained `SimSet::Physics` trigger pipeline (`tick_pending_follow_ups` →
+`collect_world_events` → `inject_comms_templates` → `tick_trigger_pipeline`),
+so it observes `pending_world_events` before `collect_world_events` drains
+them into `WorldEventBuffer`, and snapshots region membership + live UUIDs +
+flag store for the evaluator.
 
 ### Delayed messages
 

--- a/wiki/concepts/comms-range.md
+++ b/wiki/concepts/comms-range.md
@@ -16,22 +16,22 @@ Range-gated hailing for the Comms console. Entities opt in via a `[comms].range 
 range = 500.0
 ```
 
-Parsed by `CommsConfig { range: f32 }` in `src/entities/config.rs:542`. Optional field on `EntityConfig`.
+Parsed by `CommsConfig { range: f32 }` in `src/entities/config.rs:1523`. Optional field on `EntityConfig`.
 
 ### ECS
 
-- `CommsRange(pub f32)` Component — `src/comms/component.rs`. Inserted by `entities/spawner.rs` (`src/entities/spawner.rs:198`) when `config.comms.is_some()`.
+- `CommsRange(pub f32)` Component — `src/comms/component.rs`. Inserted by `entities/spawner.rs` (`src/entities/spawner.rs:631`) when `config.comms.is_some()`.
 - Pure helper: `comms::in_range(distance, a, b) -> bool` returns `distance <= a.min(b)` and is false for NaN inputs. `src/comms/range.rs`.
 
 ### Wire
 
-- `CommsContact.in_range: bool` — `src/core/messages.rs:262`.
-- `CommsMessage.sender_in_range: bool` — `src/core/messages.rs:255`.
+- `CommsContact.in_range: bool` — `src/core/messages.rs:493`.
+- `CommsMessage.sender_in_range: bool` — `src/core/messages.rs:467`.
 - Both fields use `#[serde(default = "default_true")]` for backward-compat with older JSON payloads.
 
 ## Server flow
 
-`update_comms_range_flags` (`src/world/server.rs:759`) runs every tick in `SimSet::Broadcast` immediately before `broadcast_comms_state`:
+`update_comms_range_flags` (`src/world/server.rs:1064`) runs every tick in `SimSet::Broadcast` immediately before `broadcast_comms_state`:
 
 1. Reads the player `Ship` Transform + its `CommsRange`.
 2. Walks `Query<(&EntityUuid, &Transform, &CommsRange)>`, computing per-entity `in_range`.
@@ -39,9 +39,9 @@ Parsed by `CommsConfig { range: f32 }` in `src/entities/config.rs:542`. Optional
 4. Prunes flags for despawned entities; prunes contacts whose entity lost (or never had) a `CommsRange` component (this is what excludes `[[comms]]`-template entries without a `[comms]` block).
 5. Sets `needs_broadcast = true` on any flip so `CommsState` re-broadcasts even when the inbox is clean.
 
-`broadcast_comms_state` (`src/world/server.rs:875`) then stamps `m.sender_in_range` per message from `range_flags`; missing UUIDs default to `false` when `range_active == true`.
+`broadcast_comms_state` (`src/world/server.rs:1164`) then stamps `m.sender_in_range` per message from `range_flags`; missing UUIDs default to `false` when `range_active == true`.
 
-New `CommsMessage` instances are stamped at injection time via `current_sender_in_range(&runtime, &sender_uuid)` (`src/world/server.rs:60`) — belt-and-braces so the field is correct from the moment the message lands, not only after the next broadcast.
+New `CommsMessage` instances are stamped at injection time via `current_sender_in_range(&runtime, &sender_uuid)` (`src/console/comms/server.rs:97`) — belt-and-braces so the field is correct from the moment the message lands, not only after the next broadcast.
 
 ### `range_active` semantics
 
@@ -51,14 +51,14 @@ While `range_active == false` (lobby phase, pure-handler tests), range gating is
 
 ## Server enforcement
 
-`handle_hail` and `handle_respond_to_message` (`src/world/server.rs:548`, `:648`) both reject the message when `range_active == true` and the target/sender's `range_flags` entry is missing or `false`. This means a stale or malicious client cannot bypass the gate.
+`handle_hail` and `handle_respond_to_message` (`src/console/comms/server.rs:113`, `:235` — relocated from `src/world/server.rs` in #608) both reject the message when `range_active == true` and the target/sender's `range_flags` entry is missing or `false`. This means a stale or malicious client cannot bypass the gate.
 
 ## Client UI
 
 `src/console/comms/client.rs` `refresh_all_comms_ui`:
 
 - **Contacts strip** — out-of-range contacts are **hidden** (not greyed). Empty state shows "All contacts out of range".
-- **Inbox rows** — sticky: every message stays. When `!sender_in_range`, the row appends an alert-red `[OUT OF RANGE]` tag (colour `Color::srgb(1.0, 0.2, 0.267)`, matching `COLOR_ALERT_RED` from `src/server/viewscreen_border.rs:119`).
+- **Inbox rows** — sticky: every message stays. When `!sender_in_range`, the row appends an alert-red `[OUT OF RANGE]` tag (colour `Color::srgb(1.0, 0.2, 0.267)`).
 - **Chat panel** — when viewing a message whose sender is out of range, response buttons are replaced with a disabled label. `detect_comms_clicks` also rejects clicks on those buttons.
 
 ## Values today
@@ -84,5 +84,6 @@ Default world has ship at `(150, 0, 0)`, Starbase at `(500, 0, 0)` → distance 
 - `src/core/messages.rs`, `src/core/codec.rs`
 - `src/entities/config.rs`, `src/entities/spawner.rs`
 - `src/world/server.rs`
+- `src/console/comms/server.rs` (handle_hail / handle_respond_to_message / current_sender_in_range)
 - `src/console/comms/client.rs`, `src/client_comms.rs`
 - `assets/entities/player_ship.toml`, `station_outpost.toml`, `pirate_raider.toml`

--- a/wiki/concepts/objectives.md
+++ b/wiki/concepts/objectives.md
@@ -2,8 +2,8 @@
 title: Objectives
 type: concept
 tags: [world, objectives, ai, captain, gui]
-sources: [src/objectives.rs, src/world/server.rs, src/console/comms/server.rs, src/console/captain/server.rs, src/ai/core.rs, assets/worlds/combat_test.toml]
-updated: 2026-07-14
+sources: [src/objectives.rs, src/world/server.rs, src/world/dispatch.rs, src/console/comms/server.rs, src/console/captain/server.rs, src/ai/core.rs, assets/worlds/combat_test.toml]
+updated: 2026-07-16
 ---
 
 # Objectives

--- a/wiki/concepts/pasm-feature-capture-backlog.md
+++ b/wiki/concepts/pasm-feature-capture-backlog.md
@@ -3,7 +3,7 @@ title: PASM Feature Capture Backlog
 type: concept
 tags: [pasm, audit, architecture, game-design, backlog]
 sources: [pasm/spec, src/, gui/, assets/, wiki/concepts/pasm-runtime.md]
-updated: 2026-07-14
+updated: 2026-07-16
 ---
 
 # PASM Feature Capture Backlog
@@ -216,7 +216,7 @@ cleanup, additive world layers, and load/unload cleanup. Atomic authoring
 failure and cross-world name collision detection remain required proposed
 behavior.
 
-Sources: `src/world/config.rs`, `src/world/server.rs`, `assets/worlds/`.
+Sources: `src/world/config.rs`, `src/world/server.rs`, `src/world/dispatch.rs`, `assets/worlds/`.
 
 ## 18. Terrain, space entities, and streaming — Captured
 

--- a/wiki/concepts/world-plugin.md
+++ b/wiki/concepts/world-plugin.md
@@ -2,8 +2,8 @@
 title: WorldPlugin
 type: concept
 tags: [world, plugin, server]
-sources: [src/world/server.rs, src/world/config.rs, src/world/content.rs, src/entities/config_cache.rs, src/server/bridge.rs, src/server_app.rs, src/ai/server.rs, src/ai/faction.rs, assets/worlds/default.toml, assets/worlds/combat_test.toml, assets/factions/]
-updated: 2026-06-27
+sources: [src/world/server.rs, src/world/dispatch.rs, src/world/config.rs, src/world/content.rs, src/entities/config_cache.rs, src/server/bridge.rs, src/server_app.rs, src/ai/server.rs, src/ai/faction.rs, assets/worlds/default.toml, assets/worlds/combat_test.toml, assets/factions/]
+updated: 2026-07-16
 ---
 
 # WorldPlugin
@@ -38,26 +38,26 @@ At `Startup`, `insert_world_config_resource` copies the `WORLD_CONFIG` thread-lo
 
 ## Startup chain
 
-Run-once startup systems in `WorldPlugin`, chained in order (see `src/world/server.rs:152` for `insert_world_config_resource`):
+Run-once startup systems in `WorldPlugin`, chained in order (see `src/world/server.rs:391` for `insert_world_config_resource`):
 
-1. `insert_world_config_resource` (`src/world/server.rs:152`) — copies `WORLD_CONFIG` thread-local → `Res<WorldConfig>`
-2. `spawn_world_entities` — spawns all `[[entity]]` instances (asteroid-field and non-asteroid-field routed via `partition_immediate_entities`). Per-instance placement is resolved by `resolve_entity_position_with` (`src/world/config.rs:752`), which delegates to `TransformConfig::resolve` (`src/world/config.rs:48`) with precedence `relative_to+offset` > `anchor` > `position` > origin; `rotation` (XYZ Euler radians) and `scale` (default `[1, 1, 1]`) are applied from the same `transform = { ... }` table
+1. `insert_world_config_resource` (`src/world/server.rs:391`) — copies `WORLD_CONFIG` thread-local → `Res<WorldConfig>`
+2. `spawn_world_entities` — spawns all `[[entity]]` instances (asteroid-field and non-asteroid-field routed via `partition_immediate_entities`). Per-instance placement is resolved by `resolve_entity_position_with` (`src/world/config.rs:1734`), which delegates to `TransformConfig::resolve` (`src/world/config.rs:80`) with precedence `relative_to+offset` > `anchor` > `position` > origin; `rotation` (XYZ Euler radians) and `scale` (default `[1, 1, 1]`) are applied from the same `transform = { ... }` table
 3. `init_world_runtime` — initialises `WorldContentRuntime`, `CommsInboxRes`, `ObjectiveManagerRes` from the loaded `WorldConfig`
 4. `load_extra_worlds` — loads any additional worlds declared in `WorldConfig.extra_worlds`
 
 Production always loads a world TOML via the WASM bridge; when no `WorldConfig` is present (native unit tests only), the startup chain is a no-op and the app boots with an empty world.
 
-The viewscreen space backdrop is no longer spawned by `WorldPlugin`: `RendererPlugin` attaches a Bevy `Skybox` to `GameCamera` and loads `assets/skybox/phoenix_space_cubemap.png` via `prepare_space_skybox_cubemap` (`src/server/renderer.rs:231`), replacing the old runtime star-sphere field.
+The viewscreen space backdrop is no longer spawned by `WorldPlugin`: `RendererPlugin` attaches a Bevy `Skybox` to `GameCamera` and loads `assets/skybox/phoenix_space_cubemap.png` via `prepare_space_skybox_cubemap` (`src/server/renderer.rs:247`), replacing the old runtime star-sphere field.
 
-A separate `PostStartup` system, `spawn_world_ambient_light` (`src/server/renderer.rs:209`, registered at `src/server/renderer.rs:91`), reads the optional `[ambient_light]` block (`AmbientLightConfig` at `src/world/config.rs:115`) and inserts the `AmbientLight` resource. If absent, the renderer falls back to `Color::srgb(0.6, 0.55, 0.5)` at brightness `300.0`. Running it in `PostStartup` guarantees `insert_world_config_resource` has already executed.
+A separate `PostStartup` system, `spawn_world_ambient_light` (`src/server/renderer.rs:296`, registered at `src/server/renderer.rs:94`), reads the optional `[ambient_light]` block (`AmbientLightConfig` at `src/world/config.rs:113`) and inserts the `AmbientLight` resource. If absent, the renderer falls back to `Color::srgb(0.6, 0.55, 0.5)` at brightness `300.0`. Running it in `PostStartup` guarantees `insert_world_config_resource` has already executed.
 
 ## Update systems
 
-- `handle_hail` �?" Comms officer hails a contact; matching comms templates fire and inject messages
-- `handle_respond_to_message` �?" player picks a response, may emit follow-up dialogue, runs response actions
-- `handle_clear_comms` �?" drops orphaned and read messages
-- `broadcast_comms_state` / `broadcast_objective_summary` �?" push deltas on change
-- `tick_trigger_pipeline` �?" `WorldEvent` (attacked, destroyed, hailed, timer) drives trigger evaluation and the matching trigger actions
+- `handle_hail` — Comms officer hails a contact; matching comms templates fire and inject messages (lives in `src/console/comms/server.rs` since #608, still registered by `WorldPlugin`)
+- `handle_respond_to_message` — player picks a response, may emit follow-up dialogue, runs response actions (also in `src/console/comms/server.rs`)
+- `handle_clear_comms` — drops orphaned and read messages (also in `src/console/comms/server.rs`)
+- `broadcast_comms_state` / `broadcast_objective_summary` — push deltas on change
+- Trigger pipeline (issues #707–#719), chained in `SimSet::Physics`: `tick_pending_follow_ups` → `collect_world_events` (`src/world/server.rs:1271`, drains queued `WorldEvent`s — attacked, destroyed, hailed, timer, region, flag — into the per-tick `WorldEventBuffer` resource) → `inject_comms_templates` (`src/world/server.rs:1345`, fires matching `[[comms]]` templates) → `tick_trigger_pipeline` (`src/world/server.rs:1446`, evaluates `[[trigger]]` conditions and dispatches the matching trigger actions). `tick_delayed_actions` (`src/world/server.rs:2139`) runs after the pipeline, firing queued delayed actions through the same dispatch table
 
 ## Trigger conditions
 
@@ -78,14 +78,14 @@ Triggers in `[[trigger]]` blocks are matched against `WorldEvent`s by `evaluate_
 
 ## Trigger actions
 
-Action dispatch lives in two parallel `match` blocks: `tick_trigger_pipeline` (`src/world/server.rs:2001`) for actions fired by trigger conditions, and `handle_respond_to_message` (`src/world/server.rs:1073`) for actions attached to a comms response. The two sites must dispatch the **same** set of `TriggerAction` variants — a compile-time exhaustiveness test (`comms_response_dispatches_every_trigger_action_variant`, `src/world/server.rs:8721`) guards against drift.
+Trigger-fired actions are decided by a pure dispatch table in `src/world/dispatch.rs` (issues #710–#715): `dispatch_action` (`src/world/dispatch.rs:328`) covers every `TriggerAction` variant, routing grouped variants to five group functions (`dispatch_state_action`, `dispatch_entity_modifier_action`, `dispatch_world_flag_action`, `dispatch_destroy_entity`, `dispatch_spawn_entity` — spawn template loading goes through the injected `TemplateLoader` trait, `src/entities/loader.rs:70`). Each returns a `DispatchResult` that the applier `apply_dispatch_result` (`src/world/server.rs:1789`) turns into ECS mutations — the shared apply path for `tick_trigger_pipeline` (immediate actions) and `tick_delayed_actions` (delayed ones). Actions attached to a comms response still dispatch through a parallel inline `match` in `handle_respond_to_message` (`src/console/comms/server.rs:235`); the parity test `comms_response_dispatches_every_trigger_action_variant` (`src/console/comms/server.rs:1801`) guards against drift. Design rationale for the pipeline split lives in `pasm/spec/`.
 
 Authoring shape per action variant:
 
 | `type = ` | Required fields | Effect |
 |---|---|---|
 | `add_objective` / `complete_objective` / `fail_objective` | `id`, `text` (for add), `mandatory`, `targets` | Manage the objective list. |
-| `set_ai_state` | `entity`, `state`, optional `target` | Switch the named NPC's AI controller to a named behaviour state. |
+| `set_ai_state` | `entity`, `state`, optional `target` | Legacy no-op since doctrine-based AI (#572); logs a warning. |
 | `apply_modifier` / `remove_modifier` | `entity`, `tag`, `slot`, `bonus` | Float-valued ship stat modifier (`MaxSpeed`, `MaxYawRate`, `RadarRange`, `PhaserDamage`, `HullDamageTaken`, `RepairRate`). |
 | `apply_flag` / `remove_flag` | `entity`, `tag`, `kind` | Boolean entity flag (`CommsJammed`, `SensorBlind`). |
 | `apply_int_modifier` / `remove_int_modifier` | `entity`, `tag`, `slot`, `int_bonus` | Integer modifier (`RepairTeams`). |
@@ -94,7 +94,7 @@ Authoring shape per action variant:
 | `set_flag` / `clear_flag` / `increment_flag` / `set_flag_value` | `name`, plus `by` / `value` | World-flag mutators with `parent:` prefix walking for sub-world layers. |
 | `spawn_entity` | `template_path`, `name`, one of `anchor` / `position`, optional `rotation` / `scale` | Ad-hoc spawn, registered in `name_to_uuid`; layer-tracked for `unload_world` cleanup. |
 | `destroy_entity` | `entity` | Despawn by name; emits `AiEntityDestroyed` so chained `on_destroyed` triggers fire. |
-| `add_faction_enemy` / `remove_faction_enemy` | `faction`, `enemy` | Mutate the live `FactionRegistry` by faction `name` (resolved via `FactionRegistry::uuid_by_name`, `src/ai/faction.rs:64`). Idempotent. `is_enemy` is asymmetric — flipping a relationship in both directions requires two actions. `remove_faction_enemy` additionally re-validates every `AiControllerComponent.blackboard.target` (via `revalidate_ai_targets_after_faction_change`, `src/world/server.rs:2812`) so an in-progress engagement does not stick on a now-friendly target. |
+| `add_faction_enemy` / `remove_faction_enemy` | `faction`, `enemy` | Mutate the live `FactionRegistry` by faction `name` (resolved via `FactionRegistry::uuid_by_name`, `src/ai/faction.rs:68`). Idempotent. `is_enemy` is asymmetric — flipping a relationship in both directions requires two actions. `remove_faction_enemy` additionally re-validates every AI controller's remembered target (via `revalidate_ai_targets_after_faction_change`, `src/world/server.rs:2352`) so an in-progress engagement does not stick on a now-friendly target. |
 
 The editor mirrors this catalogue in `editor/action-schema.js`'s `ACTION_SCHEMA` map (plus a `covers every action type` regression test in `editor/tests/action-schema.test.js`).
 
@@ -106,9 +106,9 @@ The editor mirrors this catalogue in `editor/action-schema.js`'s `ACTION_SCHEMA`
 
 ### Factions
 
-Factions are loaded from `assets/factions/*.toml` (`FactionConfig` at `src/ai/faction.rs:17`) into a `FactionRegistry` (`src/ai/faction.rs:29`) exposed as `FactionRegistryResource` (`src/entities/config_cache.rs:588`). The asymmetric `is_enemy(a, b, registry)` predicate (`src/ai/faction.rs:72`) returns `true` only when `a`'s `enemies` list contains `b`; factionless entities are neutral to everyone. The AI's `enemy_in_range` transition (`src/ai/core.rs:879`) consults this predicate every tick when picking a target.
+Factions are loaded from `assets/factions/*.toml` (`FactionConfig` at `src/ai/faction.rs:17`) into a `FactionRegistry` (`src/ai/faction.rs:29`) exposed as `FactionRegistryResource` (`src/entities/config_cache.rs:478`). The asymmetric `is_enemy(a, b, registry)` predicate (`src/ai/faction.rs:116`) returns `true` only when `a`'s `enemies` list contains `b`; factionless entities are neutral to everyone. The AI's shared nearest-hostile scan (`find_nearest_hostile`, `src/ai/core.rs:691`) consults this predicate when picking a target.
 
-**Defaults:** Federation is hostile to Pirate only. Harrow defaults to neutral so non-combat worlds (Starbase Alpha in `default.toml`, Before the Fire in `before_the_fire.toml`) can reuse the same Harrow ship templates as ambient patrols. Combat scenarios (`combat_test.toml`) flip the Federation↔Harrow relationship hostile on `on_world_loaded` via two `add_faction_enemy` actions before the first wave's `enemy_in_range` tick.
+**Defaults:** Federation is hostile to Pirate only. Harrow defaults to neutral so non-combat worlds (Starbase Alpha in `default.toml`, Before the Fire in `before_the_fire.toml`) can reuse the same Harrow ship templates as ambient patrols. Combat scenarios (`combat_test.toml`) flip the Federation↔Harrow relationship hostile on `on_world_loaded` via two `add_faction_enemy` actions before the first wave's hostile scan.
 
 
 ## Resources
@@ -119,7 +119,8 @@ Factions are loaded from `assets/factions/*.toml` (`FactionConfig` at `src/ai/fa
 
 | File | Contents |
 |------|----------|
-| `src/world/server.rs` | `WorldPlugin`, `insert_world_config_resource`, `spawn_world_entities`, `init_world_runtime`, `load_extra_worlds`, comms/trigger/objective Bevy systems |
+| `src/world/server.rs` | `WorldPlugin`, `insert_world_config_resource`, `spawn_world_entities`, `init_world_runtime`, `load_extra_worlds`, the trigger-pipeline systems (`tick_pending_follow_ups`, `collect_world_events`, `inject_comms_templates`, `tick_trigger_pipeline`, `tick_delayed_actions`), the `apply_dispatch_result` applier, and broadcast systems |
+| `src/world/dispatch.rs` | Pure trigger-action decision layer: `dispatch_action` + five group functions returning `DispatchResult` for the applier |
 | `src/world/config.rs` | Pure (Bevy-free): `WorldConfig`, `parse_world`, `entity_template_paths`, `partition_immediate_entities` |
 | `src/world/content.rs` | Pure (Bevy-free) runtime types: `TriggerState`, `CommsTemplateState`, `ActiveDialogue`, `FiredTrigger`, `FiredCommsTemplate`, `WorldEvent`, `evaluate_triggers`, `evaluate_comms_templates`, `process_response`, `trigger_states_from_world`, `comms_template_states_from_world`. Schema types re-exported from `world/config` |
 | `src/entities/config_cache.rs` | WASM-side storage: `wasm_load_world` (the real loader), `WORLD_CONFIG` thread-local, `get_world_config` |

--- a/wiki/concepts/world-plugin.md
+++ b/wiki/concepts/world-plugin.md
@@ -57,7 +57,7 @@ A separate `PostStartup` system, `spawn_world_ambient_light` (`src/server/render
 - `handle_respond_to_message` �?" player picks a response, may emit follow-up dialogue, runs response actions
 - `handle_clear_comms` �?" drops orphaned and read messages
 - `broadcast_comms_state` / `broadcast_objective_summary` �?" push deltas on change
-- `handle_ai_events` �?" `WorldEvent` (attacked, destroyed, hailed, timer) drives trigger evaluation and the matching trigger actions
+- `tick_trigger_pipeline` �?" `WorldEvent` (attacked, destroyed, hailed, timer) drives trigger evaluation and the matching trigger actions
 
 ## Trigger conditions
 
@@ -78,7 +78,7 @@ Triggers in `[[trigger]]` blocks are matched against `WorldEvent`s by `evaluate_
 
 ## Trigger actions
 
-Action dispatch lives in two parallel `match` blocks: `handle_ai_events` (`src/world/server.rs:2001`) for actions fired by trigger conditions, and `handle_respond_to_message` (`src/world/server.rs:1073`) for actions attached to a comms response. The two sites must dispatch the **same** set of `TriggerAction` variants — a compile-time exhaustiveness test (`comms_response_dispatches_every_trigger_action_variant`, `src/world/server.rs:8721`) guards against drift.
+Action dispatch lives in two parallel `match` blocks: `tick_trigger_pipeline` (`src/world/server.rs:2001`) for actions fired by trigger conditions, and `handle_respond_to_message` (`src/world/server.rs:1073`) for actions attached to a comms response. The two sites must dispatch the **same** set of `TriggerAction` variants — a compile-time exhaustiveness test (`comms_response_dispatches_every_trigger_action_variant`, `src/world/server.rs:8721`) guards against drift.
 
 Authoring shape per action variant:
 

--- a/wiki/entities/editor.md
+++ b/wiki/entities/editor.md
@@ -3,7 +3,7 @@ title: Editor
 type: entity
 tags: [editor, tooling, scenario, entity, definitions, fsa, vitest]
 sources: [editor/app-v2.js, editor/scenario-mode.js, editor/mode-shell.js, editor/project-root.js, editor/save-flow.js, editor/invalidation-bus.js, editor/entity-cache.js, editor/validation.js, editor/action-schema.js, editor/world-toml.js, editor/entity-toml.js]
-updated: 2026-05-22
+updated: 2026-07-16
 ---
 
 # Editor
@@ -115,9 +115,9 @@ Per-file op-log undo/redo (Cmd/Ctrl+Z, Shift+Cmd/Ctrl+Z) capped at 100 ops per f
 
 The two PRD #350 runtime additions have **landed** in `src/world/config.rs` and `src/world/server.rs` (shipped via issue #352):
 
-- World TOML carries a top-level `extra_worlds: Vec<String>` field (`src/world/config.rs:240`). Paths listed here are auto-loaded additively at startup by `load_extra_worlds` (`src/world/server.rs:478`), which pushes one `WorldLayerChange::Load` per path onto `PendingWorldLayerChanges` so the same code path handles startup and trigger-fired loads.
-- Two new trigger actions: `TriggerAction::LoadWorld { path }` (`src/world/config.rs:278`) and `TriggerAction::UnloadWorld { path }` (`src/world/config.rs:280`). Parsed from TOML at `src/world/config.rs:422` / `:425`. Dispatched at `src/world/server.rs:1017` / `:1022`, where each fires queues a `WorldLayerChange` onto `PendingWorldLayerChanges`.
-- Additive-loading runtime state: `WorldLayerMap(HashMap<String, WorldRuntime>)` and `PendingWorldLayerChanges(Vec<WorldLayerChange>)` (`src/world/server.rs:83`–`:95`). `apply_world_layer_changes` (`src/world/server.rs:1146` doc comment, fn at `:1156`) drains the queue each frame, mutating `WorldLayerMap` and `WorldContentRuntime`. Runtime test coverage lives at `src/world/server.rs:2308`–`:2710`.
+- World TOML carries a top-level `extra_worlds: Vec<String>` field (`src/world/config.rs:577`). Paths listed here are auto-loaded additively at startup by `load_extra_worlds` (`src/world/server.rs:730`), which pushes one `WorldLayerChange::Load` per path onto `PendingWorldLayerChanges` so the same code path handles startup and trigger-fired loads.
+- Two new trigger actions: `TriggerAction::LoadWorld { path }` (`src/world/config.rs:704`) and `TriggerAction::UnloadWorld { path }` (`src/world/config.rs:708`). Parsed from TOML at `src/world/config.rs:1110` / `:1116`. Decided by the pure dispatch table (`dispatch_action`, `src/world/dispatch.rs:370` / `:377`); the applier `apply_dispatch_result` turns each into a `WorldLayerChange` queued onto `PendingWorldLayerChanges` (`src/world/server.rs:1952` / `:1958`).
+- Additive-loading runtime state: `WorldLayerMap(HashMap<String, WorldRuntime>)` and `PendingWorldLayerChanges(Vec<WorldLayerChange>)` (`src/world/server.rs:161` / `:168`). `apply_world_layer_changes` (`src/world/server.rs:2628`) drains the queue each frame, mutating `WorldLayerMap` and `WorldContentRuntime`. Runtime test coverage lives in the `src/world/server.rs` test module (e.g. `load_world_trigger_action_queues_pending_layer_change`, `src/world/server.rs:5596`).
 
 The **remaining editor-side work** for this PRD: the World Mode layer tree must show `load_world`-reachable worlds in a "triggerable worlds" section with a session-only load/unload toggle for preview, and the trigger action editor needs file-picker wiring for `load_world` / `unload_world` paths. These are still in flight. The runtime additive-loading state machine that PRD #341 collapsed is partially reintroduced for these two actions only, scoped narrowly to path-keyed load/unload.
 

--- a/wiki/entities/world-data.md
+++ b/wiki/entities/world-data.md
@@ -3,7 +3,7 @@ title: World Data
 type: entity
 tags: [world, scenario, transform, ambient_light, snapshot]
 sources: [src/world/config.rs, src/world/server.rs, src/server/renderer.rs, src/entities/config.rs, assets/worlds/default.toml]
-updated: 2026-07-14
+updated: 2026-07-16
 ---
 
 # World Data
@@ -21,7 +21,7 @@ seed = 42
 [global]
 seed = 42                                # optional global block; merged into WorldConfig
 
-[ambient_light]                          # src/world/config.rs:115
+[ambient_light]                          # src/world/config.rs:113
 color = [0.6, 0.55, 0.5]                 # sRGB; default Color::srgb(0.6, 0.55, 0.5)
 brightness = 300.0                       # default 300.0
 
@@ -29,7 +29,7 @@ brightness = 300.0                       # default 300.0
 name = "starbase"
 position = [0.0, 0.0, 0.0]               # normalised to [f32; 3]
 
-[[entity]]                               # src/world/config.rs:142
+[[entity]]                               # src/world/config.rs:276
 template = "assets/entities/station_axiom.toml"
 name = "axiom"                           # optional; overrides EntityConfig.name
 transform = { anchor = "starbase", offset = [10.0, 0.0, 0.0] }
@@ -51,9 +51,9 @@ Layered-world resolution is also proposed to grow beyond the current flag-only `
 
 World comms retain a sender reference for runtime resolution and carry separate sender display text. Every message still goes to the ship Comms system; world files do not define per-role message visibility.
 
-## TransformConfig (`src/world/config.rs:48`)
+## TransformConfig (`src/world/config.rs:46`)
 
-Single struct replaces the old flat `position` / `anchor` / `relative_to` / `offset` fields on `WorldEntity`. Resolution precedence (see `TransformConfig::resolve` and `resolve_entity_position_with` at `src/world/config.rs:752`):
+Single struct replaces the old flat `position` / `anchor` / `relative_to` / `offset` fields on `WorldEntity`. Resolution precedence (see `TransformConfig::resolve` at `src/world/config.rs:80` and `resolve_entity_position_with` at `src/world/config.rs:1734`):
 
 1. `relative_to = "<entity-name>" + offset` — resolved against a previously-spawned named entity
 2. `anchor = "<anchor-name>" + offset` — resolved against a `[[anchor]]`
@@ -64,14 +64,14 @@ Additional fields:
 - `rotation: [f32; 3]` — XYZ Euler radians, applied via `Quat::from_euler(EulerRot::XYZ, x, y, z)`. Default `[0, 0, 0]`.
 - `scale: [f32; 3]` — uniform-per-axis scale; default `[1, 1, 1]`. **Scale lives only on `TransformConfig`**; there is no `EntityConfig.scale` field.
 
-## AmbientLightConfig (`src/world/config.rs:115`)
+## AmbientLightConfig (`src/world/config.rs:113`)
 
-Optional top-level `[ambient_light]` block on the world TOML. Applied by the `spawn_world_ambient_light` system (`src/server/renderer.rs:209`, registered in `PostStartup` at `src/server/renderer.rs:91`) after `insert_world_config_resource` (`src/world/server.rs:152`) has placed the `WorldConfig` resource. If absent, the renderer falls back to `Color::srgb(0.6, 0.55, 0.5)` at brightness `300.0`.
+Optional top-level `[ambient_light]` block on the world TOML. Applied by the `spawn_world_ambient_light` system (`src/server/renderer.rs:296`, registered in `PostStartup` at `src/server/renderer.rs:94`) after `insert_world_config_resource` (`src/world/server.rs:391`) has placed the `WorldConfig` resource. If absent, the renderer falls back to `Color::srgb(0.6, 0.55, 0.5)` at brightness `300.0`.
 
 ## EntityConfig name + lights
 
-- `EntityConfig.name: Option<String>` (`src/entities/config.rs:640`) is a template-level default. A `WorldEntity.name` override beats it. Both are stored as the `EntityName` component (`src/entities/spawner.rs:22`).
-- `[[light]]` array-of-tables on `EntityConfig` (`src/entities/config.rs`) spawns Bevy lights as children of the entity. Each `LightConfig` has `kind = "point" | "directional"`, `colour: [f32; 3]`, `intensity: f32`, optional `range: f32`. Collected into the `Lights` component (`src/entities/spawner.rs:28`) and instantiated by `render_spawned_entities` (`src/server_app.rs:1147`).
+- `EntityConfig.name: Option<String>` (`src/entities/config.rs:1693`) is a template-level default. A `WorldEntity.name` override beats it. Both are stored as the `EntityName` component (`src/entities/spawner.rs:22`).
+- `[[light]]` array-of-tables on `EntityConfig` (`src/entities/config.rs`) spawns Bevy lights as children of the entity. Each `LightConfig` has `kind = "point" | "directional"`, `colour: [f32; 3]`, `intensity: f32`, optional `range: f32`. Collected into the `Lights` component (`src/entities/spawner.rs:28`) and instantiated by `render_spawned_entities` (`src/server_app.rs:2966`).
 - `[mesh].emissive: Option<f32>` on `EntityConfig` controls the StandardMaterial emissive multiplier (renderer default `0.4`; star templates use `2.0`).
 
 ## Lifecycle


### PR DESCRIPTION
## Summary

Implements issues #707-#719 (parent #685): decomposes the trigger-action dispatch that used to be duplicated inline in `handle_ai_events` and `dispatch_single_action` into a single pure, Bevy-free `dispatch_action` table (`src/world/dispatch.rs`), with five per-group functions, an injected `TemplateLoader` seam, and one shared applier. Also unifies the third dispatch site, `handle_respond_to_message` (comms responses), onto the same table, and carries the whole batch forward onto `main`'s independent `#702` (AiMemory deletion → `WeaponsTarget`).

- **#707** — audit: no test coupled to the old structure (no-op slice)
- **#708** — `DispatchResult`/`ActionCmd`/`dispatch_action` pure table, all 21 `TriggerAction` variants
- **#709** — `TemplateLoader` trait (`FsTemplateLoader`, `WasmTemplateLoader`)
- **#710** — wires the table into `handle_ai_events`/`tick_delayed_actions`; deletes the duplicated `dispatch_single_action`
- **#711-#715** — extract the table into five group functions (state/objectives, entity modifiers, world flags, destroy, spawn)
- **#716** — renames `handle_ai_events` → `tick_trigger_pipeline`; drops per-pass flag-store snapshots in favour of live borrows
- **#718** — `WorldEventBuffer` resource + `collect_world_events` system
- **#719** — extracts `inject_comms_templates` from the pipeline
- **#717** — PASM architecture slice (`pasm/spec/architecture/trigger-pipeline.yaml`) + edge-case pipeline tests
- Follow-on: unifies `handle_respond_to_message`'s inline dispatch onto the shared table, fixing two latent bugs (comms-spawned entities weren't registering `groups` or getting `EntityName` patched)
- Fixup: carries the batch onto `main`'s `#702`, which independently deleted `ShipAiMemory` in favour of `WeaponsTarget`

Net effect: ~1,700 duplicated lines collapsed into one pure table; test suite grew 2377 → 2501 across the batch, with the delayed-action path, comms-response path, and flag-store liveness covered for the first time.

## Test plan

- [x] `cargo test --lib` — 2501 passed
- [x] `cargo clippy --lib` — clean (3 pre-existing, flagged dead-code warnings from now-superseded comms helpers)
- [x] `cargo check --target wasm32-unknown-unknown` — clean
- [x] `uv run pasm validate` — clean (pre-existing unrelated helm-migration warnings only)
- [x] Every issue implemented via an explore → implement → independent-review loop; each slice reviewed by a fresh agent with no access to the implementer's reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)