### PR TITLE
Per-variant lobby handler refactor (#732-#734)

### DIFF
--- a/src/core/broadcast/lobby.rs
+++ b/src/core/broadcast/lobby.rs
@@ -113,7 +113,7 @@ impl Plugin for LobbyBroadcaster {
             app.insert_resource(LobbyBroadcastRegistry::new());
             app.add_systems(
                 Update,
-                dispatch_lobby_broadcasts.after(crate::lobby::process_lobby),
+                dispatch_lobby_broadcasts.after(crate::lobby::LobbySystemSet),
             );
         }
         let mut registry = app.world_mut().resource_mut::<LobbyBroadcastRegistry>();

--- a/src/lobby/handler.rs
+++ b/src/lobby/handler.rs
@@ -74,403 +74,564 @@ pub fn process_message(
     // Per-station active ratings to embed in Welcome for (re)connecting clients.
     station_ratings: &HashMap<StationId, String>,
 ) -> LobbyHandlerResult {
-    let mut outbound = Vec::new();
-    let mut new_phase: Option<GamePhase> = None;
-    let mut station_rating_update: Option<(StationId, String)> = None;
-    let mut countdown_action = None;
-
     match msg {
         ClientMessage::Identify {
             token: id_token,
             name,
-        } => {
-            // Clamp token to 64 chars and name to 32 chars (issue #602).
-            let id_token = id_token.chars().take(64).collect::<String>();
-            let name = name.chars().take(32).collect::<String>();
-            let is_reconnect = sessions.reconnect(&id_token).is_some();
-            let joined = if is_reconnect {
-                true
-            } else {
-                sessions.register(id_token.clone(), name.clone()).is_ok()
-            };
-
-            if joined {
-                // Reconnect-yield: if the player had a station and it is still
-                // unclaimed (no connected peer holds that station), restore
-                // their seat and broadcast the pre-disconnect rating.
-                let mut reconnect_station_update: Option<(StationId, String)> = None;
-                if is_reconnect && !ship_stations.stations.is_empty() {
-                    let station_id = sessions.station_for_token(&id_token).cloned();
-                    if let Some(ref sid) = station_id {
-                        let occupied = sessions.players().iter().any(|p| {
-                            p.connected && p.token != *id_token && p.station.as_ref() == Some(sid)
-                        });
-                        if !occupied {
-                            // Capture restore info for post-Welcome broadcasts.
-                            let last_rating = sessions
-                                .players()
-                                .iter()
-                                .find(|p| p.token == *id_token)
-                                .and_then(|p| p.last_rating.clone());
-                            let rating = last_rating.unwrap_or_else(|| "Std".to_string());
-                            reconnect_station_update = Some((sid.clone(), rating));
-                        } else {
-                            sessions.set_station(&id_token, None);
-                        }
-                    }
-                }
-
-                // Send Welcome and PlayerJoined
-                let player = sessions
-                    .players()
-                    .iter()
-                    .find(|p| p.token == *id_token)
-                    .cloned()
-                    .unwrap();
-                let state = derive_game_state(sessions, &phase, world);
-                outbound.push((
-                    Target::Token(id_token.clone()),
-                    ServerMessage::Welcome {
-                        state,
-                        ship_stations: ship_stations.clone(),
-                        ship_config: ship_config.clone(),
-                        station_ratings: station_ratings.clone(),
-                    },
-                ));
-                outbound.push((
-                    Target::AllExcept(id_token.clone()),
-                    ServerMessage::PlayerJoined { player },
-                ));
-
-                // Broadcast restored station + rating (after Welcome so client is ready).
-                if let Some((ref restored_sid, ref restored_rating)) = reconnect_station_update {
-                    if let Some(station_def) = ship_stations
-                        .stations
-                        .iter()
-                        .find(|sd| &sd.id == restored_sid)
-                    {
-                        outbound.push((
-                            Target::All,
-                            ServerMessage::StationAssigned {
-                                token: id_token.clone(),
-                                station: Some(station_def.name.clone()),
-                                station_id: Some(restored_sid.clone()),
-                            },
-                        ));
-                        outbound.push((
-                            Target::All,
-                            ServerMessage::RatingChanged {
-                                station_id: restored_sid.clone(),
-                                rating_name: restored_rating.clone(),
-                            },
-                        ));
-                        // Clear last_rating now that it has been applied.
-                        sessions.set_last_rating(&id_token, None);
-                        station_rating_update = reconnect_station_update;
-                    }
-                }
-
-                // Fixed roster per #495: no advance_on_join cascade.
-                // Existing players keep their stations when new players join.
-                // The new joiner selects a station manually via SelectStation.
-
-                if !ship_stations.stations.is_empty() {
-                    let connected_with_stations = sessions
-                        .players()
-                        .iter()
-                        .filter(|p| p.connected && p.station.is_some())
-                        .count() as u32;
-                    let player_has_station = sessions
-                        .players()
-                        .iter()
-                        .find(|p| p.token == *id_token)
-                        .map(|p| p.station.is_some())
-                        .unwrap_or(false);
-                    if !player_has_station {
-                        let capacity = ship_stations.stations.len() as u32;
-                        let at_capacity = connected_with_stations >= capacity;
-                        if at_capacity {
-                            outbound.push((
-                                Target::Token(id_token.clone()),
-                                ServerMessage::StationAssigned {
-                                    token: id_token.clone(),
-                                    station: None,
-                                    station_id: None,
-                                },
-                            ));
-                        }
-                    }
-                }
-            }
-        }
-        ClientMessage::SetName { name } => {
-            sessions.set_name(token, name.clone());
-            outbound.push((
-                Target::All,
-                ServerMessage::NameChanged {
-                    token: token.to_string(),
-                    name: name.clone(),
-                },
-            ));
-        }
+        } => handle_identify(
+            id_token,
+            name,
+            sessions,
+            phase,
+            world,
+            ship_stations,
+            ship_config,
+            station_ratings,
+        ),
+        ClientMessage::SetName { name } => handle_set_name(token, name, sessions),
         ClientMessage::SelectStation { station } => {
-            if ship_stations.stations.is_empty() {
-                // No station config loaded — silently ignore (no backward-compat toggle).
-                return LobbyHandlerResult {
-                    new_phase,
-                    outbound,
-                    station_rating_update: None,
-                    countdown_action: None,
-                };
-            }
-
-            let station_def = get_station(ship_stations, station);
-            let Some(station_def) = station_def else {
-                return LobbyHandlerResult {
-                    new_phase,
-                    outbound,
-                    station_rating_update: None,
-                    countdown_action: None,
-                };
-            };
-
-            // Check if sender already holds this station (own station → no-op)
-            let sender_station = sessions.station_for_token(token).cloned();
-            if sender_station.as_ref() == Some(&station_def.id) {
-                return LobbyHandlerResult {
-                    new_phase,
-                    outbound,
-                    station_rating_update: None,
-                    countdown_action: None,
-                };
-            }
-
-            // Check if occupied by another connected player
-            let occupied = sessions.players().iter().any(|p| {
-                p.connected && p.token != token && p.station.as_ref() == Some(&station_def.id)
-            });
-            if occupied {
-                return LobbyHandlerResult {
-                    new_phase,
-                    outbound,
-                    station_rating_update: None,
-                    countdown_action: None,
-                };
-            }
-
-            let mid_game_claim = phase == GamePhase::InProgress;
-            if mid_game_claim {
-                sessions.set_ready(token, false);
-                outbound.push((
-                    Target::All,
-                    ServerMessage::ReadyChanged {
-                        token: token.to_string(),
-                        ready: false,
-                    },
-                ));
-            }
-
-            // Release current station if held.
-            if let Some(previous_station) = sender_station {
-                sessions.set_station(token, None);
-                outbound.push((
-                    Target::All,
-                    ServerMessage::StationAssigned {
-                        token: token.to_string(),
-                        station: None,
-                        station_id: None,
-                    },
-                ));
-                if mid_game_claim {
-                    let backfill = rating::BACKFILL_RATING.to_string();
-                    outbound.push((
-                        Target::All,
-                        ServerMessage::RatingChanged {
-                            station_id: previous_station.clone(),
-                            rating_name: backfill.clone(),
-                        },
-                    ));
-                    station_rating_update = Some((previous_station, backfill));
-                } else {
-                    // Pre-InProgress: don't let a new claimant inherit a
-                    // stranger's lobby-chosen complexity toggle.
-                    sessions.clear_pending_rating(&previous_station);
-                    let base_rating = get_station(ship_stations, &previous_station.0)
-                        .and_then(|def| def.ratings.first().cloned())
-                        .unwrap_or_else(|| "Std".to_string());
-                    outbound.push((
-                        Target::All,
-                        ServerMessage::RatingChanged {
-                            station_id: previous_station,
-                            rating_name: base_rating,
-                        },
-                    ));
-                }
-            }
-
-            // Assign the station.
-            sessions.set_station(token, Some(station_def.id.clone()));
-            outbound.push((
-                Target::All,
-                ServerMessage::StationAssigned {
-                    token: token.to_string(),
-                    station: Some(station.clone()),
-                    station_id: Some(station_def.id.clone()),
-                },
-            ));
-
-            // Mid-game claim is a pending join: the player can read the station
-            // help and press Ready, but Backfill AI remains in control until
-            // SetReady(true) below applies the normal human rating.
+            handle_select_station(token, station, sessions, phase, ship_stations)
         }
         ClientMessage::ReleaseStation => {
-            let released_station = sessions.station_for_token(token).cloned();
-            sessions.set_station(token, None);
-            sessions.set_ready(token, false);
-            outbound.push((
-                Target::All,
-                ServerMessage::StationAssigned {
-                    token: token.to_string(),
-                    station: None,
-                    station_id: None,
-                },
-            ));
-            outbound.push((
-                Target::All,
-                ServerMessage::ReadyChanged {
-                    token: token.to_string(),
-                    ready: false,
-                },
-            ));
-            if phase == GamePhase::InProgress {
-                if let Some(station_id) = released_station {
-                    let backfill = rating::BACKFILL_RATING.to_string();
-                    outbound.push((
-                        Target::All,
-                        ServerMessage::RatingChanged {
-                            station_id: station_id.clone(),
-                            rating_name: backfill.clone(),
-                        },
-                    ));
-                    station_rating_update = Some((station_id, backfill));
-                }
-            } else if let Some(station_id) = released_station {
-                // Pre-InProgress: don't let a new claimant inherit a
-                // stranger's lobby-chosen complexity toggle.
-                sessions.clear_pending_rating(&station_id);
-                let base_rating = get_station(ship_stations, &station_id.0)
-                    .and_then(|def| def.ratings.first().cloned())
-                    .unwrap_or_else(|| "Std".to_string());
-                outbound.push((
-                    Target::All,
-                    ServerMessage::RatingChanged {
-                        station_id,
-                        rating_name: base_rating,
-                    },
-                ));
-            }
+            handle_release_station(token, sessions, phase, ship_stations)
         }
-        ClientMessage::SetReady { ready } => {
-            sessions.set_ready(token, *ready);
-            outbound.push((
-                Target::All,
-                ServerMessage::ReadyChanged {
-                    token: token.to_string(),
-                    ready: *ready,
-                },
-            ));
-            // Start 5-second countdown when all players ready up during Lobby.
-            // If someone unreadies during the countdown, cancel it.
-            if phase == GamePhase::Lobby {
-                if sessions.all_ready() {
-                    let pending_phase = if preload_complete || ship_stations.stations.is_empty() {
-                        GamePhase::InProgress
-                    } else {
-                        GamePhase::Loading
-                    };
-                    countdown_action = Some(CountdownAction::Start {
-                        secs: 5,
-                        pending_phase,
-                    });
-                } else if !*ready {
-                    // Unready while countdown may be active → cancel it.
-                    countdown_action = Some(CountdownAction::Cancel);
-                }
-            } else if phase == GamePhase::InProgress && *ready {
-                if let Some(station_id) = sessions.station_for_token(token).cloned() {
-                    let default_rating = "Std".to_string();
-                    outbound.push((
-                        Target::All,
-                        ServerMessage::RatingChanged {
-                            station_id: station_id.clone(),
-                            rating_name: default_rating.clone(),
-                        },
-                    ));
-                    station_rating_update = Some((station_id, default_rating));
-                }
-            }
-        }
-        ClientMessage::ReturnToLobby => {
-            if phase == GamePhase::GameOver {
-                sessions.reset_ready();
-                sessions.clear_all_pending_ratings();
-                for p in sessions.players() {
-                    outbound.push((
-                        Target::All,
-                        ServerMessage::ReadyChanged {
-                            token: p.token.clone(),
-                            ready: false,
-                        },
-                    ));
-                }
-                outbound.push((Target::All, ServerMessage::ReturnedToLobby));
-                new_phase = Some(GamePhase::Lobby);
-            }
-        }
-        ClientMessage::ConfirmScenario => {
-            if phase == GamePhase::Lobby {
-                outbound.push((Target::All, ServerMessage::ScenarioLoaded));
-            }
-        }
+        ClientMessage::SetReady { ready } => handle_set_ready(
+            token,
+            *ready,
+            sessions,
+            phase,
+            preload_complete,
+            ship_stations,
+        ),
+        ClientMessage::ReturnToLobby => handle_return_to_lobby(sessions, phase),
+        ClientMessage::ConfirmScenario => handle_confirm_scenario(phase),
         ClientMessage::SetStationRating { rating_name } => {
-            // InProgress is handled by `ship_plugin::handle_station_rating_change`
-            // against the live Ship entity. Pre-spawn (Lobby/Loading), there is
-            // no ControlSourceResolver to apply to yet, so record the choice as
-            // "pending" and apply it once the ship spawns
-            // (`spawn_game_start_entities`), while still broadcasting it live so
-            // other lobby clients see the toggle update immediately.
-            if phase == GamePhase::Lobby || phase == GamePhase::Loading {
-                if let Some(station_id) = sessions.station_for_token(token).cloned() {
-                    let valid = get_station(ship_stations, &station_id.0)
-                        .map(|def| def.ratings.iter().any(|r| r == rating_name))
-                        .unwrap_or(false);
-                    if valid {
-                        sessions.set_pending_rating(&station_id, rating_name.clone());
-                        outbound.push((
-                            Target::All,
-                            ServerMessage::RatingChanged {
-                                station_id,
-                                rating_name: rating_name.clone(),
-                            },
-                        ));
-                    }
-                }
-            }
+            handle_set_station_rating(token, rating_name, sessions, phase, ship_stations)
         }
-        // SetReady IS handled above (not a no-op in lobby).
+        // SetReady IS handled above (not a no-op in lobby). The seven runtime
+        // variants are no-ops here — they are handled by the console server
+        // plugins, not the lobby handler.
         ClientMessage::FirePhaser { .. }
         | ClientMessage::FireTorpedo { .. }
         | ClientMessage::ControlSystem { .. }
         | ClientMessage::SendCoordination { .. }
         | ClientMessage::LoadTube { .. }
-        | ClientMessage::UnloadTube { .. } => {}
+        | ClientMessage::UnloadTube { .. } => LobbyHandlerResult {
+            new_phase: None,
+            outbound: Vec::new(),
+            station_rating_update: None,
+            countdown_action: None,
+        },
+    }
+}
+
+/// Handle `Identify`: (re)register the session, restore a held station on
+/// reconnect-yield, and emit `Welcome` / `PlayerJoined` (and, at capacity, an
+/// empty `StationAssigned`). `token` from the envelope is ignored — the session
+/// token comes from the message body.
+fn handle_identify(
+    id_token: &str,
+    name: &str,
+    sessions: &mut SessionManager,
+    phase: GamePhase,
+    world: Option<&WorldData>,
+    ship_stations: &ShipStations,
+    ship_config: &ShipClientConfig,
+    station_ratings: &HashMap<StationId, String>,
+) -> LobbyHandlerResult {
+    let mut outbound = Vec::new();
+    let mut station_rating_update: Option<(StationId, String)> = None;
+
+    // Clamp token to 64 chars and name to 32 chars (issue #602).
+    let id_token = id_token.chars().take(64).collect::<String>();
+    let name = name.chars().take(32).collect::<String>();
+    let is_reconnect = sessions.reconnect(&id_token).is_some();
+    let joined = if is_reconnect {
+        true
+    } else {
+        sessions.register(id_token.clone(), name.clone()).is_ok()
+    };
+
+    if joined {
+        // Reconnect-yield: if the player had a station and it is still
+        // unclaimed (no connected peer holds that station), restore
+        // their seat and broadcast the pre-disconnect rating.
+        let mut reconnect_station_update: Option<(StationId, String)> = None;
+        if is_reconnect && !ship_stations.stations.is_empty() {
+            let station_id = sessions.station_for_token(&id_token).cloned();
+            if let Some(ref sid) = station_id {
+                let occupied = sessions.players().iter().any(|p| {
+                    p.connected && p.token != *id_token && p.station.as_ref() == Some(sid)
+                });
+                if !occupied {
+                    // Capture restore info for post-Welcome broadcasts.
+                    let last_rating = sessions
+                        .players()
+                        .iter()
+                        .find(|p| p.token == *id_token)
+                        .and_then(|p| p.last_rating.clone());
+                    let rating = last_rating.unwrap_or_else(|| "Std".to_string());
+                    reconnect_station_update = Some((sid.clone(), rating));
+                } else {
+                    sessions.set_station(&id_token, None);
+                }
+            }
+        }
+
+        // Send Welcome and PlayerJoined
+        let player = sessions
+            .players()
+            .iter()
+            .find(|p| p.token == *id_token)
+            .cloned()
+            .unwrap();
+        let state = derive_game_state(sessions, &phase, world);
+        outbound.push((
+            Target::Token(id_token.clone()),
+            ServerMessage::Welcome {
+                state,
+                ship_stations: ship_stations.clone(),
+                ship_config: ship_config.clone(),
+                station_ratings: station_ratings.clone(),
+            },
+        ));
+        outbound.push((
+            Target::AllExcept(id_token.clone()),
+            ServerMessage::PlayerJoined { player },
+        ));
+
+        // Broadcast restored station + rating (after Welcome so client is ready).
+        if let Some((ref restored_sid, ref restored_rating)) = reconnect_station_update {
+            if let Some(station_def) = ship_stations
+                .stations
+                .iter()
+                .find(|sd| &sd.id == restored_sid)
+            {
+                outbound.push((
+                    Target::All,
+                    ServerMessage::StationAssigned {
+                        token: id_token.clone(),
+                        station: Some(station_def.name.clone()),
+                        station_id: Some(restored_sid.clone()),
+                    },
+                ));
+                outbound.push((
+                    Target::All,
+                    ServerMessage::RatingChanged {
+                        station_id: restored_sid.clone(),
+                        rating_name: restored_rating.clone(),
+                    },
+                ));
+                // Clear last_rating now that it has been applied.
+                sessions.set_last_rating(&id_token, None);
+                station_rating_update = reconnect_station_update;
+            }
+        }
+
+        // Fixed roster per #495: no advance_on_join cascade.
+        // Existing players keep their stations when new players join.
+        // The new joiner selects a station manually via SelectStation.
+
+        if !ship_stations.stations.is_empty() {
+            let connected_with_stations = sessions
+                .players()
+                .iter()
+                .filter(|p| p.connected && p.station.is_some())
+                .count() as u32;
+            let player_has_station = sessions
+                .players()
+                .iter()
+                .find(|p| p.token == *id_token)
+                .map(|p| p.station.is_some())
+                .unwrap_or(false);
+            if !player_has_station {
+                let capacity = ship_stations.stations.len() as u32;
+                let at_capacity = connected_with_stations >= capacity;
+                if at_capacity {
+                    outbound.push((
+                        Target::Token(id_token.clone()),
+                        ServerMessage::StationAssigned {
+                            token: id_token.clone(),
+                            station: None,
+                            station_id: None,
+                        },
+                    ));
+                }
+            }
+        }
+    }
+
+    LobbyHandlerResult {
+        new_phase: None,
+        outbound,
+        station_rating_update,
+        countdown_action: None,
+    }
+}
+
+/// Handle `SetName`: update the session's display name and broadcast
+/// `NameChanged` to everyone.
+fn handle_set_name(token: &str, name: &str, sessions: &mut SessionManager) -> LobbyHandlerResult {
+    let mut outbound = Vec::new();
+    sessions.set_name(token, name.to_string());
+    outbound.push((
+        Target::All,
+        ServerMessage::NameChanged {
+            token: token.to_string(),
+            name: name.to_string(),
+        },
+    ));
+    LobbyHandlerResult {
+        new_phase: None,
+        outbound,
+        station_rating_update: None,
+        countdown_action: None,
+    }
+}
+
+/// Handle `SelectStation`: claim `station` for `token`, releasing any current
+/// station first. Silently ignores unknown stations, own-station re-selects,
+/// and stations occupied by another connected player.
+fn handle_select_station(
+    token: &str,
+    station: &str,
+    sessions: &mut SessionManager,
+    phase: GamePhase,
+    ship_stations: &ShipStations,
+) -> LobbyHandlerResult {
+    let mut outbound = Vec::new();
+    let mut station_rating_update: Option<(StationId, String)> = None;
+
+    if ship_stations.stations.is_empty() {
+        // No station config loaded — silently ignore (no backward-compat toggle).
+        return LobbyHandlerResult {
+            new_phase: None,
+            outbound,
+            station_rating_update: None,
+            countdown_action: None,
+        };
+    }
+
+    let station_def = get_station(ship_stations, station);
+    let Some(station_def) = station_def else {
+        return LobbyHandlerResult {
+            new_phase: None,
+            outbound,
+            station_rating_update: None,
+            countdown_action: None,
+        };
+    };
+
+    // Check if sender already holds this station (own station → no-op)
+    let sender_station = sessions.station_for_token(token).cloned();
+    if sender_station.as_ref() == Some(&station_def.id) {
+        return LobbyHandlerResult {
+            new_phase: None,
+            outbound,
+            station_rating_update: None,
+            countdown_action: None,
+        };
+    }
+
+    // Check if occupied by another connected player
+    let occupied = sessions
+        .players()
+        .iter()
+        .any(|p| p.connected && p.token != token && p.station.as_ref() == Some(&station_def.id));
+    if occupied {
+        return LobbyHandlerResult {
+            new_phase: None,
+            outbound,
+            station_rating_update: None,
+            countdown_action: None,
+        };
+    }
+
+    let mid_game_claim = phase == GamePhase::InProgress;
+    if mid_game_claim {
+        sessions.set_ready(token, false);
+        outbound.push((
+            Target::All,
+            ServerMessage::ReadyChanged {
+                token: token.to_string(),
+                ready: false,
+            },
+        ));
+    }
+
+    // Release current station if held.
+    if let Some(previous_station) = sender_station {
+        sessions.set_station(token, None);
+        outbound.push((
+            Target::All,
+            ServerMessage::StationAssigned {
+                token: token.to_string(),
+                station: None,
+                station_id: None,
+            },
+        ));
+        if mid_game_claim {
+            let backfill = rating::BACKFILL_RATING.to_string();
+            outbound.push((
+                Target::All,
+                ServerMessage::RatingChanged {
+                    station_id: previous_station.clone(),
+                    rating_name: backfill.clone(),
+                },
+            ));
+            station_rating_update = Some((previous_station, backfill));
+        } else {
+            // Pre-InProgress: don't let a new claimant inherit a
+            // stranger's lobby-chosen complexity toggle.
+            sessions.clear_pending_rating(&previous_station);
+            let base_rating = get_station(ship_stations, &previous_station.0)
+                .and_then(|def| def.ratings.first().cloned())
+                .unwrap_or_else(|| "Std".to_string());
+            outbound.push((
+                Target::All,
+                ServerMessage::RatingChanged {
+                    station_id: previous_station,
+                    rating_name: base_rating,
+                },
+            ));
+        }
+    }
+
+    // Assign the station.
+    sessions.set_station(token, Some(station_def.id.clone()));
+    outbound.push((
+        Target::All,
+        ServerMessage::StationAssigned {
+            token: token.to_string(),
+            station: Some(station.to_string()),
+            station_id: Some(station_def.id.clone()),
+        },
+    ));
+
+    // Mid-game claim is a pending join: the player can read the station
+    // help and press Ready, but Backfill AI remains in control until
+    // SetReady(true) applies the normal human rating.
+    LobbyHandlerResult {
+        new_phase: None,
+        outbound,
+        station_rating_update,
+        countdown_action: None,
+    }
+}
+
+/// Handle `ReleaseStation`: give up the caller's station, unready them, and
+/// reset the vacated station's rating (Backfill mid-game, base rating pre-game).
+fn handle_release_station(
+    token: &str,
+    sessions: &mut SessionManager,
+    phase: GamePhase,
+    ship_stations: &ShipStations,
+) -> LobbyHandlerResult {
+    let mut outbound = Vec::new();
+    let mut station_rating_update: Option<(StationId, String)> = None;
+
+    let released_station = sessions.station_for_token(token).cloned();
+    sessions.set_station(token, None);
+    sessions.set_ready(token, false);
+    outbound.push((
+        Target::All,
+        ServerMessage::StationAssigned {
+            token: token.to_string(),
+            station: None,
+            station_id: None,
+        },
+    ));
+    outbound.push((
+        Target::All,
+        ServerMessage::ReadyChanged {
+            token: token.to_string(),
+            ready: false,
+        },
+    ));
+    if phase == GamePhase::InProgress {
+        if let Some(station_id) = released_station {
+            let backfill = rating::BACKFILL_RATING.to_string();
+            outbound.push((
+                Target::All,
+                ServerMessage::RatingChanged {
+                    station_id: station_id.clone(),
+                    rating_name: backfill.clone(),
+                },
+            ));
+            station_rating_update = Some((station_id, backfill));
+        }
+    } else if let Some(station_id) = released_station {
+        // Pre-InProgress: don't let a new claimant inherit a
+        // stranger's lobby-chosen complexity toggle.
+        sessions.clear_pending_rating(&station_id);
+        let base_rating = get_station(ship_stations, &station_id.0)
+            .and_then(|def| def.ratings.first().cloned())
+            .unwrap_or_else(|| "Std".to_string());
+        outbound.push((
+            Target::All,
+            ServerMessage::RatingChanged {
+                station_id,
+                rating_name: base_rating,
+            },
+        ));
+    }
+
+    LobbyHandlerResult {
+        new_phase: None,
+        outbound,
+        station_rating_update,
+        countdown_action: None,
+    }
+}
+
+/// Handle `SetReady`: record the caller's ready flag and broadcast it. During
+/// Lobby, manage the 5-second start countdown; while InProgress, applying a
+/// ready flag restores the caller's station to the default human rating.
+fn handle_set_ready(
+    token: &str,
+    ready: bool,
+    sessions: &mut SessionManager,
+    phase: GamePhase,
+    preload_complete: bool,
+    ship_stations: &ShipStations,
+) -> LobbyHandlerResult {
+    let mut outbound = Vec::new();
+    let mut station_rating_update: Option<(StationId, String)> = None;
+    let mut countdown_action = None;
+
+    sessions.set_ready(token, ready);
+    outbound.push((
+        Target::All,
+        ServerMessage::ReadyChanged {
+            token: token.to_string(),
+            ready,
+        },
+    ));
+    // Start 5-second countdown when all players ready up during Lobby.
+    // If someone unreadies during the countdown, cancel it.
+    if phase == GamePhase::Lobby {
+        if sessions.all_ready() {
+            let pending_phase = if preload_complete || ship_stations.stations.is_empty() {
+                GamePhase::InProgress
+            } else {
+                GamePhase::Loading
+            };
+            countdown_action = Some(CountdownAction::Start {
+                secs: 5,
+                pending_phase,
+            });
+        } else if !ready {
+            // Unready while countdown may be active → cancel it.
+            countdown_action = Some(CountdownAction::Cancel);
+        }
+    } else if phase == GamePhase::InProgress && ready {
+        if let Some(station_id) = sessions.station_for_token(token).cloned() {
+            let default_rating = "Std".to_string();
+            outbound.push((
+                Target::All,
+                ServerMessage::RatingChanged {
+                    station_id: station_id.clone(),
+                    rating_name: default_rating.clone(),
+                },
+            ));
+            station_rating_update = Some((station_id, default_rating));
+        }
+    }
+
+    LobbyHandlerResult {
+        new_phase: None,
+        outbound,
+        station_rating_update,
+        countdown_action,
+    }
+}
+
+/// Handle `ReturnToLobby`: from `GameOver`, reset ready flags + pending ratings,
+/// broadcast the cleared readies and `ReturnedToLobby`, and transition to
+/// `Lobby`. No-op in any other phase.
+fn handle_return_to_lobby(sessions: &mut SessionManager, phase: GamePhase) -> LobbyHandlerResult {
+    let mut outbound = Vec::new();
+    let mut new_phase: Option<GamePhase> = None;
+
+    if phase == GamePhase::GameOver {
+        sessions.reset_ready();
+        sessions.clear_all_pending_ratings();
+        for p in sessions.players() {
+            outbound.push((
+                Target::All,
+                ServerMessage::ReadyChanged {
+                    token: p.token.clone(),
+                    ready: false,
+                },
+            ));
+        }
+        outbound.push((Target::All, ServerMessage::ReturnedToLobby));
+        new_phase = Some(GamePhase::Lobby);
     }
 
     LobbyHandlerResult {
         new_phase,
         outbound,
-        station_rating_update,
-        countdown_action,
+        station_rating_update: None,
+        countdown_action: None,
+    }
+}
+
+/// Handle `ConfirmScenario`: broadcast `ScenarioLoaded` during Lobby.
+fn handle_confirm_scenario(phase: GamePhase) -> LobbyHandlerResult {
+    let mut outbound = Vec::new();
+    if phase == GamePhase::Lobby {
+        outbound.push((Target::All, ServerMessage::ScenarioLoaded));
+    }
+    LobbyHandlerResult {
+        new_phase: None,
+        outbound,
+        station_rating_update: None,
+        countdown_action: None,
+    }
+}
+
+/// Handle `SetStationRating` in Lobby/Loading: validate the rating against the
+/// station def, record it as pending, and broadcast the live toggle. InProgress
+/// is handled by `ship_plugin::handle_station_rating_change` instead.
+fn handle_set_station_rating(
+    token: &str,
+    rating_name: &str,
+    sessions: &mut SessionManager,
+    phase: GamePhase,
+    ship_stations: &ShipStations,
+) -> LobbyHandlerResult {
+    let mut outbound = Vec::new();
+
+    // InProgress is handled by `ship_plugin::handle_station_rating_change`
+    // against the live Ship entity. Pre-spawn (Lobby/Loading), there is
+    // no ControlSourceResolver to apply to yet, so record the choice as
+    // "pending" and apply it once the ship spawns
+    // (`spawn_game_start_entities`), while still broadcasting it live so
+    // other lobby clients see the toggle update immediately.
+    if phase == GamePhase::Lobby || phase == GamePhase::Loading {
+        if let Some(station_id) = sessions.station_for_token(token).cloned() {
+            let valid = get_station(ship_stations, &station_id.0)
+                .map(|def| def.ratings.iter().any(|r| r == rating_name))
+                .unwrap_or(false);
+            if valid {
+                sessions.set_pending_rating(&station_id, rating_name.to_string());
+                outbound.push((
+                    Target::All,
+                    ServerMessage::RatingChanged {
+                        station_id,
+                        rating_name: rating_name.to_string(),
+                    },
+                ));
+            }
+        }
+    }
+
+    LobbyHandlerResult {
+        new_phase: None,
+        outbound,
+        station_rating_update: None,
+        countdown_action: None,
     }
 }
 

--- a/src/lobby/handler.rs
+++ b/src/lobby/handler.rs
@@ -292,7 +292,7 @@ fn handle_set_name(token: &str, name: &str, sessions: &mut SessionManager) -> Lo
 /// Handle `SelectStation`: claim `station` for `token`, releasing any current
 /// station first. Silently ignores unknown stations, own-station re-selects,
 /// and stations occupied by another connected player.
-fn handle_select_station(
+pub(crate) fn handle_select_station(
     token: &str,
     station: &str,
     sessions: &mut SessionManager,
@@ -421,7 +421,7 @@ fn handle_select_station(
 
 /// Handle `ReleaseStation`: give up the caller's station, unready them, and
 /// reset the vacated station's rating (Backfill mid-game, base rating pre-game).
-fn handle_release_station(
+pub(crate) fn handle_release_station(
     token: &str,
     sessions: &mut SessionManager,
     phase: GamePhase,
@@ -487,7 +487,7 @@ fn handle_release_station(
 /// Handle `SetReady`: record the caller's ready flag and broadcast it. During
 /// Lobby, manage the 5-second start countdown; while InProgress, applying a
 /// ready flag restores the caller's station to the default human rating.
-fn handle_set_ready(
+pub(crate) fn handle_set_ready(
     token: &str,
     ready: bool,
     sessions: &mut SessionManager,
@@ -594,7 +594,7 @@ fn handle_confirm_scenario(phase: GamePhase) -> LobbyHandlerResult {
 /// Handle `SetStationRating` in Lobby/Loading: validate the rating against the
 /// station def, record it as pending, and broadcast the live toggle. InProgress
 /// is handled by `ship_plugin::handle_station_rating_change` instead.
-fn handle_set_station_rating(
+pub(crate) fn handle_set_station_rating(
     token: &str,
     rating_name: &str,
     sessions: &mut SessionManager,

--- a/src/lobby/handler.rs
+++ b/src/lobby/handler.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::messages::{
-    ClientMessage, GamePhase, GameState, ServerMessage, ShipClientConfig, StationId, WorldData,
+    GamePhase, GameState, ServerMessage, ShipClientConfig, StationId, WorldData,
 };
 use crate::session::SessionManager;
 use crate::ship::config::ShipConfig;
@@ -32,7 +32,7 @@ pub struct LobbyHandlerResult {
     /// Station rating change the Bevy runtime must apply to the control-source
     /// resolver and active_ratings map (in addition to broadcasting it).
     /// Set by `process_disconnect_with_stations` (backfill) and the reconnect
-    /// branch of `process_message` (restore).
+    /// branch of `handle_identify` (restore).
     pub station_rating_update: Option<(StationId, String)>,
     /// Optional countdown action. When set, `new_phase` and the corresponding
     /// `GameStarted` outbound message must NOT be produced for this round —
@@ -58,78 +58,11 @@ pub fn derive_game_state(
     }
 }
 
-/// Handle one decoded `ClientMessage` from a peer. `token` is the session token
-/// for non-Identify messages; for Identify it is ignored (the session token is
-/// taken from the message body).
-pub fn process_message(
-    token: &str,
-    msg: &ClientMessage,
-    sessions: &mut SessionManager,
-    phase: GamePhase,
-    world: Option<&WorldData>,
-    ship_stations: &ShipStations,
-    ship_config: &ShipClientConfig,
-    // When `false`, `SetReady` transitions to `Loading` instead of `InProgress`.
-    preload_complete: bool,
-    // Per-station active ratings to embed in Welcome for (re)connecting clients.
-    station_ratings: &HashMap<StationId, String>,
-) -> LobbyHandlerResult {
-    match msg {
-        ClientMessage::Identify {
-            token: id_token,
-            name,
-        } => handle_identify(
-            id_token,
-            name,
-            sessions,
-            phase,
-            world,
-            ship_stations,
-            ship_config,
-            station_ratings,
-        ),
-        ClientMessage::SetName { name } => handle_set_name(token, name, sessions),
-        ClientMessage::SelectStation { station } => {
-            handle_select_station(token, station, sessions, phase, ship_stations)
-        }
-        ClientMessage::ReleaseStation => {
-            handle_release_station(token, sessions, phase, ship_stations)
-        }
-        ClientMessage::SetReady { ready } => handle_set_ready(
-            token,
-            *ready,
-            sessions,
-            phase,
-            preload_complete,
-            ship_stations,
-        ),
-        ClientMessage::ReturnToLobby => handle_return_to_lobby(sessions, phase),
-        ClientMessage::ConfirmScenario => handle_confirm_scenario(phase),
-        ClientMessage::SetStationRating { rating_name } => {
-            handle_set_station_rating(token, rating_name, sessions, phase, ship_stations)
-        }
-        // SetReady IS handled above (not a no-op in lobby). The seven runtime
-        // variants are no-ops here — they are handled by the console server
-        // plugins, not the lobby handler.
-        ClientMessage::FirePhaser { .. }
-        | ClientMessage::FireTorpedo { .. }
-        | ClientMessage::ControlSystem { .. }
-        | ClientMessage::SendCoordination { .. }
-        | ClientMessage::LoadTube { .. }
-        | ClientMessage::UnloadTube { .. } => LobbyHandlerResult {
-            new_phase: None,
-            outbound: Vec::new(),
-            station_rating_update: None,
-            countdown_action: None,
-        },
-    }
-}
-
 /// Handle `Identify`: (re)register the session, restore a held station on
 /// reconnect-yield, and emit `Welcome` / `PlayerJoined` (and, at capacity, an
 /// empty `StationAssigned`). `token` from the envelope is ignored — the session
 /// token comes from the message body.
-fn handle_identify(
+pub(crate) fn handle_identify(
     id_token: &str,
     name: &str,
     sessions: &mut SessionManager,
@@ -271,7 +204,11 @@ fn handle_identify(
 
 /// Handle `SetName`: update the session's display name and broadcast
 /// `NameChanged` to everyone.
-fn handle_set_name(token: &str, name: &str, sessions: &mut SessionManager) -> LobbyHandlerResult {
+pub(crate) fn handle_set_name(
+    token: &str,
+    name: &str,
+    sessions: &mut SessionManager,
+) -> LobbyHandlerResult {
     let mut outbound = Vec::new();
     sessions.set_name(token, name.to_string());
     outbound.push((
@@ -549,7 +486,10 @@ pub(crate) fn handle_set_ready(
 /// Handle `ReturnToLobby`: from `GameOver`, reset ready flags + pending ratings,
 /// broadcast the cleared readies and `ReturnedToLobby`, and transition to
 /// `Lobby`. No-op in any other phase.
-fn handle_return_to_lobby(sessions: &mut SessionManager, phase: GamePhase) -> LobbyHandlerResult {
+pub(crate) fn handle_return_to_lobby(
+    sessions: &mut SessionManager,
+    phase: GamePhase,
+) -> LobbyHandlerResult {
     let mut outbound = Vec::new();
     let mut new_phase: Option<GamePhase> = None;
 
@@ -578,7 +518,7 @@ fn handle_return_to_lobby(sessions: &mut SessionManager, phase: GamePhase) -> Lo
 }
 
 /// Handle `ConfirmScenario`: broadcast `ScenarioLoaded` during Lobby.
-fn handle_confirm_scenario(phase: GamePhase) -> LobbyHandlerResult {
+pub(crate) fn handle_confirm_scenario(phase: GamePhase) -> LobbyHandlerResult {
     let mut outbound = Vec::new();
     if phase == GamePhase::Lobby {
         outbound.push((Target::All, ServerMessage::ScenarioLoaded));
@@ -758,9 +698,76 @@ pub fn process_disconnect(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::messages::{EntitySnapshot, StationId, WorldData};
+    use crate::messages::{ClientMessage, EntitySnapshot, StationId, WorldData};
     use crate::ship::control_source::ControlSourceResolver;
     use crate::stations_config::{ShipStations, StationDef};
+
+    /// Test-only dispatch matching the former production `process_message`
+    /// signature. Production now routes each `ClientMessage` lobby variant
+    /// through its own per-variant Bevy system in `LobbySystemSet` (issue #734),
+    /// so this helper preserves the exact per-variant pure-fn calls the tests
+    /// exercise (including dropping `preload_complete` for the `Identify` arm,
+    /// which `handle_identify` never took).
+    fn dispatch(
+        token: &str,
+        msg: &ClientMessage,
+        sessions: &mut SessionManager,
+        phase: GamePhase,
+        world: Option<&WorldData>,
+        ship_stations: &ShipStations,
+        ship_config: &ShipClientConfig,
+        preload_complete: bool,
+        station_ratings: &HashMap<StationId, String>,
+    ) -> LobbyHandlerResult {
+        match msg {
+            ClientMessage::Identify {
+                token: id_token,
+                name,
+            } => handle_identify(
+                id_token,
+                name,
+                sessions,
+                phase,
+                world,
+                ship_stations,
+                ship_config,
+                station_ratings,
+            ),
+            ClientMessage::SetName { name } => handle_set_name(token, name, sessions),
+            ClientMessage::SelectStation { station } => {
+                handle_select_station(token, station, sessions, phase, ship_stations)
+            }
+            ClientMessage::ReleaseStation => {
+                handle_release_station(token, sessions, phase, ship_stations)
+            }
+            ClientMessage::SetReady { ready } => handle_set_ready(
+                token,
+                *ready,
+                sessions,
+                phase,
+                preload_complete,
+                ship_stations,
+            ),
+            ClientMessage::ReturnToLobby => handle_return_to_lobby(sessions, phase),
+            ClientMessage::ConfirmScenario => handle_confirm_scenario(phase),
+            ClientMessage::SetStationRating { rating_name } => {
+                handle_set_station_rating(token, rating_name, sessions, phase, ship_stations)
+            }
+            // The six runtime variants are no-ops in the lobby — handled by the
+            // console server plugins, not the lobby handler.
+            ClientMessage::FirePhaser { .. }
+            | ClientMessage::FireTorpedo { .. }
+            | ClientMessage::ControlSystem { .. }
+            | ClientMessage::SendCoordination { .. }
+            | ClientMessage::LoadTube { .. }
+            | ClientMessage::UnloadTube { .. } => LobbyHandlerResult {
+                new_phase: None,
+                outbound: Vec::new(),
+                station_rating_update: None,
+                countdown_action: None,
+            },
+        }
+    }
 
     fn sessions_with(token: &str, name: &str) -> SessionManager {
         let mut s = SessionManager::new();
@@ -845,7 +852,7 @@ max_level = 4
         phase: GamePhase,
         world: Option<&WorldData>,
     ) -> LobbyHandlerResult {
-        process_message(
+        dispatch(
             token,
             msg,
             sessions,
@@ -1199,7 +1206,7 @@ max_level = 4
         phase: GamePhase,
         world: Option<&WorldData>,
     ) -> LobbyHandlerResult {
-        process_message(
+        dispatch(
             token,
             msg,
             sessions,
@@ -1500,7 +1507,7 @@ max_level = 4
             StationId("captain".into()),
             rating::BACKFILL_RATING.to_string(),
         )]);
-        let result = process_message(
+        let result = dispatch(
             "t1",
             &ClientMessage::SelectStation {
                 station: "Captain".into(),
@@ -1580,7 +1587,7 @@ max_level = 4
             StationId("captain".into()),
             rating::BACKFILL_RATING.to_string(),
         )]);
-        let result = process_message(
+        let result = dispatch(
             "t1",
             &ClientMessage::SetReady { ready: true },
             &mut sessions,
@@ -1634,7 +1641,7 @@ max_level = 4
         let mut sessions = sessions_with("t1", "Alice");
         sessions.set_station("t1", Some(StationId("captain".into())));
         sessions.set_ready("t1", true);
-        let result = process_message(
+        let result = dispatch(
             "t1",
             &ClientMessage::ReleaseStation,
             &mut sessions,
@@ -1912,7 +1919,7 @@ max_level = 4
             token: "t1".into(),
             name: "Alice".into(),
         };
-        let _result = process_message(
+        let _result = dispatch(
             "t1",
             &msg,
             &mut sessions,
@@ -1963,7 +1970,7 @@ max_level = 4
             token: "t1".into(),
             name: "Alice".into(),
         };
-        let result = process_message(
+        let result = dispatch(
             "t1",
             &msg,
             &mut sessions,
@@ -2002,7 +2009,7 @@ max_level = 4
             token: "t2".into(),
             name: "Bob".into(),
         };
-        let result = process_message(
+        let result = dispatch(
             "t2",
             &msg,
             &mut sessions,
@@ -2252,7 +2259,7 @@ max_level = 4
             true,
         );
         // t1 reconnects via Identify
-        let reconnect_result = process_message(
+        let reconnect_result = dispatch(
             "t1",
             &ClientMessage::Identify {
                 token: "t1".into(),
@@ -2328,7 +2335,7 @@ max_level = 4
             None,
         );
         // t1 reconnects
-        let reconnect_result = process_message(
+        let reconnect_result = dispatch(
             "t1",
             &ClientMessage::Identify {
                 token: "t1".into(),

--- a/src/lobby/mod.rs
+++ b/src/lobby/mod.rs
@@ -6,6 +6,6 @@ pub mod stations_policy;
 
 pub use server::{
     lobby_outbox_broadcaster, process_lobby, CountdownTimer, GameStateCache, InboundMessage,
-    LobbyOutbox, LobbyPlugin, OutboundMessage, PlayerDisconnected, SelectedShipResource, Sessions,
-    Target, WorldResource,
+    LobbyOutbox, LobbyPlugin, LobbySystemSet, OutboundMessage, PlayerDisconnected,
+    SelectedShipResource, Sessions, Target, WorldResource,
 };

--- a/src/lobby/mod.rs
+++ b/src/lobby/mod.rs
@@ -5,7 +5,7 @@ pub mod stations_config;
 pub mod stations_policy;
 
 pub use server::{
-    lobby_outbox_broadcaster, process_lobby, CountdownTimer, GameStateCache, InboundMessage,
-    LobbyOutbox, LobbyPlugin, LobbySystemSet, OutboundMessage, PlayerDisconnected,
-    SelectedShipResource, Sessions, Target, WorldResource,
+    lobby_outbox_broadcaster, CountdownTimer, GameStateCache, InboundMessage, LobbyOutbox,
+    LobbyPlugin, LobbySystemSet, OutboundMessage, PlayerDisconnected, SelectedShipResource,
+    Sessions, Target, WorldResource,
 };

--- a/src/lobby/server.rs
+++ b/src/lobby/server.rs
@@ -101,9 +101,10 @@ pub struct OutboundMessage {
 
 // ── System set ─────────────────────────────────────────────────────────────
 
-/// Ordering anchor for every lobby `Update` system: the `handle_disconnect →
-/// process_lobby → tick_countdown → update_game_state_cache` chain plus the
-/// four per-variant station-management systems. Downstream systems that must
+/// Ordering anchor for every lobby `Update` system: `handle_disconnect` runs
+/// first, then the eight per-variant message systems (Identify / SetName /
+/// ReturnToLobby / ConfirmScenario plus the four station-management systems),
+/// then `tick_countdown → update_game_state_cache`. Downstream systems that must
 /// observe the post-lobby world state order themselves with
 /// `.after(LobbySystemSet)`.
 #[derive(bevy::ecs::schedule::SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
@@ -134,44 +135,73 @@ impl Plugin for LobbyPlugin {
             .add_message::<OutboundMessage>()
             .add_message::<PlayerDisconnected>()
             .add_systems(Startup, update_session_with_config)
-            // Order matters: `handle_disconnect` must run before `process_lobby`
-            // so that when a stale disconnect and the reconnect `Identify` land
-            // in the same frame (a browser refresh), the seat is vacated+saved
+            // Ordering scaffold (replaces the former monolithic `process_lobby`
+            // chain). `handle_disconnect` must run before the per-variant message
+            // systems so that when a stale disconnect and the reconnect `Identify`
+            // land in the same frame (a browser refresh), the seat is vacated+saved
             // first and then restored — not the reverse, which would leave the
-            // player marked disconnected with their seat cleared.
-            // `tick_countdown` runs after processing messages but before the
-            // outbox drain so countdown broadcasts reach the outbound bus.
+            // player marked disconnected with their seat cleared. `tick_countdown`
+            // runs after the message systems (but before the outbox drain) so
+            // countdown broadcasts reach the outbound bus.
             .add_systems(
                 Update,
-                (
-                    handle_disconnect,
-                    process_lobby,
-                    tick_countdown,
-                    update_game_state_cache,
-                )
+                (handle_disconnect, tick_countdown, update_game_state_cache)
                     .chain()
                     .in_set(LobbySystemSet),
             )
-            // Per-variant station-management systems (issue #733). Each owns
-            // exactly one ClientMessage variant, reading it via its own
-            // `MessageReader` cursor; `process_lobby` no longer processes these
-            // four variants. All four gate on Lobby/Loading/InProgress so
-            // players can claim/release stations and toggle ratings both in the
-            // lobby and mid-game.
+            // Per-variant message systems (issues #733 + #734). Each owns exactly
+            // one ClientMessage variant, reading it via its own `MessageReader`
+            // cursor. They replace the monolithic `process_lobby`/`process_message`
+            // dispatch. All run after `handle_disconnect` and before
+            // `tick_countdown`. They carry different phase gates, so they are
+            // registered per matching gate:
+            //
+            // Identify + the four station systems gate on
+            // Lobby/Loading/InProgress (claim/release/toggle + mid-game reconnect).
             .add_systems(
                 Update,
                 (
+                    handle_identify_system,
                     handle_select_station_system,
                     handle_release_station_system,
                     handle_set_ready_system,
                     handle_set_station_rating_system,
                 )
                     .in_set(LobbySystemSet)
+                    .after(handle_disconnect)
+                    .before(tick_countdown)
                     .run_if(
                         in_state(GamePhase::Lobby)
                             .or(in_state(GamePhase::Loading))
                             .or(in_state(GamePhase::InProgress)),
                     ),
+            )
+            // SetName gates on Lobby/Loading (rename before the game starts).
+            .add_systems(
+                Update,
+                handle_set_name_system
+                    .in_set(LobbySystemSet)
+                    .after(handle_disconnect)
+                    .before(tick_countdown)
+                    .run_if(in_state(GamePhase::Lobby).or(in_state(GamePhase::Loading))),
+            )
+            // ReturnToLobby gates on GameOver (the game-over screen's button).
+            .add_systems(
+                Update,
+                handle_return_to_lobby_system
+                    .in_set(LobbySystemSet)
+                    .after(handle_disconnect)
+                    .before(tick_countdown)
+                    .run_if(in_state(GamePhase::GameOver)),
+            )
+            // ConfirmScenario gates on Lobby (scenario picker confirmation).
+            .add_systems(
+                Update,
+                handle_confirm_scenario_system
+                    .in_set(LobbySystemSet)
+                    .after(handle_disconnect)
+                    .before(tick_countdown)
+                    .run_if(in_state(GamePhase::Lobby)),
             );
     }
 }
@@ -390,7 +420,15 @@ pub fn update_game_state_cache(
 
 // ── Systems ────────────────────────────────────────────────────────────────
 
-pub fn process_lobby(
+/// Per-variant system for `ClientMessage::Identify` (issue #734) — the reconnect
+/// handshake. Gated on Lobby/Loading/InProgress so a browser refresh mid-game
+/// still receives its `Welcome` and has its seat restored. Every parameter is
+/// sourced exactly as the former `process_lobby` Identify path did:
+/// `world` from `WorldResource`, `ship_stations` with a `default()` fallback,
+/// `ship_config` from `ShipClientConfigResource`, and the ratings SNAPSHOT from
+/// either `active_ratings` (ship present) or `pending_ratings()` (pre-spawn).
+/// `handle_identify` takes no `preload_complete` (only `SetReady` needed it).
+pub fn handle_identify_system(
     mut inbound: MessageReader<InboundMessage>,
     mut sessions: ResMut<Sessions>,
     state: Res<State<GamePhase>>,
@@ -399,7 +437,6 @@ pub fn process_lobby(
     world: Option<Res<WorldResource>>,
     ship_stations: Option<Res<ShipStations>>,
     ship_client_config: Res<ShipClientConfigResource>,
-    preload: Option<Res<crate::server::asset_preload::AssetPreloadResource>>,
     mut ship_query: Query<
         (
             &ShipConfigComponent,
@@ -410,102 +447,36 @@ pub fn process_lobby(
     >,
     mut countdown: Option<ResMut<CountdownTimer>>,
 ) {
-    // During the Lobby phase this system owns the inbound queue and handles
-    // every message type. Outside the lobby the simulation systems own it, so
-    // here we handle *only* the reconnect handshake (`Identify`) — a browser
-    // refresh mid-game must still receive its `Welcome` and have its seat
-    // restored. Additionally, station management messages (`SelectStation`,
-    // `ReleaseStation`, `SetReady`) are allowed during `InProgress` so players
-    // can claim vacated stations mid-game and press Ready to hand control back
-    // from Backfill AI — `SetReady`'s InProgress branch in
-    // `lobby_handler::process_message` is unreachable without this, since it's
-    // the only place that handles that message. `ReturnToLobby` is allowed so
-    // the GameOver screen's button works even though GameOver isn't `accepts_all`.
-    // All other message types are left for the in-game systems.
-    // (Bevy `MessageReader`s have independent cursors, so reading here never
-    // hides messages from those systems.)
-    //
-    // During `Loading` the lobby system also handles inbound messages (reconnect,
-    // Identify, etc.) while the asset pre-cache runs.
-    let accepts_all = state.get() == &GamePhase::Lobby || state.get() == &GamePhase::Loading;
     let default_stations = ShipStations::default();
     let stations = ship_stations
         .as_ref()
         .map(|s| s.as_ref())
         .unwrap_or(&default_stations);
     let world_data = world.as_ref().map(|w| &w.0);
-    // Preload gate: only Engage when the asset pre-cache has finished.
-    // - If the resource is missing entirely (test app, native build that
-    //   hasn't run `begin_asset_preload`), treat as complete.
-    // - If the resource exists but `!started`, treat as complete too — the
-    //   preload system runs every `Update` and may not have observed the
-    //   lobby state yet on the first frame. This avoids a deadlock where
-    //   `process_lobby` would refuse Engage forever waiting for a system
-    //   that never runs.
-    // - In Playwright automation mode the renderer plugins are skipped
-    //   (MinimalPlugins), and asset preloading can never complete because
-    //   the renderer asset pipeline isn't available. Treat preload as
-    //   complete unconditionally in this environment.
-    // - Otherwise gate on `preload.complete`, which is set by
-    //   `poll_asset_preload` once all icons, sidecars, sub-worlds, and GLBs
-    //   reach a terminal LoadState (Loaded or Failed).
-    let preload_complete = if crate::debug_overlay::is_playwright_automation() {
-        true
-    } else {
-        preload
-            .as_ref()
-            .map(|p| !p.started || p.complete)
-            .unwrap_or(true)
-    };
-    // Collect all messages first to avoid borrow conflicts with ship_query.
-    //
-    // The four station-management variants (SelectStation, ReleaseStation,
-    // SetReady, SetStationRating) are owned exclusively by the per-variant
-    // systems (`handle_select_station_system` et al., issue #733) — they must
-    // never be processed here, in any phase, or they would be double-read (this
-    // system and the per-variant system have independent `MessageReader`
-    // cursors). `process_lobby` retains Identify (reconnect handshake) plus, in
-    // Lobby/Loading (`accepts_all`), SetName / ConfirmScenario / the runtime
-    // no-op catch-all, and ReturnToLobby in every phase (GameOver's button).
-    let events: Vec<_> = inbound
-        .read()
-        .filter(|ev| {
-            if matches!(
-                ev.msg,
-                ClientMessage::SelectStation { .. }
-                    | ClientMessage::ReleaseStation
-                    | ClientMessage::SetReady { .. }
-                    | ClientMessage::SetStationRating { .. }
-            ) {
-                return false;
-            }
-            accepts_all
-                || matches!(ev.msg, ClientMessage::Identify { .. })
-                || matches!(ev.msg, ClientMessage::ReturnToLobby)
-        })
-        .cloned()
-        .collect();
+    let phase = state.get().clone();
+    let events: Vec<_> = inbound.read().cloned().collect();
     for ev in events {
-        if let Ok((ship_config, mut control_sources, mut active_ratings)) = ship_query.single_mut()
-        {
+        let ClientMessage::Identify { token, name } = &ev.msg else {
+            continue;
+        };
+        if let Ok((cfg, mut cs, mut active_ratings)) = ship_query.single_mut() {
             let ratings_snapshot = active_ratings.0.clone();
-            let result = lobby_handler::process_message(
-                &ev.token,
-                &ev.msg,
+            let result = lobby_handler::handle_identify(
+                token,
+                name,
                 &mut sessions.0,
-                state.get().clone(),
+                phase.clone(),
                 world_data,
                 stations,
                 &ship_client_config.0,
-                preload_complete,
                 &ratings_snapshot,
             );
             apply_result(
                 result,
                 &mut outbox,
                 &mut next_state,
-                Some(ship_config),
-                Some(&mut control_sources),
+                Some(cfg),
+                Some(&mut cs),
                 &mut active_ratings,
                 countdown.as_deref_mut(),
             );
@@ -514,17 +485,171 @@ pub fn process_lobby(
             // ratings players have picked in the lobby so far, so (re)joining
             // clients' Welcome reflects current toggle state.
             let pending_ratings = sessions.0.pending_ratings().clone();
-            let result = lobby_handler::process_message(
-                &ev.token,
-                &ev.msg,
+            let result = lobby_handler::handle_identify(
+                token,
+                name,
                 &mut sessions.0,
-                state.get().clone(),
+                phase.clone(),
                 world_data,
                 stations,
                 &ship_client_config.0,
-                preload_complete,
                 &pending_ratings,
             );
+            let mut fallback_ratings = ActiveStationRatings::default();
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                None,
+                None,
+                &mut fallback_ratings,
+                countdown.as_deref_mut(),
+            );
+        }
+    }
+}
+
+/// Per-variant system for `ClientMessage::SetName` (issue #734). Gated on
+/// Lobby/Loading. The result only carries outbound (a `NameChanged` broadcast),
+/// but the dual-path `apply_result` call mirrors the other systems for
+/// consistency.
+pub fn handle_set_name_system(
+    mut inbound: MessageReader<InboundMessage>,
+    mut sessions: ResMut<Sessions>,
+    mut next_state: ResMut<NextState<GamePhase>>,
+    mut outbox: ResMut<LobbyOutbox>,
+    mut ship_query: Query<
+        (
+            &ShipConfigComponent,
+            &mut ShipSystemControlSources,
+            &mut ActiveStationRatings,
+        ),
+        With<crate::server_app::LocalShip>,
+    >,
+    mut countdown: Option<ResMut<CountdownTimer>>,
+) {
+    let events: Vec<_> = inbound.read().cloned().collect();
+    for ev in events {
+        let ClientMessage::SetName { name } = &ev.msg else {
+            continue;
+        };
+        if let Ok((cfg, mut cs, mut active_ratings)) = ship_query.single_mut() {
+            let result = lobby_handler::handle_set_name(&ev.token, name, &mut sessions.0);
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                Some(cfg),
+                Some(&mut cs),
+                &mut active_ratings,
+                countdown.as_deref_mut(),
+            );
+        } else {
+            let result = lobby_handler::handle_set_name(&ev.token, name, &mut sessions.0);
+            let mut fallback_ratings = ActiveStationRatings::default();
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                None,
+                None,
+                &mut fallback_ratings,
+                countdown.as_deref_mut(),
+            );
+        }
+    }
+}
+
+/// Per-variant system for `ClientMessage::ReturnToLobby` (issue #734). Gated on
+/// GameOver — the game-over screen's "return to lobby" button. `apply_result`
+/// routes the phase transition back to `Lobby` plus the cleared-ready / returned
+/// broadcasts.
+pub fn handle_return_to_lobby_system(
+    mut inbound: MessageReader<InboundMessage>,
+    mut sessions: ResMut<Sessions>,
+    state: Res<State<GamePhase>>,
+    mut next_state: ResMut<NextState<GamePhase>>,
+    mut outbox: ResMut<LobbyOutbox>,
+    mut ship_query: Query<
+        (
+            &ShipConfigComponent,
+            &mut ShipSystemControlSources,
+            &mut ActiveStationRatings,
+        ),
+        With<crate::server_app::LocalShip>,
+    >,
+    mut countdown: Option<ResMut<CountdownTimer>>,
+) {
+    let phase = state.get().clone();
+    let events: Vec<_> = inbound.read().cloned().collect();
+    for ev in events {
+        let ClientMessage::ReturnToLobby = &ev.msg else {
+            continue;
+        };
+        if let Ok((cfg, mut cs, mut active_ratings)) = ship_query.single_mut() {
+            let result = lobby_handler::handle_return_to_lobby(&mut sessions.0, phase.clone());
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                Some(cfg),
+                Some(&mut cs),
+                &mut active_ratings,
+                countdown.as_deref_mut(),
+            );
+        } else {
+            let result = lobby_handler::handle_return_to_lobby(&mut sessions.0, phase.clone());
+            let mut fallback_ratings = ActiveStationRatings::default();
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                None,
+                None,
+                &mut fallback_ratings,
+                countdown.as_deref_mut(),
+            );
+        }
+    }
+}
+
+/// Per-variant system for `ClientMessage::ConfirmScenario` (issue #734). Gated
+/// on Lobby. Needs almost nothing, but still routes its outbound
+/// (`ScenarioLoaded`) through `apply_result`.
+pub fn handle_confirm_scenario_system(
+    mut inbound: MessageReader<InboundMessage>,
+    state: Res<State<GamePhase>>,
+    mut next_state: ResMut<NextState<GamePhase>>,
+    mut outbox: ResMut<LobbyOutbox>,
+    mut ship_query: Query<
+        (
+            &ShipConfigComponent,
+            &mut ShipSystemControlSources,
+            &mut ActiveStationRatings,
+        ),
+        With<crate::server_app::LocalShip>,
+    >,
+    mut countdown: Option<ResMut<CountdownTimer>>,
+) {
+    let phase = state.get().clone();
+    let events: Vec<_> = inbound.read().cloned().collect();
+    for ev in events {
+        let ClientMessage::ConfirmScenario = &ev.msg else {
+            continue;
+        };
+        if let Ok((cfg, mut cs, mut active_ratings)) = ship_query.single_mut() {
+            let result = lobby_handler::handle_confirm_scenario(phase.clone());
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                Some(cfg),
+                Some(&mut cs),
+                &mut active_ratings,
+                countdown.as_deref_mut(),
+            );
+        } else {
+            let result = lobby_handler::handle_confirm_scenario(phase.clone());
             let mut fallback_ratings = ActiveStationRatings::default();
             apply_result(
                 result,
@@ -542,8 +667,9 @@ pub fn process_lobby(
 /// Per-variant system for `ClientMessage::SelectStation` (issue #733).
 /// Reads its variant off the inbound bus with its own cursor, calls the pure
 /// `lobby_handler::handle_select_station`, then applies the result to Bevy
-/// resources via `apply_result` — mirroring `process_lobby`'s dual-path
-/// (real ship entity vs. pre-spawn fallback) handling.
+/// resources via `apply_result` — using the same dual-path
+/// (real ship entity vs. pre-spawn fallback) handling as the other lobby
+/// message systems.
 pub fn handle_select_station_system(
     mut inbound: MessageReader<InboundMessage>,
     mut sessions: ResMut<Sessions>,
@@ -702,7 +828,7 @@ pub fn handle_set_ready_system(
         .map(|s| s.as_ref())
         .unwrap_or(&default_stations);
     let phase = state.get().clone();
-    // Preload gate: same logic as process_lobby / handle_disconnect.
+    // Preload gate: same logic as handle_disconnect.
     let preload_complete = if crate::debug_overlay::is_playwright_automation() {
         true
     } else {
@@ -851,7 +977,7 @@ fn handle_disconnect(
     let empty_stations = ShipStations::default();
     let ship_stations = stations.as_deref().unwrap_or(&empty_stations);
 
-    // Preload gate: same logic as process_lobby.
+    // Preload gate: same logic as handle_set_ready_system.
     let preload_complete = if crate::debug_overlay::is_playwright_automation() {
         true
     } else {
@@ -1017,7 +1143,7 @@ fn tick_countdown(
 /// Plugin that drains [`LobbyOutbox`] into the `OutboundMessage` bus every
 /// frame, regardless of the current game phase.
 ///
-/// This phase-agnostic drain is intentional: `process_lobby` both transitions
+/// This phase-agnostic drain is intentional: `tick_countdown` both transitions
 /// the phase to `InProgress` *and* queues `GameStarted` in the same frame.
 /// A phase-gated drain (such as routing through `LobbyBroadcaster`) would skip
 /// the outbox on that transition frame, causing `GameStarted` to be lost.

--- a/src/lobby/server.rs
+++ b/src/lobby/server.rs
@@ -99,6 +99,16 @@ pub struct OutboundMessage {
     pub delivery: DeliveryClass,
 }
 
+// ── System set ─────────────────────────────────────────────────────────────
+
+/// Ordering anchor for every lobby `Update` system: the `handle_disconnect →
+/// process_lobby → tick_countdown → update_game_state_cache` chain plus the
+/// four per-variant station-management systems. Downstream systems that must
+/// observe the post-lobby world state order themselves with
+/// `.after(LobbySystemSet)`.
+#[derive(bevy::ecs::schedule::SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LobbySystemSet;
+
 // ── Plugin ─────────────────────────────────────────────────────────────────
 
 pub struct LobbyPlugin;
@@ -139,7 +149,29 @@ impl Plugin for LobbyPlugin {
                     tick_countdown,
                     update_game_state_cache,
                 )
-                    .chain(),
+                    .chain()
+                    .in_set(LobbySystemSet),
+            )
+            // Per-variant station-management systems (issue #733). Each owns
+            // exactly one ClientMessage variant, reading it via its own
+            // `MessageReader` cursor; `process_lobby` no longer processes these
+            // four variants. All four gate on Lobby/Loading/InProgress so
+            // players can claim/release stations and toggle ratings both in the
+            // lobby and mid-game.
+            .add_systems(
+                Update,
+                (
+                    handle_select_station_system,
+                    handle_release_station_system,
+                    handle_set_ready_system,
+                    handle_set_station_rating_system,
+                )
+                    .in_set(LobbySystemSet)
+                    .run_if(
+                        in_state(GamePhase::Lobby)
+                            .or(in_state(GamePhase::Loading))
+                            .or(in_state(GamePhase::InProgress)),
+                    ),
             );
     }
 }
@@ -426,16 +458,29 @@ pub fn process_lobby(
             .unwrap_or(true)
     };
     // Collect all messages first to avoid borrow conflicts with ship_query.
-    // During InProgress, allow station management messages (SelectStation, ReleaseStation)
-    // so players can claim stations mid-game.
+    //
+    // The four station-management variants (SelectStation, ReleaseStation,
+    // SetReady, SetStationRating) are owned exclusively by the per-variant
+    // systems (`handle_select_station_system` et al., issue #733) — they must
+    // never be processed here, in any phase, or they would be double-read (this
+    // system and the per-variant system have independent `MessageReader`
+    // cursors). `process_lobby` retains Identify (reconnect handshake) plus, in
+    // Lobby/Loading (`accepts_all`), SetName / ConfirmScenario / the runtime
+    // no-op catch-all, and ReturnToLobby in every phase (GameOver's button).
     let events: Vec<_> = inbound
         .read()
         .filter(|ev| {
+            if matches!(
+                ev.msg,
+                ClientMessage::SelectStation { .. }
+                    | ClientMessage::ReleaseStation
+                    | ClientMessage::SetReady { .. }
+                    | ClientMessage::SetStationRating { .. }
+            ) {
+                return false;
+            }
             accepts_all
                 || matches!(ev.msg, ClientMessage::Identify { .. })
-                || matches!(ev.msg, ClientMessage::SelectStation { .. })
-                || matches!(ev.msg, ClientMessage::ReleaseStation)
-                || matches!(ev.msg, ClientMessage::SetReady { .. })
                 || matches!(ev.msg, ClientMessage::ReturnToLobby)
         })
         .cloned()
@@ -479,6 +524,297 @@ pub fn process_lobby(
                 &ship_client_config.0,
                 preload_complete,
                 &pending_ratings,
+            );
+            let mut fallback_ratings = ActiveStationRatings::default();
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                None,
+                None,
+                &mut fallback_ratings,
+                countdown.as_deref_mut(),
+            );
+        }
+    }
+}
+
+/// Per-variant system for `ClientMessage::SelectStation` (issue #733).
+/// Reads its variant off the inbound bus with its own cursor, calls the pure
+/// `lobby_handler::handle_select_station`, then applies the result to Bevy
+/// resources via `apply_result` — mirroring `process_lobby`'s dual-path
+/// (real ship entity vs. pre-spawn fallback) handling.
+pub fn handle_select_station_system(
+    mut inbound: MessageReader<InboundMessage>,
+    mut sessions: ResMut<Sessions>,
+    state: Res<State<GamePhase>>,
+    mut next_state: ResMut<NextState<GamePhase>>,
+    mut outbox: ResMut<LobbyOutbox>,
+    ship_stations: Option<Res<ShipStations>>,
+    mut ship_query: Query<
+        (
+            &ShipConfigComponent,
+            &mut ShipSystemControlSources,
+            &mut ActiveStationRatings,
+        ),
+        With<crate::server_app::LocalShip>,
+    >,
+    mut countdown: Option<ResMut<CountdownTimer>>,
+) {
+    let default_stations = ShipStations::default();
+    let stations = ship_stations
+        .as_ref()
+        .map(|s| s.as_ref())
+        .unwrap_or(&default_stations);
+    let phase = state.get().clone();
+    let events: Vec<_> = inbound.read().cloned().collect();
+    for ev in events {
+        let ClientMessage::SelectStation { station } = &ev.msg else {
+            continue;
+        };
+        if let Ok((cfg, mut cs, mut active_ratings)) = ship_query.single_mut() {
+            let result = lobby_handler::handle_select_station(
+                &ev.token,
+                station,
+                &mut sessions.0,
+                phase.clone(),
+                stations,
+            );
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                Some(cfg),
+                Some(&mut cs),
+                &mut active_ratings,
+                countdown.as_deref_mut(),
+            );
+        } else {
+            let result = lobby_handler::handle_select_station(
+                &ev.token,
+                station,
+                &mut sessions.0,
+                phase.clone(),
+                stations,
+            );
+            let mut fallback_ratings = ActiveStationRatings::default();
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                None,
+                None,
+                &mut fallback_ratings,
+                countdown.as_deref_mut(),
+            );
+        }
+    }
+}
+
+/// Per-variant system for `ClientMessage::ReleaseStation` (issue #733).
+pub fn handle_release_station_system(
+    mut inbound: MessageReader<InboundMessage>,
+    mut sessions: ResMut<Sessions>,
+    state: Res<State<GamePhase>>,
+    mut next_state: ResMut<NextState<GamePhase>>,
+    mut outbox: ResMut<LobbyOutbox>,
+    ship_stations: Option<Res<ShipStations>>,
+    mut ship_query: Query<
+        (
+            &ShipConfigComponent,
+            &mut ShipSystemControlSources,
+            &mut ActiveStationRatings,
+        ),
+        With<crate::server_app::LocalShip>,
+    >,
+    mut countdown: Option<ResMut<CountdownTimer>>,
+) {
+    let default_stations = ShipStations::default();
+    let stations = ship_stations
+        .as_ref()
+        .map(|s| s.as_ref())
+        .unwrap_or(&default_stations);
+    let phase = state.get().clone();
+    let events: Vec<_> = inbound.read().cloned().collect();
+    for ev in events {
+        let ClientMessage::ReleaseStation = &ev.msg else {
+            continue;
+        };
+        if let Ok((cfg, mut cs, mut active_ratings)) = ship_query.single_mut() {
+            let result = lobby_handler::handle_release_station(
+                &ev.token,
+                &mut sessions.0,
+                phase.clone(),
+                stations,
+            );
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                Some(cfg),
+                Some(&mut cs),
+                &mut active_ratings,
+                countdown.as_deref_mut(),
+            );
+        } else {
+            let result = lobby_handler::handle_release_station(
+                &ev.token,
+                &mut sessions.0,
+                phase.clone(),
+                stations,
+            );
+            let mut fallback_ratings = ActiveStationRatings::default();
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                None,
+                None,
+                &mut fallback_ratings,
+                countdown.as_deref_mut(),
+            );
+        }
+    }
+}
+
+/// Per-variant system for `ClientMessage::SetReady` (issue #733).
+pub fn handle_set_ready_system(
+    mut inbound: MessageReader<InboundMessage>,
+    mut sessions: ResMut<Sessions>,
+    state: Res<State<GamePhase>>,
+    mut next_state: ResMut<NextState<GamePhase>>,
+    mut outbox: ResMut<LobbyOutbox>,
+    ship_stations: Option<Res<ShipStations>>,
+    preload: Option<Res<AssetPreloadResource>>,
+    mut ship_query: Query<
+        (
+            &ShipConfigComponent,
+            &mut ShipSystemControlSources,
+            &mut ActiveStationRatings,
+        ),
+        With<crate::server_app::LocalShip>,
+    >,
+    mut countdown: Option<ResMut<CountdownTimer>>,
+) {
+    let default_stations = ShipStations::default();
+    let stations = ship_stations
+        .as_ref()
+        .map(|s| s.as_ref())
+        .unwrap_or(&default_stations);
+    let phase = state.get().clone();
+    // Preload gate: same logic as process_lobby / handle_disconnect.
+    let preload_complete = if crate::debug_overlay::is_playwright_automation() {
+        true
+    } else {
+        preload
+            .as_ref()
+            .map(|p| !p.started || p.complete)
+            .unwrap_or(true)
+    };
+    let events: Vec<_> = inbound.read().cloned().collect();
+    for ev in events {
+        let ClientMessage::SetReady { ready } = &ev.msg else {
+            continue;
+        };
+        if let Ok((cfg, mut cs, mut active_ratings)) = ship_query.single_mut() {
+            let result = lobby_handler::handle_set_ready(
+                &ev.token,
+                *ready,
+                &mut sessions.0,
+                phase.clone(),
+                preload_complete,
+                stations,
+            );
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                Some(cfg),
+                Some(&mut cs),
+                &mut active_ratings,
+                countdown.as_deref_mut(),
+            );
+        } else {
+            let result = lobby_handler::handle_set_ready(
+                &ev.token,
+                *ready,
+                &mut sessions.0,
+                phase.clone(),
+                preload_complete,
+                stations,
+            );
+            let mut fallback_ratings = ActiveStationRatings::default();
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                None,
+                None,
+                &mut fallback_ratings,
+                countdown.as_deref_mut(),
+            );
+        }
+    }
+}
+
+/// Per-variant system for `ClientMessage::SetStationRating` (issue #733).
+/// The pure handler only acts in Lobby/Loading (InProgress rating changes are
+/// applied against the live Ship entity by
+/// `ship_plugin::handle_station_rating_change`), so the InProgress run is a
+/// no-op here — but the system is still gated on InProgress per the user's
+/// decision to keep the four station systems on a uniform phase gate.
+pub fn handle_set_station_rating_system(
+    mut inbound: MessageReader<InboundMessage>,
+    mut sessions: ResMut<Sessions>,
+    state: Res<State<GamePhase>>,
+    mut next_state: ResMut<NextState<GamePhase>>,
+    mut outbox: ResMut<LobbyOutbox>,
+    ship_stations: Option<Res<ShipStations>>,
+    mut ship_query: Query<
+        (
+            &ShipConfigComponent,
+            &mut ShipSystemControlSources,
+            &mut ActiveStationRatings,
+        ),
+        With<crate::server_app::LocalShip>,
+    >,
+    mut countdown: Option<ResMut<CountdownTimer>>,
+) {
+    let default_stations = ShipStations::default();
+    let stations = ship_stations
+        .as_ref()
+        .map(|s| s.as_ref())
+        .unwrap_or(&default_stations);
+    let phase = state.get().clone();
+    let events: Vec<_> = inbound.read().cloned().collect();
+    for ev in events {
+        let ClientMessage::SetStationRating { rating_name } = &ev.msg else {
+            continue;
+        };
+        if let Ok((cfg, mut cs, mut active_ratings)) = ship_query.single_mut() {
+            let result = lobby_handler::handle_set_station_rating(
+                &ev.token,
+                rating_name,
+                &mut sessions.0,
+                phase.clone(),
+                stations,
+            );
+            apply_result(
+                result,
+                &mut outbox,
+                &mut next_state,
+                Some(cfg),
+                Some(&mut cs),
+                &mut active_ratings,
+                countdown.as_deref_mut(),
+            );
+        } else {
+            let result = lobby_handler::handle_set_station_rating(
+                &ev.token,
+                rating_name,
+                &mut sessions.0,
+                phase.clone(),
+                stations,
             );
             let mut fallback_ratings = ActiveStationRatings::default();
             apply_result(

--- a/src/lobby/session.rs
+++ b/src/lobby/session.rs
@@ -21,8 +21,8 @@ pub enum RegisterError {
 ///   same token would miss `idx()` and fall through to `register()` as a
 ///   brand-new player — losing `last_rating` and, for a player who still
 ///   holds a station, breaking the reconnect-yield seat/rating restore in
-///   `process_disconnect_with_stations` / `process_message`'s `Identify`
-///   handler (`src/lobby/handler.rs`).
+///   `process_disconnect_with_stations` / `handle_identify` (the `Identify`
+///   handler in `src/lobby/handler.rs`).
 /// - Even a station-less disconnected player is not safe to prune purely on
 ///   "disconnected + no station": nothing in `SessionManager` distinguishes
 ///   "never held a station this game" from "held one and had it stolen by a

--- a/src/server_app.rs
+++ b/src/server_app.rs
@@ -1395,8 +1395,9 @@ fn is_command_authorized(
     }
 }
 
-/// When a player reconnects mid-game (Identify during InProgress), `process_lobby`
-/// queues a `Welcome { .. }` into `LobbyOutbox` targeted at that player's
+/// When a player reconnects mid-game (Identify during InProgress),
+/// `handle_identify_system` (in `LobbySystemSet`) queues a `Welcome { .. }` into
+/// `LobbyOutbox` targeted at that player's
 /// token. Detect this and push a full-state resync to *just that token* via
 /// [`crate::core::broadcast::cache_registry::resync_for_token`] (issue #613).
 ///
@@ -3772,7 +3773,7 @@ station = "pilot"
         );
         tick(app);
         push(app, "captain", ClientMessage::SetReady { ready: true });
-        tick(app); // process_lobby → starts countdown
+        tick(app); // handle_set_ready_system → starts countdown
         fast_forward_countdown(app);
         tick(app); // tick_countdown → emits GameStarted, sets NextState::Set(InProgress)
         tick(app); // NextState takes effect: Phase switches to InProgress

--- a/src/server_app.rs
+++ b/src/server_app.rs
@@ -231,7 +231,7 @@ pub fn add_simulation_plugins(app: &mut App) {
         )
             .chain()
             .run_if(in_state(GamePhase::InProgress))
-            .after(crate::lobby::process_lobby),
+            .after(crate::lobby::LobbySystemSet),
     )
     .add_plugins(RapierPhysicsPlugin::<()>::default())
     .add_plugins(crate::region_plugin::RegionPlugin)
@@ -291,13 +291,13 @@ pub fn add_simulation_plugins(app: &mut App) {
         Update,
         (reconcile_runtime_entities, broadcast_world_setup_on_start)
             .chain()
-            .after(crate::lobby::process_lobby)
+            .after(crate::lobby::LobbySystemSet)
             .before(crate::sim_sets::SimSet::Input),
     )
     .add_systems(
         Update,
         (admit_system_commands, clear_inter_system_queue)
-            .after(crate::lobby::process_lobby)
+            .after(crate::lobby::LobbySystemSet)
             .before(crate::sim_sets::SimSet::Input)
             .run_if(in_state(GamePhase::InProgress)),
     )
@@ -308,7 +308,7 @@ pub fn add_simulation_plugins(app: &mut App) {
     .add_systems(
         Update,
         refresh_caches_on_midgame_reconnect
-            .after(crate::lobby::process_lobby)
+            .after(crate::lobby::LobbySystemSet)
             .before(crate::lobby::server::drain_lobby_outbox)
             .before(crate::sim_sets::SimSet::Broadcast),
     )
@@ -319,7 +319,7 @@ pub fn add_simulation_plugins(app: &mut App) {
             handle_collisions.in_set(crate::sim_sets::SimSet::Damage),
             sim_processing_anchor,
         )
-            .after(crate::lobby::process_lobby),
+            .after(crate::lobby::LobbySystemSet),
     )
     .add_systems(
         Update,
@@ -1229,7 +1229,7 @@ impl Plugin for AdmissionPlugin {
             .configure_sets(
                 Update,
                 AdmissionSet
-                    .after(crate::lobby::process_lobby)
+                    .after(crate::lobby::LobbySystemSet)
                     .before(crate::sim_sets::SimSet::Input),
             )
             .add_systems(
@@ -3466,7 +3466,7 @@ station = "pilot"
         .add_systems(
             Update,
             (admit_system_commands, clear_inter_system_queue)
-                .after(crate::lobby::process_lobby)
+                .after(crate::lobby::LobbySystemSet)
                 .before(crate::sim_sets::SimSet::Input),
         )
         .add_systems(
@@ -3475,10 +3475,10 @@ station = "pilot"
                 handle_impulse_messages,
                 broadcast_shield_status,
                 reconcile_runtime_entities
-                    .after(crate::lobby::process_lobby)
+                    .after(crate::lobby::LobbySystemSet)
                     .before(broadcast_world_setup_on_start),
-                broadcast_world_setup_on_start.after(crate::lobby::process_lobby),
-                refresh_caches_on_midgame_reconnect.after(crate::lobby::process_lobby),
+                broadcast_world_setup_on_start.after(crate::lobby::LobbySystemSet),
+                refresh_caches_on_midgame_reconnect.after(crate::lobby::LobbySystemSet),
             ),
         )
         .add_systems(

--- a/src/ship_plugin.rs
+++ b/src/ship_plugin.rs
@@ -418,7 +418,7 @@ impl Plugin for ShipPlugin {
                 sync_console_damage_tiers.in_set(crate::sim_sets::SimSet::Damage),
                 detect_damage_tier_crossings.in_set(crate::sim_sets::SimSet::Damage),
             )
-                .after(crate::lobby::process_lobby),
+                .after(crate::lobby::LobbySystemSet),
         );
 
         // Per-axis helm AI (issue #701). Registered separately from the tuple
@@ -457,7 +457,7 @@ impl Plugin for ShipPlugin {
             Update,
             (ai_helm_thrust, ai_helm_steering)
                 .in_set(crate::sim_sets::SimSet::Physics)
-                .after(crate::lobby::process_lobby)
+                .after(crate::lobby::LobbySystemSet)
                 .after(crate::sim_sets::AiTickLabel)
                 .after(process_helm_inputs)
                 .before(publish_joystick_to_engines)
@@ -485,7 +485,7 @@ impl Plugin for ShipPlugin {
             Update,
             ai_helm_impulse
                 .in_set(crate::sim_sets::SimSet::Physics)
-                .after(crate::lobby::process_lobby)
+                .after(crate::lobby::LobbySystemSet)
                 .after(crate::sim_sets::AiTickLabel)
                 .before(apply_helm_commands)
                 // Shared AI-helm sim tick (issue #803) — one fixed-rate

--- a/wiki/concepts/message-flow.md
+++ b/wiki/concepts/message-flow.md
@@ -2,8 +2,8 @@
 title: Message Flow
 type: concept
 tags: [messages, bridge, wasm, bevy, events, routing, delivery-class, snapshot]
-sources: [src/server/bridge.rs, src/lobby/server.rs, src/server_app.rs, AGENTS.md]
-updated: 2026-07-15
+sources: [src/server/bridge.rs, src/lobby/server.rs, src/lobby/handler.rs, src/server_app.rs, AGENTS.md]
+updated: 2026-07-16
 ---
 
 # Message Flow
@@ -45,6 +45,33 @@ This project uses Bevy's **pull-based** message system (not legacy events):
 - `app.add_message::<InboundMessage>()`, `add_message::<OutboundMessage>()`, `add_message::<PlayerDisconnected>()`.
 - Producers use `MessageWriter<T>`. Consumers use `MessageReader<T>`.
 - Messages live one frame and are drained.
+
+## Lobby message dispatch (per-variant systems)
+
+Inbound `ClientMessage` lobby variants are no longer routed through a single
+monolithic `process_lobby` / `process_message` dispatch (deleted in #734). Each
+lobby variant is now handled by its own dedicated Bevy system in `LobbySystemSet`
+(`src/lobby/server.rs`), reading the inbound bus with its own `MessageReader`
+cursor and calling the matching pure handler in `src/lobby/handler.rs`:
+
+| System | Variant | Phase gate |
+|---|---|---|
+| `handle_identify_system` | `Identify` | Lobby / Loading / InProgress (mid-game reconnect) |
+| `handle_set_name_system` | `SetName` | Lobby / Loading |
+| `handle_return_to_lobby_system` | `ReturnToLobby` | GameOver |
+| `handle_confirm_scenario_system` | `ConfirmScenario` | Lobby |
+| `handle_select_station_system` | `SelectStation` | Lobby / Loading / InProgress |
+| `handle_release_station_system` | `ReleaseStation` | Lobby / Loading / InProgress |
+| `handle_set_ready_system` | `SetReady` | Lobby / Loading / InProgress |
+| `handle_set_station_rating_system` | `SetStationRating` | Lobby / Loading / InProgress |
+
+Ordering within the set: `handle_disconnect` runs first (so a same-frame
+disconnect+reconnect vacates then restores a seat in the right order), then the
+per-variant message systems, then `tick_countdown → update_game_state_cache`.
+The seven in-game runtime variants (`ControlSystem`, `FirePhaser`, `FireTorpedo`,
+`SetPhaserFrequency`, `SendCoordination`, `LoadTube`, `UnloadTube`) are simply
+not read by any lobby system — the console server plugins own them under
+`SimSet::Input`.
 
 ## Routing targets
 


### PR DESCRIPTION
## Summary
- Extracts each match arm of the lobby handler's `process_message` into standalone pure functions (#732)
- Replaces the monolithic `process_lobby` Bevy system with per-variant systems joined to a new `LobbySystemSet`, starting with station management (#733)
- Finishes the migration for the remaining variants (Identify, SetName, ReturnToLobby, ConfirmScenario), then deletes `process_lobby` and `process_message` entirely (#734)

Each inbound `ClientMessage` lobby variant is now handled by its own Bevy system, gated to the phases it's valid in, calling a pure `handle_*` function and then `apply_result`. Design decision: `SetStationRating` is permitted during `InProgress` (not just Lobby/Loading), diverging from the original issue proposal per sign-off.

## Test plan
- [x] `cargo test` — 2507 passed, including all 60 handler.rs tests + 4 server.rs integration tests
- [x] `cargo check --tests` clean
- [x] `npx vitest run` — 2273 passed
- [x] `cargo clippy` clean
- [x] Rebased onto latest `main`, resolving a conflict from #804 (deleted legacy `SetPhaserFrequency` top-level variant) — removed the now-dead match arm from the test-only `dispatch` helper
- [x] PASM validated OK (no design-doc changes needed; runtime note added to `wiki/concepts/message-flow.md`)

Fixes #732, Fixes #733, Fixes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)