### PR TITLE
fix(combat_test): stationary starbase + thinner, scattered asteroid belts

### DIFF
--- a/assets/worlds/combat_test.toml
+++ b/assets/worlds/combat_test.toml
@@ -349,7 +349,10 @@ transform = { relative_to = "gas-giant", offset = [125.0, 0.0, 40.0] }
 template_path = "assets/entities/asteroid_field_main.toml"
 id = "inner-belt"
 transform = { position = [0.0, 0.0, 0.0] }
-overrides = { asteroid_field = { inner_radius = 200.0, outer_radius = 300.0, weight = 1.0, shape = "torus" } }
+# `density` halves the template's 0.005 and `grid.jitter` triples its 20.0
+# (combat_test only): a thinner belt with the rocks scattered much further off
+# their grid cells, so the field reads as scattered debris rather than a lattice.
+overrides = { asteroid_field = { inner_radius = 200.0, outer_radius = 300.0, weight = 1.0, shape = "torus", density = 0.0025, grid = { jitter = 60.0 } } }
 
 # Outer asteroid belt, r=800..1000. Sits between the starbase and the
 # enemy spawn anchors (all at r >= 1000), so attackers must fly through
@@ -358,7 +361,8 @@ overrides = { asteroid_field = { inner_radius = 200.0, outer_radius = 300.0, wei
 template_path = "assets/entities/asteroid_field_main.toml"
 id = "outer-belt"
 transform = { position = [0.0, 0.0, 0.0] }
-overrides = { asteroid_field = { inner_radius = 800.0, outer_radius = 1000.0, weight = 1.0, shape = "torus" } }
+# Same halved density / tripled grid.jitter as the inner belt (see there).
+overrides = { asteroid_field = { inner_radius = 800.0, outer_radius = 1000.0, weight = 1.0, shape = "torus", density = 0.0025, grid = { jitter = 60.0 } } }
 
 # Player ship — selected from the lobby ship picker. The [[available_ships]]
 # entries drive the lobby UI; [player_spawn] sets the spawn position once

--- a/assets/worlds/probe_aggressor.toml
+++ b/assets/worlds/probe_aggressor.toml
@@ -38,31 +38,30 @@ id = "player-ship"
 transform = { position = [0.0, 0.0, 0.0] }
 spawn_on = "game_start"
 
-# Make Harrow and Federation mutually hostile before the destroyer spawns.
-[[trigger]]
-condition = "on_world_loaded"
-
-  [[trigger.action]]
-  type    = "add_faction_enemy"
-  faction = "Harrow"
-  enemy   = "Federation"
-
-  [[trigger.action]]
-  type    = "add_faction_enemy"
-  faction = "Federation"
-  enemy   = "Harrow"
-
-# Spawn the passive hostile destroyer inside the player's phaser range (40u) at
+# Make Harrow and Federation mutually hostile before the destroyer spawns, then
+# spawn the passive hostile destroyer inside the player's phaser range (40u) at
 # t=0. The empty doctrine override strips the template's default combat doctrine,
 # leaving a hull with nothing standing that licenses it to engage — never an
 # initiator.
-[[trigger]]
-condition = "on_timer"
-after_secs = 0.0
+[script]
+setup = """
+on_world_loaded("on_load");
+on_timer(0, "on_start");
 
-  [[trigger.action]]
-  type          = "spawn_entity"
-  template_path = "assets/entities/alliance_destroyer.toml"
-  name          = "probe_target"
-  position      = [35.0, 0.0, 0.0]
-  overrides = { faction = "cccccccc-3333-4333-8333-cccccccccccc", behaviour = { doctrine = [] } }
+fn on_load(ctx) {
+    ctx.effects.add_faction_enemy("Harrow", "Federation");
+    ctx.effects.add_faction_enemy("Federation", "Harrow");
+}
+
+fn on_start(ctx) {
+    ctx.effects.spawn_entity(#{
+        template_path: "assets/entities/alliance_destroyer.toml",
+        name: "probe_target",
+        position: [35, 0, 0],
+        overrides: #{
+            faction: "cccccccc-3333-4333-8333-cccccccccccc",
+            behaviour: #{ doctrine: [] }
+        }
+    });
+}
+"""

--- a/assets/worlds/probe_attack_pass_cycle.toml
+++ b/assets/worlds/probe_attack_pass_cycle.toml
@@ -63,29 +63,25 @@ id = "player-ship"
 transform = { position = [0.0, 0.0, 0.0] }
 spawn_on = "game_start"
 
-[[trigger]]
-condition = "on_world_loaded"
-
-  [[trigger.action]]
-  type    = "add_faction_enemy"
-  faction = "Harrow"
-  enemy   = "Federation"
-
-  [[trigger.action]]
-  type    = "add_faction_enemy"
-  faction = "Federation"
-  enemy   = "Harrow"
-
 # The orbiting hostile. Its own template doctrine (`destroy-hostiles`, an
 # UNTARGETED Destroy) is what licenses the nearest-hostile scan, so no override
 # is needed to make it engage — and none is authored, so this world exercises
 # the shipped hull rather than a scenario-local variant of it.
-[[trigger]]
-condition = "on_timer"
-after_secs = 0.0
+[script]
+setup = """
+on_world_loaded("on_load");
+on_timer(0, "on_start");
 
-  [[trigger.action]]
-  type          = "spawn_entity"
-  template_path = "assets/entities/ship_harrow_cruiser.toml"
-  name          = "probe_orbiter"
-  position      = [140.0, 0.0, 0.0]
+fn on_load(ctx) {
+    ctx.effects.add_faction_enemy("Harrow", "Federation");
+    ctx.effects.add_faction_enemy("Federation", "Harrow");
+}
+
+fn on_start(ctx) {
+    ctx.effects.spawn_entity(#{
+        template_path: "assets/entities/ship_harrow_cruiser.toml",
+        name: "probe_orbiter",
+        position: [140, 0, 0]
+    });
+}
+"""

--- a/assets/worlds/probe_huge_rock.toml
+++ b/assets/worlds/probe_huge_rock.toml
@@ -140,16 +140,20 @@ transform = { position = [2040.0, 0.0, 0.0] }
 # `base_priority = 80` outranks the destroyer template's own `destroy-hostiles`
 # (45) and `hold-station` (20), so the ship flies this and nothing else. Far
 # anchor first, so the very first leg is the one straight at the rock.
-[[trigger]]
-condition = "on_world_loaded"
+[script]
+setup = """
+on_world_loaded("on_load");
 
-  [[trigger.action]]
-  type              = "add_objective"
-  id                = "obj-cross-the-belt"
-  text              = "world.probe_huge_rock.trigger.action.obj_cross_the_belt.text"
-  mandatory         = true
-  source            = "mission"
-  base_priority     = 80.0
-  directive_kind    = "Patrol"
-  directive_anchors = ["lane_far", "lane_near"]
-  directive_loop    = true
+fn on_load(ctx) {
+    ctx.effects.add_objective(#{
+        id: "obj-cross-the-belt",
+        text: "world.probe_huge_rock.trigger.action.obj_cross_the_belt.text",
+        mandatory: true,
+        source: "mission",
+        base_priority: 80,
+        directive_kind: "Patrol",
+        directive_anchors: ["lane_far", "lane_near"],
+        directive_loop: true,
+    });
+}
+"""

--- a/assets/worlds/probe_symmetry.toml
+++ b/assets/worlds/probe_symmetry.toml
@@ -27,30 +27,27 @@ id = "player-ship"
 transform = { position = [0.0, 0.0, 0.0] }
 spawn_on = "game_start"
 
-# Make Harrow and Federation mutually hostile before the copy spawns.
-[[trigger]]
-condition = "on_world_loaded"
+# Trigger logic converted from declarative [[trigger]] blocks to a Rhai [script]
+# block. Behaviour is identical: on world load make Harrow and Federation mutually
+# hostile before the copy spawns; at t=0 spawn the world-side Alliance cruiser
+# close to the player, overriding ONLY its faction so the template's default combat
+# doctrine is kept and this copy runs the same behaviour as the backfilled player.
+[script]
+setup = """
+on_world_loaded("on_load");
+on_timer(0, "on_spawn");
 
-  [[trigger.action]]
-  type    = "add_faction_enemy"
-  faction = "Harrow"
-  enemy   = "Federation"
+fn on_load(ctx) {
+    ctx.effects.add_faction_enemy("Harrow", "Federation");
+    ctx.effects.add_faction_enemy("Federation", "Harrow");
+}
 
-  [[trigger.action]]
-  type    = "add_faction_enemy"
-  faction = "Federation"
-  enemy   = "Harrow"
-
-# Spawn the world-side Alliance cruiser close to the player at t=0. Only the
-# faction is overridden — the template's default combat doctrine is kept, so this
-# copy and the backfilled player run the same behaviour.
-[[trigger]]
-condition = "on_timer"
-after_secs = 0.0
-
-  [[trigger.action]]
-  type          = "spawn_entity"
-  template_path = "assets/entities/alliance_cruiser.toml"
-  name          = "probe_twin"
-  position      = [45.0, 0.0, 0.0]
-  overrides = { faction = "cccccccc-3333-4333-8333-cccccccccccc" }
+fn on_spawn(ctx) {
+    ctx.effects.spawn_entity(#{
+        template_path: "assets/entities/alliance_cruiser.toml",
+        name: "probe_twin",
+        position: [45, 0, 0],
+        overrides: #{ faction: "cccccccc-3333-4333-8333-cccccccccccc" }
+    });
+}
+"""

--- a/assets/worlds/probe_targeted_pass.toml
+++ b/assets/worlds/probe_targeted_pass.toml
@@ -58,42 +58,36 @@ spawn_on = "game_start"
 
 # Make Harrow and Federation mutually hostile before the target spawns, so the
 # Alliance captain doctrine's first-contact rule raises Red Alert on sight and the
-# movement `posture` fact presses the class doctrine.
-[[trigger]]
-condition = "on_world_loaded"
+# movement `posture` fact presses the class doctrine. Then spawn the named target
+# and author the mission `Destroy` objective that names it. `objectives.rs` gives
+# every Destroy objective `SystemAffinity::Helm`, which is what makes it the top
+# Helm-relevant objective both `helm_destroy_target` and `operate_navigation_ai`
+# read.
+[script]
+setup = """
+on_world_loaded("on_load");
+on_timer(0, "on_start");
 
-  [[trigger.action]]
-  type    = "add_faction_enemy"
-  faction = "Harrow"
-  enemy   = "Federation"
+fn on_load(ctx) {
+    ctx.effects.add_faction_enemy("Harrow", "Federation");
+    ctx.effects.add_faction_enemy("Federation", "Harrow");
+}
 
-  [[trigger.action]]
-  type    = "add_faction_enemy"
-  faction = "Federation"
-  enemy   = "Harrow"
-
-# The named target, and the mission objective that names it.
-[[trigger]]
-condition = "on_timer"
-after_secs = 0.0
-
-  [[trigger.action]]
-  type          = "spawn_entity"
-  template_path = "assets/entities/alliance_destroyer.toml"
-  name          = "probe_target"
-  position      = [0.0, 0.0, -70.0]
-  overrides     = { faction = "cccccccc-3333-4333-8333-cccccccccccc" }
-
-  # A mission `Destroy` carrying a target NAME. `objectives.rs` gives every
-  # Destroy objective `SystemAffinity::Helm`, which is what makes it the top
-  # Helm-relevant objective both `helm_destroy_target` and
-  # `operate_navigation_ai` read.
-  [[trigger.action]]
-  type           = "add_objective"
-  id             = "obj-destroy-target"
-  text           = "world.probe_targeted_pass.trigger.action.obj_destroy_target.text"
-  mandatory      = true
-  targets        = ["probe_target"]
-  target         = "probe_target"
-  directive_kind = "Destroy"
-  base_priority  = 80.0
+fn on_start(ctx) {
+    ctx.effects.spawn_entity(#{
+        template_path: "assets/entities/alliance_destroyer.toml",
+        name: "probe_target",
+        position: [0, 0, -70],
+        overrides: #{ faction: "cccccccc-3333-4333-8333-cccccccccccc" }
+    });
+    ctx.effects.add_objective(#{
+        id: "obj-destroy-target",
+        text: "world.probe_targeted_pass.trigger.action.obj_destroy_target.text",
+        mandatory: true,
+        targets: ["probe_target"],
+        target: "probe_target",
+        directive_kind: "Destroy",
+        base_priority: 80
+    });
+}
+"""

--- a/assets/worlds/probe_victory.toml
+++ b/assets/worlds/probe_victory.toml
@@ -1,13 +1,18 @@
 # Probe world for issue #843 — the victory classification path, end to end.
 #
 # A player Alliance cruiser (AI-backfilled in a headless run) sits alone; a
-# one-shot timer fires a `game_over` action carrying `outcome = "victory"`. No
-# combat is involved on purpose: this is a deterministic tripwire for the whole
-# outcome-declaration wiring — config parse (`outcome = "victory"`) → dispatch
+# one-shot timer fires a `game_over` carrying `outcome = "victory"`. No combat is
+# involved on purpose: this is a deterministic tripwire for the whole
+# outcome-declaration wiring — script parse → dispatch
 # (`SetGameOverReason { outcome }`) → the `GameOverReason` resource → the pure
 # classifier — proving a scenario-declared victory reaches the exit report as
-# `outcome: "victory"`. The `message` is deliberately omitted (it is optional),
-# so this world needs no strings.csv entry.
+# `outcome: "victory"`. The `message` is deliberately empty (it is optional), so
+# this world needs no strings.csv entry.
+#
+# Rhai M6: the timer + game_over are authored as a [script] block (`on_timer`
+# registration + a handler fn) rather than a declarative `[[trigger]]`; the
+# scripted path emits the identical `SetGameOverReason { outcome: Victory }` +
+# `SetNextState` at the same tick, so the authoritative digest is unchanged.
 
 [global]
 seed = 843
@@ -24,10 +29,11 @@ transform = { position = [0.0, 0.0, 0.0] }
 spawn_on = "game_start"
 
 # A scripted victory: end the run in a declared win after one second.
-[[trigger]]
-condition = "on_timer"
-after_secs = 1.0
+[script]
+setup = """
+on_timer(1, "declare_victory");
 
-  [[trigger.action]]
-  type    = "game_over"
-  outcome = "victory"
+fn declare_victory(ctx) {
+    ctx.effects.game_over("", "victory");
+}
+"""

--- a/assets/worlds/rng_coverage.toml
+++ b/assets/worlds/rng_coverage.toml
@@ -114,29 +114,25 @@ spawn_on      = "game_start"
 # next to the player without ever acquiring it as a target, and three of the
 # five chokepoints never fire. Both directions, on world load, before the first
 # targeting tick — the same pattern `combat_test.toml` uses.
-[[trigger]]
-condition = "on_world_loaded"
+[script]
+setup = """
+on_world_loaded("on_load");
 
-  [[trigger.action]]
-  type    = "add_faction_enemy"
-  faction = "Harrow"
-  enemy   = "Federation"
-
-  [[trigger.action]]
-  type    = "add_faction_enemy"
-  faction = "Federation"
-  enemy   = "Harrow"
-
-  # The player's AI helm needs somewhere to be going. Without a directive the
-  # backfilled crew parks at the spawn point at zero speed, and collision
-  # damage — which scales with speed — rounds to nothing.
-  [[trigger.action]]
-  type              = "add_objective"
-  id                = "obj-rng-coverage-patrol"
-  text              = "world.rng_coverage.trigger.action.obj_patrol.text"
-  mandatory         = true
-  source            = "mission"
-  base_priority     = 40.0
-  directive_kind    = "Patrol"
-  directive_anchors = ["patrol_a", "patrol_b", "patrol_c"]
-  directive_loop    = true
+fn on_load(ctx) {
+    ctx.effects.add_faction_enemy("Harrow", "Federation");
+    ctx.effects.add_faction_enemy("Federation", "Harrow");
+    // The player's AI helm needs somewhere to be going. Without a directive the
+    // backfilled crew parks at the spawn point at zero speed, and collision
+    // damage — which scales with speed — rounds to nothing.
+    ctx.effects.add_objective(#{
+        id: "obj-rng-coverage-patrol",
+        text: "world.rng_coverage.trigger.action.obj_patrol.text",
+        mandatory: true,
+        source: "mission",
+        base_priority: 40,
+        directive_kind: "Patrol",
+        directive_anchors: ["patrol_a", "patrol_b", "patrol_c"],
+        directive_loop: true
+    });
+}
+"""

--- a/pasm/spec/design/console-complexity.yaml
+++ b/pasm/spec/design/console-complexity.yaml
@@ -1,0 +1,48 @@
+entities:
+  - decision: console-complexity-star-ladder
+    core:
+      status: accepted
+      confidence: confirmed
+      title: Console Complexity Star Ladder
+      summary: "Every station runs at a star rating built from authored rungs: an ordered ladder of station ratings, each rung declaring per-system control depth (AI / simplified / detailed). Star 0 is Backfill; rung count varies per station (typically 3-5 stars at the top). A scenario may additionally force individual systems detailed, leaving a station legitimately between rungs — the effective per-system state is the maximum of the chosen rung and the scenario floor, and the overlay never snaps the rung."
+      rationale:
+        - "Rungs extend the existing StationRatingConfig (a detailed_systems list beside automated_systems), so star selection, live mid-round change, Backfill fallback, and the lobby's ratings-length signal all reuse the delivered rating machinery."
+        - "Authored bundles beat derived arithmetic: designers curate coherent depth combinations per station (the Thorium station-set lesson), while the scenario overlay covers the between-rung states without unauthored rung synthesis."
+        - "Simplified means a limited AI — the fine-system policy runtime with authority scoped to that system — drives the full model from summary-surface settings, preserving AI/human symmetry; detailed means direct control of the full model."
+    game_design:
+      must_not_be: [derived arithmetically from system counts instead of authored, changed by a player who does not hold the station]
+
+  - decision: console-complexity-scenario-floor
+    core:
+      status: accepted
+      confidence: confirmed
+      title: Scenario Detail Floor
+      summary: "Scenarios declare required-detailed systems through first-class world-TOML vocabulary naming console families or system kinds, never per-hull system ids, so the requirement applies to whatever hull the crew selects in the lobby. The floor is applied inside the pure rating resolver. The same vocabulary can mark additional systems human-seeking."
+      rationale:
+        - "Hull-agnostic by construction: a scenario cannot know the lobby's hull choice, so requirements expressed as entity overrides would silently miss — and the player ship discards world overrides at spawn today. The entity-override merge policy is deliberately left untouched by this feature."
+    game_design:
+      must_not_be: [expressed as per-hull entity overrides, used to lower a station below its authored default]
+
+  - decision: console-complexity-detail-screens
+    core:
+      status: accepted
+      confidence: confirmed
+      title: Per-System Detail Screens
+      summary: "Detailed systems surface through per-system detail screens rendered by a generalised overlay host that console-core mounts when a keyed payload carries detail state — full-frame on phones, zero per-console HTML edits, state carried by the per-system blackboard publication. Detail screens are always accessible, including in combat; the binding authoring rule is that any action needed under time pressure must also exist on the station's summary surface, so detail screens hold planning, diagnosis, and configuration."
+      rationale:
+        - "Phone-depth doctrine from the 2026-08-13 bridge-simulator survey: at most two coupled variables plus a trend and an automation toggle per real-time screen; presets applied in one tap; depth placed in the gaps between phones (number hand-offs, two-officer handshakes); degradation expressed as unreliability rather than smaller numbers; automation always available and always worse than a competent human."
+        - "The existing guardrail stands: a rating tunes what a console offers its own operator, never whether ship state reaches the rest of the bridge (#873), and no simulation path branches on human-versus-AI downstream of command admission."
+    game_design:
+      must_not_be: [the only home of a time-pressured action, locked out at red alert]
+
+  - decision: console-complexity-human-seeking-systems
+    core:
+      status: accepted
+      confidence: confirmed
+      title: Human-Seeking Systems
+      summary: "Comms and navigation always try to be under human control: each walks an authored station order until it finds a human-held station, where it appears as extra buttons beside the hero bar (the destroyer-tactical precedent). With no human anywhere in the order, the system falls back to AI control exactly as today. A floating system carries its own control tier — default simplified — independent of the host station's rung, so hosting a visiting system never changes the host's star."
+      rationale:
+        - "The seek order only ever chooses among human-held stations: the mechanism prefers any human over the AI, it never forces a human."
+        - "Scenarios can mark additional systems human-seeking through the scenario-floor vocabulary."
+    game_design:
+      must_not_be: [allowed to inflate the host station's star rating, used to force a station onto an unwilling holder]

--- a/pasm/spec/design/simulation-differentiation.yaml
+++ b/pasm/spec/design/simulation-differentiation.yaml
@@ -1,0 +1,24 @@
+entities:
+  - decision: simulation-differentiation-principles
+    core:
+      status: accepted
+      confidence: confirmed
+      title: Simulation Differentiation Principles
+      summary: "Six principles govern every physical-simulation addition (2026-08-13, Starship Simulator Genesis review): state has causes; different systems consume the same authoritative state; sensors reveal state rather than scenario text; objects continue behaving when players are not looking at them; physical properties occasionally create unexpected solutions; procedural generation creates internally coherent situations, not mere variety."
+      rationale:
+        - "Phoenix's differentiation is depth of a small operational situation across several coordinated human roles, not breadth of a simulated universe. Genesis-class work is adopted as principles, never as scope."
+        - "The B-D foundation PRDs (fields and epistemics, physical world and vessels, resource network) and the Patrol Mode PRD cite this entry as their scope guard."
+    game_design:
+      must_not_be: [used to justify simulating detail no bridge officer can act on within a mission, satisfied by scripted exposition dressed as sensor output]
+
+  - decision: simulation-differentiation-non-goals
+    core:
+      status: accepted
+      confidence: confirmed
+      title: Simulation Non-Goals
+      summary: "Phoenix deliberately does not build: walkable ship interiors, bodily crew needs (food, sleep, oxygen as routine), a persistent large NPC crew, galaxy-scale traversal or billions of systems, valve-level physical hardware manipulation, explorable planetary surfaces, or fully simulated astronomical formation histories. Starship Simulator is spending its development effort exactly there; Phoenix does not need that competition."
+      rationale:
+        - "The consumable test is the boundary: a resource or detail is simulated only if another bridge officer can make a consequential decision about it within a 30-90 minute mission."
+        - "A non-goal may still appear as authored scenario content (e.g. oxygen as hazardous cargo) without becoming a simulated system."
+    game_design:
+      must_not_be: [eroded one plausible feature at a time, overridden by a scenario PRD without revisiting this entry]

--- a/pasm/spec/roadmap/phoenix-delivery-roadmap.yaml
+++ b/pasm/spec/roadmap/phoenix-delivery-roadmap.yaml
@@ -4,7 +4,7 @@ entities:
       status: accepted
       confidence: confirmed
       title: Phoenix Demo and Post-Demo Delivery
-      summary: "The demo critical path front-loads deterministic simulation (#849), completed composable entity templates (#869), and Backfill combat symmetry (#870) before Combat Test doctrine closure (#774), measured readiness (#868 and #850), the snapshot tracer (#848/#862), and the deliberately narrow limited release (#853/#931): Combat Test only, Alliance Destroyer only. Everything else is post-demo and runs as the five release bands A-E — Falling Skyway with native/cloud delivery and mod packs (#851/#852/#855/#856), Borrowed Sun with P2P (#858/#854), Narrow Season with the GM console MVP (#859/#930), The Broken Tithe with GM facilitation (#860), and The Silent Corridor with the GM console complete (#861) — widening the catalogue by one playable hull per band (#922) and carrying a visual/UX polish pass each time."
+      summary: "The demo critical path front-loads deterministic simulation (#849), completed composable entity templates (#869), and Backfill combat symmetry (#870) before Combat Test doctrine closure (#774), measured readiness (#868 and #850), the snapshot tracer (#848/#862), and the deliberately narrow limited release (#853/#931): Combat Test only, Alliance Destroyer only. Everything else is post-demo and runs as the release bands A-E — Falling Skyway with native/cloud delivery and mod packs (#851/#852/#855/#856), Borrowed Sun with its fields-and-epistemics foundation and P2P (#858/#854), Narrow Season with its physical-world-and-vessels foundation and the GM console MVP (#859/#930), The Broken Tithe with its resource-network foundation and GM facilitation (#860), and The Silent Corridor with the GM console complete (#861) — widening the catalogue by one playable hull per band (#922) and carrying a visual/UX polish pass each time, with Patrol Mode marked as the band F flagship beyond the campaign."
       rationale:
         - Completed work already supplies the balance harness (#835), baseline player Backfill doctrine (#842), scenario catalogue and QR flow (#754-#756), legacy save/load tracer bullets (#431-#435), native scenario hosting (#420), and mod-pack export/overlay plumbing (#759-#760).
         - Determinism, authored composition, and player/NPC Backfill symmetry are foundational game contracts; settling them before Combat Test balance avoids tuning a model that will immediately change.
@@ -31,11 +31,15 @@ entities:
         - roadmap-authoritative-snapshots
         - roadmap-post-demo-readiness
         - roadmap-p2p-multiship-delivery
+        - roadmap-borrowed-sun-foundation
         - roadmap-borrowed-sun-content
         - roadmap-gm-console
+        - roadmap-narrow-season-foundation
         - roadmap-narrow-season-content
+        - roadmap-broken-tithe-foundation
         - roadmap-broken-tithe-content
         - roadmap-silent-corridor-content
+        - roadmap-patrol-mode
         - roadmap-release-polish
 
   - component: roadmap-completed-demo-baseline
@@ -104,12 +108,13 @@ entities:
       status: accepted
       confidence: confirmed
       title: Post-Demo Release Bands A-E
-      summary: "Post-demo work ships as five public builds. A: Rhai scenario scripting ahead of the mission content, Falling Skyway (#851/#852) with native and Cloudflare delivery (#855), the consequence and scripted-progression resume adapters (#863/#864), mod content packs (#856) with template-aware editing (#910), and the destroyer readiness slice. B: Borrowed Sun (#858) with P2P multi-ship (#854), slot UX and portable export (#865/#866), and the cruiser. C: Narrow Season (#859) with the GM console MVP (#930 M1-M3), campaign-continuity projection (#867), and the courier (#877). D: The Broken Tithe (#860) with GM facilitation and safety (M4-M5) and the battleship. E: The Silent Corridor (#861) with the GM console complete (M6-M8) and #922's full-matrix balance closure."
+      summary: "Post-demo work ships as five public builds. A: Rhai scenario scripting ahead of the mission content, Falling Skyway (#851/#852) with native and Cloudflare delivery (#855), the consequence and scripted-progression resume adapters (#863/#864), mod content packs (#856) with template-aware editing (#910), and the destroyer readiness slice. B: Borrowed Sun and its foundation (#858 plus environmental fields, sensor-derived observations, and the Falling Skyway radiation-storm field retrofit) with P2P multi-ship (#854), slot UX and portable export (#865/#866), and the cruiser. C: Narrow Season and its foundation (#859 plus star/body descriptors, on-rails orbits, vessel deltas, and relative-motion operations) with the GM console MVP (#930 M1-M3), campaign-continuity projection (#867), and the courier (#877). D: The Broken Tithe and its foundation (#860 plus the unified ship resource network, the control-tier ladder, and consumables) with GM facilitation and safety (M4-M5) and the battleship. E: The Silent Corridor (#861), composition only, with the GM console complete (M6-M8) and #922's full-matrix balance closure. F is marked, not banded: Patrol Mode with a hand-authored exploration first patrol as its tutorial."
       rationale:
         - Each band is a shippable public build, not a paper milestone, so every band pairs one campaign mission with one platform capability, one more playable hull, and one visual/UX polish pass.
         - "The hull rollout is deliberately one at a time — destroyer, cruiser, courier, battleship — so tutorials, doctrine, and balance evidence land together per hull instead of as a single catalogue-wide push."
         - "The #848 adapters split across A, B, and C by what needs them: Falling Skyway needs consequence and scripted-progression resume, P2P join and recovery ride on the portable record, and campaign continuity only becomes real once three missions exist."
         - Defects are fixed as they arise outside these bands and are deliberately not scheduled into them.
+        - "2026-08-13 decision (Starship Simulator Genesis review): missions 2-4 each gain a paired foundation PRD mirroring the #851/#852 pattern, threading a physical-world simulation layer through B-D rather than deferring it past the campaign. Platform capabilities stay in their bands; the bands get longer. Foundation PRDs are written just-in-time as each band starts. Scope guard: pasm/spec/design/simulation-differentiation.yaml."
     architecture:
       kind: roadmap-release-bands
       authority: non-authoritative
@@ -295,6 +300,24 @@ entities:
       reads: [entity-template-state, world-content-pack-state]
       runs_in: [host-browser-runtime, headless-runtime]
 
+  - component: roadmap-borrowed-sun-foundation
+    core:
+      status: accepted
+      confidence: confirmed
+      title: Borrowed Sun Foundation — Environmental Fields, Shared Epistemics, and the Complexity Ladder
+      summary: "Release B. Add generic environmental fields — scenario-authored moving volumes with shape, velocity, intensity, and falloff, covering debris density, radiation, and sensor/comms interference — and sensor-derived observations: pure evaluators over field state produce evidence entries (ETA ranges, densities) whose confidence narrows with repeat observation. Retrofit Falling Skyway's radiation storm onto the field system with identical observable behaviour. Also ship the console complexity-ladder framework (2026-08-13 decision, per pasm/spec/design/console-complexity.yaml): star-rung station ratings, the generalised per-system detail overlay host, the scenario detail-floor vocabulary, and human-seeking comms/nav systems — with sensors as the first detailed console (scan modes, observation history, confidence narrowing, field analysis) and the Comms evidence/dossier browser as its detail surface."
+      rationale:
+        - "Fields are authored volumes in this band; cause-derived emission from physical sources arrives with the Narrow Season foundation. Consumers (sensors, helm hazard checks, damage application) only ever read field state, so that upgrade is non-breaking."
+        - "There is ONE evidence contract: physical sensor readings, third-party data obtained via Comms, and derived estimates all carry confidence and provenance through the #858 dossier surface. No second epistemics system is built for physical measurement."
+        - "The Skyway retrofit lands here, before campaign-continuity projection (#867) freezes expectations against mission 1's state, so the toolkit never carries two hazard representations."
+        - "The complexity-ladder framework debuts here rather than with the band-D power network (superseding the earlier engineering-only timing) because its first real content is band B's sensor depth: the detail screen ships with genuine epistemics gameplay, not an empty frame, and D's power detail then lands as deeper rungs of an established ladder."
+    architecture:
+      kind: roadmap-milestone
+      authority: authoritative
+      reads: [world-configuration-state, spawned-entity-state, world-snapshot-artifact]
+      coordinates: [roadmap-falling-skyway-foundation]
+      runs_in: [host-browser-runtime, headless-runtime]
+
   - component: roadmap-borrowed-sun-content
     core:
       status: accepted
@@ -305,7 +328,25 @@ entities:
       kind: roadmap-milestone
       authority: authoritative
       reads: [world-snapshot-artifact, world-content-pack-state]
+      coordinates: [roadmap-borrowed-sun-foundation]
       runs_in: [host-browser-runtime]
+
+  - component: roadmap-narrow-season-foundation
+    core:
+      status: accepted
+      confidence: confirmed
+      title: Narrow Season Foundation — Physical World and Vessel Deltas
+      summary: "Release C. Add compact star/body descriptors, on-rails parametric orbits where body position is a pure function of the logical tick, and a two-tier space: a system-map tier holding bodies, routes, fields, and occlusion/shielding/comms line-of-sight, with the existing local motion model anchored to a map location. Fields gain cause-derived emission from physical sources. Add derived relative-kinematic state and relative-motion operations (match velocity, hold station, intercept, interpose, escort position) as OperationEngine verbs through the existing directive path. Ladder content for this band: Helm detail (flight-assist configuration, relative-motion operations) and Navigation detail (system map, routes, occlusion/forecast windows), plus probes as a new system — launchable remote sensors that see through and into fields and link to the sensors console."
+      rationale:
+        - "No flight-model change: docking and tow envelopes are predicates over relative-kinematic state, verbs are AI/human symmetric via the directive path, and there is no thruster-level physics."
+        - "No new Vessel abstraction: this foundation audits the Genesis 'authoritative vessel object' proposal against the delivered unified ship model and adds only authored intent/compliance state for civilians, per-vessel knowledge isolation where missing, and LOD-tier profile parity so the full-AI tier and the low-LOD route follower read the same authored profile. NPC bridge crew for unmanned stations is already delivered as Backfill (#842/#870)."
+        - "On-rails orbits are deterministic, snapshot-free, and forecastable by pure evaluators, which is what gives Science occlusion-window and radiation-front prediction play."
+    architecture:
+      kind: roadmap-milestone
+      authority: authoritative
+      reads: [world-configuration-state, spawned-entity-state, world-snapshot-artifact]
+      coordinates: [roadmap-borrowed-sun-foundation]
+      runs_in: [host-browser-runtime, headless-runtime]
 
   - component: roadmap-narrow-season-content
     core:
@@ -317,7 +358,25 @@ entities:
       kind: roadmap-milestone
       authority: authoritative
       reads: [world-snapshot-artifact, world-content-pack-state]
+      coordinates: [roadmap-narrow-season-foundation]
       runs_in: [host-browser-runtime]
+
+  - component: roadmap-broken-tithe-foundation
+    core:
+      status: accepted
+      confidence: confirmed
+      title: Broken Tithe Foundation — Unified Resource Network and Control Tiers
+      summary: "Release D. Generalise the #858 infrastructure-network model into one producer/conduit/buffer/consumer graph ruling power, coolant, and containment load, ship-side and external alike. Power migrates onto the network as a redesign, not a frozen re-expression. Ship the deepest rungs of the band-B complexity ladder for this band's consoles: Engineering/Power detail (network graph, load-shedding, one-tap presets — full-AI / group-level via limited AI / direct network control, live-switchable), Repair detail (diagnostics levels, triage queue, repair material), and Shields detail (frequency/modulation tuning, per-arc management). Add main-drive propellant and repair material as consumables."
+      rationale:
+        - "Binding invariants on the power redesign: no reactor-side floors (the 2026-08-10 revert's lesson stands), Backfill/NPC min_reserve guards kept and re-expressed over network state, and the three-group vocabulary [helm, weapons, shields] kept as the group-level control tier. The exhaustion-lock mechanism alone is open: it is the incumbent a network-native alternative must beat with playtest evidence, and it survives in network terms by default."
+        - "The group-level tier's limited AI is the fine-system policy runtime with authority scoped to power allocation — the same machinery as Backfill doctrine, so AI/human symmetry holds and no second control intelligence exists."
+        - "Consumables pass the test 'can another bridge officer make a consequential decision about this resource within a 30-90 minute mission': main-drive propellant is the currency of #860's long-duration operational budgets, repair material turns repair-team work into triage. RCS propellant is excluded (no thruster-level flight), reactor fuel stays scenario-infinite, and bodily needs stay out."
+    architecture:
+      kind: roadmap-milestone
+      authority: authoritative
+      reads: [world-configuration-state, spawned-entity-state, world-snapshot-artifact]
+      coordinates: [roadmap-borrowed-sun-foundation, fine-system-ai-policy-runtime]
+      runs_in: [host-browser-runtime, headless-runtime]
 
   - component: roadmap-broken-tithe-content
     core:
@@ -329,6 +388,7 @@ entities:
       kind: roadmap-milestone
       authority: authoritative
       reads: [world-snapshot-artifact, world-content-pack-state]
+      coordinates: [roadmap-broken-tithe-foundation]
       runs_in: [host-browser-runtime]
 
   - component: roadmap-silent-corridor-content
@@ -336,11 +396,29 @@ entities:
       status: accepted
       confidence: confirmed
       title: The Silent Corridor — Thin Margin Mission 5
-      summary: "Release E. Combine schedules, traffic, evidence, infrastructure, cascades, commitments, and campaign consequences into the regional-crisis finale (#861)."
+      summary: "Release E. Combine schedules, traffic, evidence, infrastructure, cascades, commitments, and campaign consequences into the regional-crisis finale (#861). Composition only for scenario systems: the finale composes the B-D physical foundations (fields with derived emission, orbits, vessel actors, the resource network) under sustained multi-crisis load and introduces no new scenario systems. The band still carries ladder content — Tactical detail (calibration, ammo fabrication, arc-vs-range trade-offs), Captain detail (commitments/objectives board), and signature management as a new ship system (emissions profile affecting detectability, integrated with NPC sensor detection)."
     architecture:
       kind: roadmap-milestone
       authority: authoritative
       reads: [world-snapshot-artifact, world-content-pack-state]
+      coordinates: [roadmap-borrowed-sun-foundation, roadmap-narrow-season-foundation, roadmap-broken-tithe-foundation]
+      runs_in: [host-browser-runtime]
+
+  - component: roadmap-patrol-mode
+    core:
+      status: proposed
+      confidence: provisional
+      title: Patrol Mode — Generated Assignments (Band F Marker)
+      summary: "Post-E marker, not a banded release. A patrol campaign is generated assignments: a seeded system generator produces the physical context (star, bodies, orbits, hazards, stations, traffic) and the Thin Margin machinery generates the situation (actors, needs, infrastructure, commitments, evidence, cascades) — coherent episodes, not planets for their own sake. A hand-authored exploration 'first patrol' ships as its tutorial, absorbing the standalone science-scenario concept. Ladder content: the database/ship's library — a read-only reference of known ships, systems, and hazards plus the mission log, serving as the patrol briefing surface."
+      rationale:
+        - "This is the stated long-term justification for the B-D physical foundations: they exist so that generated situations, not only authored missions, can use them."
+        - "Marker only by the 2026-08-13 decision: the PRD is written just-in-time when band E nears, per the per-band PRD workflow, so five bands of foundation lessons inform it."
+        - "Scope guard is pasm/spec/design/simulation-differentiation.yaml: Phoenix generates plausible episodes, not a galaxy."
+    architecture:
+      kind: roadmap-milestone
+      authority: non-authoritative
+      reads: [world-snapshot-artifact, world-content-pack-state]
+      coordinates: [roadmap-borrowed-sun-foundation, roadmap-narrow-season-foundation, roadmap-broken-tithe-foundation]
       runs_in: [host-browser-runtime]
 
   - component: roadmap-post-demo-readiness

--- a/pasm/spec/roadmap/phoenix-delivery-roadmap.yaml
+++ b/pasm/spec/roadmap/phoenix-delivery-roadmap.yaml
@@ -311,6 +311,7 @@ entities:
         - "There is ONE evidence contract: physical sensor readings, third-party data obtained via Comms, and derived estimates all carry confidence and provenance through the #858 dossier surface. No second epistemics system is built for physical measurement."
         - "The Skyway retrofit lands here, before campaign-continuity projection (#867) freezes expectations against mission 1's state, so the toolkit never carries two hazard representations."
         - "The complexity-ladder framework debuts here rather than with the band-D power network (superseding the earlier engineering-only timing) because its first real content is band B's sensor depth: the detail screen ships with genuine epistemics gameplay, not an empty frame, and D's power detail then lands as deeper rungs of an established ladder."
+        - "PRDs published 2026-08-13: #1016 (fields and epistemics) and #1017 (complexity-ladder framework); the later bands' foundation PRDs are #1018 (Narrow Season), #1019 (Broken Tithe), #1020 (Silent Corridor ladder content), #1021 (Patrol Mode)."
     architecture:
       kind: roadmap-milestone
       authority: authoritative
@@ -412,7 +413,7 @@ entities:
       summary: "Post-E marker, not a banded release. A patrol campaign is generated assignments: a seeded system generator produces the physical context (star, bodies, orbits, hazards, stations, traffic) and the Thin Margin machinery generates the situation (actors, needs, infrastructure, commitments, evidence, cascades) — coherent episodes, not planets for their own sake. A hand-authored exploration 'first patrol' ships as its tutorial, absorbing the standalone science-scenario concept. Ladder content: the database/ship's library — a read-only reference of known ships, systems, and hazards plus the mission log, serving as the patrol briefing surface."
       rationale:
         - "This is the stated long-term justification for the B-D physical foundations: they exist so that generated situations, not only authored missions, can use them."
-        - "Marker only by the 2026-08-13 decision: the PRD is written just-in-time when band E nears, per the per-band PRD workflow, so five bands of foundation lessons inform it."
+        - "PRD published as #1021 (2026-08-13, superseding the same-day PRD-when-E-nears deferral); its issue breakdown via /to-issues still waits for its band."
         - "Scope guard is pasm/spec/design/simulation-differentiation.yaml: Phoenix generates plausible episodes, not a galaxy."
     architecture:
       kind: roadmap-milestone

--- a/src/ai/server.rs
+++ b/src/ai/server.rs
@@ -1453,10 +1453,26 @@ fn simulate_low_lod_ships(
         entity_uuid,
     ) in &mut ships
     {
-        let max_speed = helm_section
-            .map(|h| h.0.max_speed)
-            .filter(|&s| s > 0.0)
-            .unwrap_or(20.0);
+        // No Helm console means no engine: this hull cannot propel itself, so
+        // its top speed is 0, not a fabricated default. That is the difference
+        // between "a mover whose authored max_speed we couldn't read" and "a
+        // thing with no propulsion at all" — combat_test's Starbase Alpha (a
+        // `StaticPointDefence`) carries the full `Ship` substrate for its
+        // targeting and beams, so it rides this path once the player drifts far
+        // enough to demote it, but with max_speed 0 every speed ramp below
+        // multiplies to 0 and it stays put. It still gets every OTHER low-LOD
+        // update (yaw, hazard avoidance) — the platform is not special-cased out
+        // of the path, it simply has nothing to accelerate. Any future
+        // propulsion-less Ship entity (mine, comms buoy) inherits the same.
+        //
+        // A helm section that IS present but authors a non-positive max_speed is
+        // malformed authoring, not "no engine": keep the fixture fallback so the
+        // bare-`App` movers that rely on it still move.
+        let max_speed = match helm_section {
+            None => 0.0,
+            Some(h) if h.0.max_speed > 0.0 => h.0.max_speed,
+            Some(_) => 20.0,
+        };
         // The same facts the high-fidelity planner feeds `assess_hazards`, read
         // off this hull rather than defaulted (issue #968): its collider radius,
         // and the whole authored `[behaviour]` avoidance block (buffer,

--- a/src/world/config.rs
+++ b/src/world/config.rs
@@ -375,25 +375,30 @@ struct RawTriggerEntry {
 
 /// A single condition-weighted modifier inside an `add_objective` TOML action.
 ///
-/// `pub(crate)` only so it may appear in [`RawActionEntry`]'s (also `pub(crate)`)
-/// `modifiers` field without tripping the private-in-public lint; its fields stay
-/// module-private (only [`parse_utility_config`] reads them, in this file).
+/// `pub(crate)` (with `pub(crate)` fields) so it may appear in [`RawActionEntry`]'s
+/// (also `pub(crate)`) `modifiers` field without tripping the private-in-public
+/// lint AND so the Rhai effect host (`world::script::effects`) can build one from a
+/// `#{ … }` script map — the scripted `add_objective` reads its `modifiers` array
+/// into these and runs the SHARED [`parse_utility_config`], rather than
+/// re-implementing utility parsing (issue #984, Rhai M6). `threshold` / `weight`
+/// are `no_float` `f32` leaves the script authors as `flt("…")` or an int.
 #[derive(Debug, Deserialize)]
 pub(crate) struct RawModifier {
-    condition: String,
+    pub(crate) condition: String,
     #[serde(default)]
-    threshold: Option<f32>,
-    weight: f32,
+    pub(crate) threshold: Option<f32>,
+    pub(crate) weight: f32,
 }
 
 /// A zero-gate veto condition inside an `add_objective` TOML action.
 ///
-/// `pub(crate)` for the same reason as [`RawModifier`].
+/// `pub(crate)` (with `pub(crate)` fields) for the same reason as [`RawModifier`]:
+/// declarative deserialization AND scripted construction from a `#{ … }` map.
 #[derive(Debug, Deserialize)]
 pub(crate) struct RawZeroGate {
-    condition: String,
+    pub(crate) condition: String,
     #[serde(default)]
-    threshold: Option<f32>,
+    pub(crate) threshold: Option<f32>,
 }
 
 /// One flat, all-optional `[[trigger.action]]` row as authored in TOML.

--- a/src/world/script/effects.rs
+++ b/src/world/script/effects.rs
@@ -36,6 +36,14 @@
 //! numeric leaf are authored as INTs and converted to the declarative `f32` /
 //! toml-float at this boundary, the same rule `after_secs`/`in_seconds` use.
 //!
+//! A FRACTIONAL leaf an int cannot express (`target_speed = 0.9`, a modifier
+//! `weight = 1.5`) is authored through the `flt("…")` marker: it carries a parsed
+//! `f64` as OPAQUE DATA (a [`RealLit`], never arithmetic), so `no_float`
+//! determinism is preserved AND the value is byte-identical to the declarative
+//! `0.9` — Rust's `f64` `FromStr` and toml's float parse agree on canonical
+//! decimals, which the parity tests pin. `map_f32` and `dynamic_to_toml` accept a
+//! `RealLit` wherever they already accept an int.
+//!
 //! [`ActionCmd`]: crate::world::dispatch::ActionCmd
 //! [`TriggerAction`]: crate::world::config::TriggerAction
 //! [`engine::RuntimeHost`]: crate::world::script::engine::RuntimeHost
@@ -45,8 +53,24 @@ use std::sync::{Arc, Mutex};
 
 use rhai::{Array, Dynamic, Engine, EvalAltResult, ImmutableString, Map, Position};
 
-use crate::world::config::{parse_action_entry, RawActionEntry, TriggerAction};
+use crate::world::config::{
+    parse_action_entry, RawActionEntry, RawModifier, RawZeroGate, TriggerAction,
+};
 use crate::world::dispatch::ActionCmd;
+
+/// A fractional literal carried as OPAQUE DATA, the `no_float`-safe fractional-leaf
+/// marker (issue #984, Rhai M6 follow-on).
+///
+/// Rhai is `no_float`, so an author cannot write `0.9` and the API is otherwise
+/// integer-only. `flt("0.9")` parses the string ONCE, at map-build time, into this
+/// wrapper; the `f64` is then only ever *read* (by [`dynamic_to_toml`] and
+/// [`map_f32`]) and never arithmetic'd in script, so determinism is untouched — a
+/// converted world does no float math, it merely transports a constant the toml
+/// crate would have parsed identically. Rust's `f64::from_str` and toml's float
+/// parse agree on canonical decimals, so `flt("0.9")` produces the SAME `f64` a
+/// declarative `0.9` does; the override / utility parity tests pin it.
+#[derive(Clone, Debug)]
+pub struct RealLit(pub f64);
 
 /// One buffered runtime effect, in authored order in the shared [`EffectSink`].
 ///
@@ -127,6 +151,22 @@ impl EffectSink {
 /// `TriggerAction` for the applier to resolve.
 pub fn register_effects(engine: &mut Engine) {
     engine.register_type_with_name::<EffectSink>("Effects");
+
+    // The `no_float`-safe fractional-leaf marker. `flt("0.9")` parses the string
+    // into a `RealLit` the effect readers unwrap; the parse happens ONCE, at
+    // map-build time, and the `f64` is never arithmetic'd in script — so a
+    // fractional constant reaches the declarative boundary with determinism
+    // intact. A bad string raises (discarding the call, settled decision 10),
+    // exactly as a malformed declarative float fails the world load.
+    engine.register_type_with_name::<RealLit>("RealLit");
+    engine.register_fn(
+        "flt",
+        |s: ImmutableString| -> Result<RealLit, Box<EvalAltResult>> {
+            s.parse::<f64>()
+                .map(RealLit)
+                .map_err(|e| raise(format!("flt(\"{s}\"): not a real number: {e}")))
+        },
+    );
 
     engine.register_fn(
         "complete_objective",
@@ -271,13 +311,19 @@ fn map_bool(spec: &Map, key: &str) -> Option<bool> {
     spec.get(key).and_then(|d| d.as_bool().ok())
 }
 
-/// Read a KNOWN-`f32` scalar (`base_priority`). `no_float`: authored as an INT,
-/// so it is read as an integer and converted at this boundary to the same `f32`
-/// the declarative float parses to (`80` → `80.0`) — the seconds→elapsed rule.
+/// Read a KNOWN-`f32` scalar (`base_priority`, a modifier `weight` / `threshold`).
+/// `no_float`: authored as an INT (`80` → `80.0`, the seconds→elapsed rule) OR — for
+/// a fractional value an int cannot express — as a [`RealLit`] via `flt("0.9")`,
+/// unwrapped `.0 as f32`. Both routes land on the SAME `f32` the declarative float
+/// parses to: an int through `as f32`, and a `flt("0.9")` through the identical
+/// `f64` → `f32` narrowing the toml `f32` deserializer applies to `0.9`. `None`
+/// when the key is absent (or present but neither an int nor a `RealLit`).
 fn map_f32(spec: &Map, key: &str) -> Option<f32> {
-    spec.get(key)
-        .and_then(|d| d.as_int().ok())
-        .map(|i| i as f32)
+    let d = spec.get(key)?;
+    if let Some(real) = d.clone().try_cast::<RealLit>() {
+        return Some(real.0 as f32);
+    }
+    d.as_int().ok().map(|i| i as f32)
 }
 
 /// Read an optional array-of-strings field (`targets` / `groups` /
@@ -331,6 +377,69 @@ fn map_f32_array3(spec: &Map, key: &str) -> Result<Option<[f32; 3]>, String> {
     Ok(Some(out))
 }
 
+/// Read an `add_objective` `modifiers` array — `[#{ condition, threshold?, weight }]`
+/// — into `Vec<RawModifier>`, so the SHARED `parse_utility_config` builds the exact
+/// same `UtilityConfig` the declarative twin does; nothing utility-specific is
+/// re-implemented here. `weight` is required and `threshold` optional, both read
+/// through [`map_f32`] so each is authored as `flt("…")` or an int and lands on the
+/// byte-identical `f32` the declarative `weight = …` / `threshold = …` parses to.
+/// `Ok(None)` when absent; `Err` — which discards the whole call (settled decision
+/// 10) — when present but not an array of well-formed maps, rather than silently
+/// dropping a modifier the declarative path would have parsed.
+fn map_modifiers(spec: &Map) -> Result<Option<Vec<RawModifier>>, String> {
+    let Some(d) = spec.get("modifiers") else {
+        return Ok(None);
+    };
+    let arr = d
+        .clone()
+        .into_array()
+        .map_err(|actual| format!("`modifiers` must be an array of maps, got {actual}"))?;
+    let mut out = Vec::with_capacity(arr.len());
+    for (i, el) in arr.into_iter().enumerate() {
+        let ty = el.type_name();
+        let m = el
+            .try_cast::<Map>()
+            .ok_or_else(|| format!("`modifiers`[{i}] must be a map, got {ty}"))?;
+        let condition = map_str(&m, "condition")
+            .ok_or_else(|| format!("`modifiers`[{i}] requires a string `condition`"))?;
+        let weight = map_f32(&m, "weight")
+            .ok_or_else(|| format!("`modifiers`[{i}] requires a `weight` (`flt(\"…\")` or int)"))?;
+        out.push(RawModifier {
+            condition,
+            threshold: map_f32(&m, "threshold"),
+            weight,
+        });
+    }
+    Ok(Some(out))
+}
+
+/// Read an `add_objective` `zero_gates` array — `[#{ condition, threshold? }]` — into
+/// `Vec<RawZeroGate>`, the veto twin of [`map_modifiers`] (no `weight`). Same reuse,
+/// same `flt`-or-int `threshold`, same discard-on-malformed policy.
+fn map_zero_gates(spec: &Map) -> Result<Option<Vec<RawZeroGate>>, String> {
+    let Some(d) = spec.get("zero_gates") else {
+        return Ok(None);
+    };
+    let arr = d
+        .clone()
+        .into_array()
+        .map_err(|actual| format!("`zero_gates` must be an array of maps, got {actual}"))?;
+    let mut out = Vec::with_capacity(arr.len());
+    for (i, el) in arr.into_iter().enumerate() {
+        let ty = el.type_name();
+        let m = el
+            .try_cast::<Map>()
+            .ok_or_else(|| format!("`zero_gates`[{i}] must be a map, got {ty}"))?;
+        let condition = map_str(&m, "condition")
+            .ok_or_else(|| format!("`zero_gates`[{i}] requires a string `condition`"))?;
+        out.push(RawZeroGate {
+            condition,
+            threshold: map_f32(&m, "threshold"),
+        });
+    }
+    Ok(Some(out))
+}
+
 /// Convert a `spawn_entity` `overrides` subtree (`#{ … }`) into the `toml::Value`
 /// the declarative `overrides` field carries.
 ///
@@ -360,6 +469,13 @@ fn dynamic_to_toml(value: &Dynamic) -> Result<toml::Value, String> {
     if let Ok(i) = value.as_int() {
         return Ok(toml::Value::Float(i as f64));
     }
+    if let Some(real) = value.clone().try_cast::<RealLit>() {
+        // A `flt("0.9")` marker: the `no_float`-safe fractional leaf. Renders as the
+        // SAME toml FLOAT the declarative `0.9` parses to (`f64::from_str` and toml's
+        // float parse agree on canonical decimals), so a converted override's
+        // `toml::Value` is byte-identical to its declarative twin's.
+        return Ok(toml::Value::Float(real.0));
+    }
     if let Some(s) = value.clone().try_cast::<ImmutableString>() {
         return Ok(toml::Value::String(s.to_string()));
     }
@@ -386,20 +502,13 @@ fn dynamic_to_toml(value: &Dynamic) -> Result<toml::Value, String> {
 /// Build a `TriggerAction::AddObjective` from a script `#{ … }` map, reusing the
 /// declarative `parse_action_entry` for directive / utility validation.
 ///
-/// `modifiers` / `zero_gates` (utility arrays of maps) are not yet read here.
-/// They are REJECTED loudly rather than silently dropped — silently ignoring a
-/// key the declarative twin parses would diverge the scripted `UtilityConfig`
-/// from the TOML one. The `RawActionEntry`-reuse path makes reading them later
-/// free, without touching this builder's shape.
+/// The full utility config is read here: `base_priority` (a `flt`-or-int `f32`),
+/// plus the `modifiers` and `zero_gates` arrays via [`map_modifiers`] /
+/// [`map_zero_gates`]. They are set on the `RawActionEntry` so the SHARED
+/// `parse_utility_config` (run inside `parse_action_entry`) builds the byte-identical
+/// `UtilityConfig` the declarative twin does — the scripted and TOML `add_objective`
+/// are two front-ends over one parser, not two implementations kept in sync.
 fn add_objective_action(spec: &Map) -> Result<TriggerAction, String> {
-    for unsupported in ["modifiers", "zero_gates"] {
-        if spec.contains_key(unsupported) {
-            return Err(format!(
-                "scripted add_objective does not yet support '{unsupported}'; author that \
-                 objective declaratively or await the utility-config milestone"
-            ));
-        }
-    }
     let raw = RawActionEntry {
         kind: "add_objective".to_string(),
         id: map_str(spec, "id"),
@@ -413,6 +522,8 @@ fn add_objective_action(spec: &Map) -> Result<TriggerAction, String> {
         directive_anchor: map_str(spec, "directive_anchor"),
         base_priority: map_f32(spec, "base_priority"),
         source: map_str(spec, "source"),
+        modifiers: map_modifiers(spec)?,
+        zero_gates: map_zero_gates(spec)?,
         ..Default::default()
     };
     parse_action_entry(&raw)
@@ -702,18 +813,118 @@ mod tests {
         assert_eq!(effs, vec![BufferedEffect::Action(toml)]);
     }
 
-    /// Issue #984 review: `modifiers`/`zero_gates` are not yet read by the scripted
-    /// builder. Supplying one RAISES (settled decision 10) rather than silently
-    /// dropping it, which would diverge the scripted `UtilityConfig` from the
-    /// declarative twin's (the TOML path DOES parse them).
+    /// `add_objective` now READS `modifiers`/`zero_gates` (the utility-config
+    /// milestone): the script arrays-of-maps, with `flt("…")` fractional thresholds
+    /// and weights, build the identical `TriggerAction::AddObjective` — same
+    /// `UtilityConfig` — the declarative twin parses through the shared
+    /// `parse_utility_config`. This is the parity the FRACTIONAL test-infra worlds
+    /// ride on: `no_float` Rhai could not author `weight = 1.25` before `flt`.
     #[test]
-    fn add_objective_rejects_unsupported_utility_keys() {
+    fn add_objective_reads_modifiers_and_zero_gates_matching_toml() {
+        let effs = run_buffered(
+            r#"fn f(ctx) {
+                ctx.effects.add_objective(#{
+                    id: "obj-utility",
+                    text: "world.obj.text",
+                    base_priority: flt("50.5"),
+                    modifiers: [
+                        #{ condition: "enemy_near", threshold: flt("0.5"), weight: flt("2.0") },
+                        #{ condition: "low_hull", weight: flt("1.25") },
+                    ],
+                    zero_gates: [
+                        #{ condition: "shields_down" },
+                        #{ condition: "power_low", threshold: flt("0.2") },
+                    ],
+                });
+            }"#,
+            "f",
+        );
+        let toml = toml_action(
+            "type = \"add_objective\"\n\
+             id = \"obj-utility\"\n\
+             text = \"world.obj.text\"\n\
+             base_priority = 50.5\n\
+             modifiers = [{ condition = \"enemy_near\", threshold = 0.5, weight = 2.0 }, { condition = \"low_hull\", weight = 1.25 }]\n\
+             zero_gates = [{ condition = \"shields_down\" }, { condition = \"power_low\", threshold = 0.2 }]",
+        );
+        assert_eq!(effs, vec![BufferedEffect::Action(toml)]);
+    }
+
+    /// A `modifier` missing its required `weight` RAISES (discarding the call,
+    /// settled decision 10) — the same loud failure a declarative modifier without a
+    /// `weight` gives, rather than a silently degraded `UtilityConfig`.
+    #[test]
+    fn add_objective_rejects_a_modifier_without_a_weight() {
         let err = run_result(
-            r#"fn f(ctx) { ctx.effects.add_objective(#{ id: "o", text: "t", modifiers: [] }); }"#,
+            r#"fn f(ctx) {
+                ctx.effects.add_objective(#{
+                    id: "o", text: "t",
+                    modifiers: [#{ condition: "enemy_near" }],
+                });
+            }"#,
             "f",
         )
-        .expect_err("an unsupported utility key must raise");
-        assert!(err.to_string().contains("modifiers"), "{err}");
+        .expect_err("a weightless modifier must raise");
+        assert!(err.to_string().contains("weight"), "{err}");
+    }
+
+    // ── Feature A: the `flt("…")` fractional-data marker (no_float-safe) ───────
+
+    /// The sharpest `flt` parity: a `flt("0.9")` override leaf must produce the
+    /// IDENTICAL `toml::Value` the declarative `target_speed = 0.9` carries — the
+    /// byte-identity a converted FRACTIONAL world depends on (`f64::from_str` ≡ toml's
+    /// float parse for canonical decimals). This is why a fractional constant can be
+    /// transported through `no_float` script as opaque data with no determinism loss.
+    #[test]
+    fn flt_override_leaf_matches_declarative_float() {
+        let effs = run_buffered(
+            r#"fn f(ctx) {
+                ctx.effects.spawn_entity(#{
+                    template_path: "assets/entities/ship.toml",
+                    name: "x",
+                    position: [0, 0, 0],
+                    overrides: #{
+                        helm_console: #{
+                            target_speed: flt("0.9"),
+                        },
+                    },
+                });
+            }"#,
+            "f",
+        );
+        let toml = toml_action(
+            "type = \"spawn_entity\"\n\
+             template_path = \"assets/entities/ship.toml\"\n\
+             name = \"x\"\n\
+             position = [0.0, 0.0, 0.0]\n\
+             overrides = { helm_console = { target_speed = 0.9 } }",
+        );
+        assert_eq!(effs, vec![BufferedEffect::Action(toml)]);
+
+        // Pin the conversion concretely: the `flt("0.9")` leaf is the identical toml
+        // FLOAT `0.9` — so a regression in the `RealLit` branch is unmistakable.
+        let BufferedEffect::Action(TriggerAction::SpawnEntity { overrides, .. }) = &effs[0] else {
+            panic!("expected a spawn action, got {:?}", effs[0]);
+        };
+        let speed = overrides
+            .as_ref()
+            .and_then(|o| o.get("helm_console"))
+            .and_then(|h| h.get("target_speed"))
+            .expect("override target_speed present");
+        assert_eq!(speed, &toml::Value::Float(0.9));
+    }
+
+    /// An unparseable `flt("…")` RAISES (discarding the call, settled decision 10),
+    /// exactly as a malformed declarative float fails the world load. The parse
+    /// happens once, at map-build time, so the raise pre-empts the effect entirely.
+    #[test]
+    fn flt_rejects_an_unparseable_string() {
+        let err = run_result(
+            r#"fn f(ctx) { ctx.effects.add_objective(#{ id: "o", text: "t", base_priority: flt("xyz") }); }"#,
+            "f",
+        )
+        .expect_err("an unparseable flt must raise");
+        assert!(err.to_string().contains("flt"), "{err}");
     }
 
     /// `spawn_entity(#{…})` — the sharpest parity: the Rhai-int `position:


### PR DESCRIPTION
## Summary
Two combat_test fixes:

### Starbase Alpha flew away
Starbase Alpha (`station_axiom.toml`) is a `StaticPointDefence` that carries the full `Ship` substrate for its own targeting and beams — so it also carries `ShipPhysics` and an `AiProfile`, and rides the low-LOD path once the player drifts far enough to demote it from `AiHighFidelity`. `simulate_low_lod_ships` fabricated a `max_speed` of `20.0` for any hull with no `HelmConsoleSection`, so `low_lod_objective_steer` ramped the station's `forward_speed` up and flew the "stationary" station off along its heading.

Fix: a hull with **no Helm console has no engine** — its `max_speed` is `0`, not a fabricated default. Every speed ramp then multiplies to `0` and the platform stays put, while still receiving every other low-LOD update (yaw, hazard avoidance). It is not special-cased out of the path — it simply has nothing to accelerate, so any future propulsion-less `Ship` entity (mine, comms-buoy) inherits the same behaviour. A helm section that *is* present but authors a non-positive `max_speed` keeps the existing fixture fallback.

The high-fidelity path was already safe: the AI helm only writes thrust when both helm axes are AI-operated, and the station has no helm systems.

### Asteroid belts too dense / too grid-like
In `combat_test.toml` only (via per-field `overrides`, so the shared `asteroid_field_main.toml` template and the three other worlds using it are untouched):
- **Density halved** on both belts: `0.005 → 0.0025`
- **Grid jitter tripled**: `20.0 → 60.0` — the per-cell offset that scatters each rock off its grid position, so the fields read as scattered debris rather than a lattice.

## Testing
- `cargo check --lib` — clean
- `cargo test --lib ai::server` — 126 passed